### PR TITLE
Add simulation capabilities and update proposal synthesis

### DIFF
--- a/agents/simulation_agent.py
+++ b/agents/simulation_agent.py
@@ -1,0 +1,37 @@
+from simulation.simulation_manager import SimulationManager
+
+class SimulationAgent:
+    """Agent that selects and runs the appropriate simulation for a given role's design."""
+    def __init__(self):
+        # Initialize a SimulationManager to handle simulation calls
+        self.sim_manager = SimulationManager()
+
+    def run_simulation(self, role: str, design_spec: str) -> str:
+        """
+        Determine the simulation type based on the role or content, run the simulation,
+        and return the results formatted as Markdown.
+        """
+        # Decide simulation type by role (or design content for Research Scientist)
+        role_lower = role.lower()
+        if "engineer" in role_lower:
+            sim_type = "structural"
+        elif "cto" in role_lower:
+            sim_type = "electronics"
+        elif "research scientist" in role_lower:
+            # Heuristic: choose thermal vs chemical based on keywords in the design spec
+            spec_lower = design_spec.lower()
+            if any(term in spec_lower for term in ["chemical", "chemistry", "compound", "reaction", "material"]):
+                sim_type = "chemical"
+            else:
+                sim_type = "thermal"
+        else:
+            # Roles without a designated simulation type
+            return ""
+
+        # Run the chosen simulation and get metrics
+        metrics = self.sim_manager.simulate(sim_type, design_spec)
+        # Format the metrics as a Markdown section
+        lines = [f"**Simulation ({sim_type.capitalize()}) Results:**"]
+        for metric, value in metrics.items():
+            lines.append(f"- **{metric}**: {value}")
+        return "\n".join(lines)

--- a/simulation/simulation_manager.py
+++ b/simulation/simulation_manager.py
@@ -1,0 +1,35 @@
+class SimulationManager:
+    """Manages different types of simulations (structural, thermal, electronics, chemical)."""
+    def __init__(self):
+        # Register simulation handler stubs for each simulation type
+        self.simulators = {
+            "structural": self._simulate_structural,
+            "thermal": self._simulate_thermal,
+            "electronics": self._simulate_electronics,
+            "chemical": self._simulate_chemical
+        }
+
+    def simulate(self, sim_type: str, design_spec: str) -> dict:
+        """Run the specified type of simulation on the given design specification.
+        Returns a dictionary of performance metrics as the simulation result."""
+        sim_type = sim_type.lower()
+        if sim_type in self.simulators:
+            return self.simulators[sim_type](design_spec)
+        else:
+            raise ValueError(f"Simulation type '{sim_type}' is not supported.")
+
+    def _simulate_structural(self, design_spec: str) -> dict:
+        # Stub: simulate structural analysis (e.g., load, stress)
+        return {"Max Load": "1.5 tons", "Safety Factor": 3.2}
+
+    def _simulate_thermal(self, design_spec: str) -> dict:
+        # Stub: simulate thermal performance (e.g., temperature, heat dissipation)
+        return {"Max Temperature": "85°C", "Heat Dissipation": "120 W"}
+
+    def _simulate_electronics(self, design_spec: str) -> dict:
+        # Stub: simulate electronics performance (e.g., power usage, speed)
+        return {"Power Consumption": "50 W", "Clock Speed": "2.5 GHz"}
+
+    def _simulate_chemical(self, design_spec: str) -> dict:
+        # Stub: simulate chemical process (e.g., yield, purity)
+        return {"Yield": "78%", "Purity": "95%"}


### PR DESCRIPTION
## Summary
- add stub `SimulationManager` for various simulation types
- create `SimulationAgent` to choose and run simulations
- integrate simulations into `app.py` with new checkboxes and options
- enhance final proposal synthesis to include simulation summaries
- adjust UI tests for new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d63715a38832cb2d9119ec3264cc2