### PR TITLE
Ensure planner returns JSON

### DIFF
--- a/agents/planner_agent.py
+++ b/agents/planner_agent.py
@@ -17,3 +17,21 @@ class PlannerAgent(BaseAgent):
                 "Conclude with a JSON summary of the key planning steps and deadlines."
             ),
         )
+
+    def run(self, idea: str, task: str) -> dict:
+        """Return the planner's JSON summary as a Python dict."""
+        import openai, json
+
+        prompt = self.user_prompt_template.format(idea=idea, task=task)
+        response = openai.chat.completions.create(
+            model=self.model,
+            response_format={"type": "json_object"},
+            messages=[
+                {"role": "system", "content": self.system_message},
+                {"role": "user", "content": prompt},
+            ],
+        )
+        try:
+            return json.loads(response.choices[0].message.content)
+        except json.JSONDecodeError as e:
+            raise ValueError("Planner returned invalid JSON") from e

--- a/tests/test_planner_agent.py
+++ b/tests/test_planner_agent.py
@@ -1,0 +1,18 @@
+from unittest.mock import Mock, patch
+import os
+from agents.planner_agent import PlannerAgent
+
+
+def make_openai_response(text: str):
+    mock_choice = Mock()
+    mock_choice.message = Mock(content=text)
+    return Mock(choices=[mock_choice])
+
+
+@patch.dict(os.environ, {"OPENAI_API_KEY": "x"})
+@patch('openai.chat.completions.create')
+def test_planner_agent_returns_dict(mock_create):
+    mock_create.return_value = make_openai_response('{"X": "Y"}')
+    agent = PlannerAgent()
+    result = agent.run('idea', 'task')
+    assert result == {"X": "Y"}


### PR DESCRIPTION
## Summary
- implement JSON mode in `PlannerAgent.run`
- test that `PlannerAgent.run` returns a dictionary

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d442bfc24832ca25da8d2ca6f41f7