### PR TITLE
Align planner output with available agents

### DIFF
--- a/agents/planner_agent.py
+++ b/agents/planner_agent.py
@@ -12,9 +12,18 @@ class PlannerAgent(BaseAgent):
                 "You are an expert project planner specializing in turning ideas into actionable plans."
             ),
             user_prompt_template=(
-                "Project Idea: {idea}\nAs the Planner, your task is {task}. "
-                "Provide a detailed project plan in Markdown format, including milestones and timelines. "
-                "Conclude with a JSON summary of the key planning steps and deadlines."
+                "Project Idea: {idea}\n"
+                "As the Planner, your task is {task}.\n\n"
+                "Return **only** a JSON object mapping each of these roles exactly:\n"
+                "  - CTO\n"
+                "  - Research Scientist\n"
+                "  - Engineer\n"
+                "  - QA Specialist\n"
+                "  - Regulatory Specialist\n"
+                "  - Patent Specialist\n"
+                "  - Documentation Specialist\n\n"
+                "to one or two succinct research or implementation tasks each.\n"
+                "Do not include any other keys."
             ),
         )
 

--- a/app.py
+++ b/app.py
@@ -35,9 +35,14 @@ if not idea:
 if st.button("1⃣ Generate Research Plan"):
     with st.spinner("📝 Planning..."):
         try:
-            plan = agents["Planner"].run(
+            raw_plan = agents["Planner"].run(
                 idea, "Break down the project into role-specific tasks"
             )
+            # keep only keys that have a matching agent
+            plan = {role: task for role, task in raw_plan.items() if role in agents}
+            dropped = [r for r in raw_plan if r not in agents]
+            if dropped:
+                st.warning(f"Dropped unrecognized roles: {', '.join(dropped)}")
         except Exception as e:
             st.error(f"Planner failed: {e}")
             st.stop()

--- a/tests/test_app_ui.py
+++ b/tests/test_app_ui.py
@@ -63,10 +63,13 @@ def test_generate_plan_updates_state(monkeypatch):
         {"1\u20e3 Generate Research Plan": True},
     )
     patches = {
-        "agents.planner_agent.PlannerAgent.run": lambda self, idea, task: {"X": "Y"}
+        "agents.planner_agent.PlannerAgent.run": (
+            lambda self, idea, task: {"CTO": "foo", "X": "Y"}
+        )
     }
     reload_app(monkeypatch, st, patches)
-    assert st.session_state["plan"] == {"X": "Y"}
+    assert st.session_state["plan"] == {"CTO": "foo"}
+    st.warning.assert_called_with("Dropped unrecognized roles: X")
 
 
 def test_run_domain_experts(monkeypatch):


### PR DESCRIPTION
## Summary
- restrict `PlannerAgent` to emit a JSON object only containing keys for the project roles
- filter the plan from the planner so only recognized roles remain and warn if any were dropped
- adapt UI tests to expect filtered results

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d4c1e3260832caba21ecacd15bba9