### PR TITLE
Add orchestrator agent with loop refinement

### DIFF
--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -1,0 +1,59 @@
+"""
+Loop Orchestrator
+-----------------
+Reviews the first-round answers, decides where depth is lacking,
+and (optionally) issues ONE follow-up query per domain to enrich
+the answer.  Uses OpenAI for the review, then re-uses the existing
+obfuscator + router for follow-up.
+
+Call:
+    from agents.orchestrator import refine_once
+    enriched = refine_once(plan, answers)
+"""
+from typing import Dict
+import openai
+from agents.obfuscator import obfuscate_task
+from agents.router import route
+
+def _needs_follow_up(domain: str, task: str, answer: str) -> str | None:
+    """Return a follow-up question *or* None if answer is judged complete."""
+    review = openai.chat.completions.create(
+        model="gpt-3.5-turbo",
+        temperature=0,
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    "You are a senior R&D reviewer. If the answer below is "
+                    "technically thorough and actionable, reply exactly "
+                    "'COMPLETE'. If not, write ONE specific follow-up question "
+                    "that would close the biggest gap. No other text."
+                ),
+            },
+            {
+                "role": "user",
+                "content": (
+                    f"DOMAIN: {domain}\n"
+                    f"Original task: {task}\n"
+                    f"Answer so far: {answer}"
+                ),
+            },
+        ],
+    )
+    proposal = review.choices[0].message.content.strip()
+    return None if proposal.upper().startswith("COMPLETE") else proposal
+
+def refine_once(plan: Dict[str, str], answers: Dict[str, str]) -> Dict[str, str]:
+    """Return answers, optionally enriched with one follow-up per domain."""
+    updated = answers.copy()
+    for domain in plan:
+        follow_up = _needs_follow_up(domain, plan[domain], updated[domain])
+        if not follow_up:
+            continue
+
+        # Obfuscate & re-query
+        obf = obfuscate_task(domain, follow_up)
+        extra = route(domain, obf)
+
+        updated[domain] += "\n\n--- *(Loop-refined)* ---\n" + extra
+    return updated

--- a/app.py
+++ b/app.py
@@ -79,11 +79,28 @@ if st.session_state.obfuscated:
     from agents.router import route
     if st.button("Run Query Router"):
         with st.spinner("Contacting external services…"):
-            answers = {
+            st.session_state.answers = {
                 d: route(d, p) for d, p in st.session_state.obfuscated.items()
             }
-        st.success("Results")
-        for d, ans in answers.items():
+    if "answers" in st.session_state:
+        st.success("Round-1 Results")
+        for d, ans in st.session_state.answers.items():
+            st.markdown(f"**{d}**")
+            st.write(ans)
+            st.markdown("---")
+
+# ---- 4. Loop Orchestrator ----
+if "answers" in st.session_state:
+    from agents.orchestrator import refine_once
+    if st.button("Refine Research (Loop Orchestrator)"):
+        with st.spinner("Reviewing answers & issuing follow-ups…"):
+            st.session_state.answers = refine_once(
+                st.session_state.plan, st.session_state.answers
+            )
+
+    if st.button("Show Latest Answers"):
+        st.header("📑 Current Answer Set")
+        for d, ans in st.session_state.answers.items():
             st.markdown(f"**{d}**")
             st.write(ans)
             st.markdown("---")


### PR DESCRIPTION
## Summary
- support follow-up refinement by adding `agents/orchestrator.py`
- extend Streamlit app with new Loop Orchestrator stage

## Testing
- `python -m py_compile agents/obfuscator.py agents/router.py agents/orchestrator.py app.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_688d0bdb07a4832c94a08cbf4c7d5752