### PR TITLE
Fix planner JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ prototype or development plan.
 _Current repo state_  
 **Step 1:** Minimal Streamlit front-end + “Creation Planner” prompt.
 
+The planner now uses OpenAI's JSON mode for reliable parsing.
+
 ## Quick start (local)
 
 ```bash
@@ -16,3 +18,4 @@ python -m venv .venv && source .venv/bin/activate   # PowerShell: .venv\Scripts\
 pip install -r requirements.txt
 export OPENAI_API_KEY="sk-..."
 streamlit run app.py
+```

--- a/app.py
+++ b/app.py
@@ -37,6 +37,7 @@ if run_btn and idea.strip():
         response = openai.chat.completions.create(
             model="gpt-4o-mini",   # or "gpt-4o"
             temperature=0.3,
+            response_format={"type": "json_object"},
             messages=[
                 {
                     "role": "system",


### PR DESCRIPTION
## Summary
- ensure GPT responses are valid JSON via `response_format`
- document JSON mode in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688d03ab17c8832c8d2c5690c5405e48