### PR TITLE
Add comprehensive docstrings to plugin system

### DIFF
--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,0 +1,22 @@
+"""Plugin package initialization with automatic discovery.
+
+Importing this package will automatically discover and import any
+modules that define plugins. To add a new plugin, drop a ``.py`` file
+into this directory that defines a subclass of
+:class:`~plugins.plugin_base.Plugin`.
+
+Examples
+--------
+>>> import plugins  # doctest: +SKIP
+This will import all plugin modules in the directory.
+"""
+
+import importlib
+import os
+
+# Auto-discover and import all plugin modules in this package
+plugins_dir = os.path.dirname(__file__)
+for filename in os.listdir(plugins_dir):
+    if filename.endswith(".py") and filename not in ["__init__.py", "plugin_base.py", "plugin_manager.py"]:
+        module_name = f"plugins.{filename[:-3]}"
+        importlib.import_module(module_name)

--- a/plugins/eco_impact_plugin.py
+++ b/plugins/eco_impact_plugin.py
@@ -1,0 +1,90 @@
+"""Sustainability metrics plugin.
+
+This module implements :class:`EcoImpactPlugin`, a simple plugin that
+estimates energy usage, carbon footprint and recyclability metrics based
+on keyword heuristics.
+"""
+
+from __future__ import annotations
+
+from plugins.plugin_base import Plugin
+
+
+class EcoImpactPlugin(Plugin):
+    """Plugin to simulate sustainability metrics based on project content.
+
+    Examples
+    --------
+    >>> plugin = EcoImpactPlugin()
+    >>> plugin.run("Develop a green software platform")  # doctest: +SKIP
+    {'Energy Usage': '50 kWh/year', 'Carbon Footprint': '20 kg CO2/year', 'Recyclability': '90%'}
+    """
+
+    def __init__(self) -> None:
+        """Initialize the plugin with identifying metadata."""
+        super().__init__()
+        self.name = "eco_impact"
+        self.description = (
+            "Estimates environmental impact metrics (energy use, carbon footprint, recyclability)."
+        )
+
+    def run(self, task: str, context: str = ""):
+        """Analyze the given text and return sustainability metrics.
+
+        Parameters
+        ----------
+        task:
+            Description of the project task.
+        context:
+            Additional context or details about the project.
+
+        Returns
+        -------
+        dict[str, str]
+            Mapping of metric name to human-readable value.
+
+        Examples
+        --------
+        >>> plugin = EcoImpactPlugin()
+        >>> plugin.run("Design an AI data center")  # doctest: +SKIP
+        {'Energy Usage': '1000 kWh/year', 'Carbon Footprint': '500 kg CO2/year', 'Recyclability': '20%'}
+        """
+        text = f"{task} {context}".lower()
+        # Define keyword heuristics for energy usage categories
+        high_energy_keywords = ["ai", "machine learning", "data center", "blockchain", "cloud", "mining"]
+        moderate_energy_keywords = ["device", "hardware", "robot", "manufactur"]
+        low_energy_keywords = ["software", "app", "service", "platform"]
+        # Default categories
+        energy_level = "Moderate"
+        carbon_level = "Moderate"
+        recycle_level = "Moderate"
+        # Determine energy/carbon levels based on keywords
+        if any(term in text for term in high_energy_keywords):
+            energy_level = "High"
+            carbon_level = "High"
+            recycle_level = "Low"
+        elif any(term in text for term in moderate_energy_keywords):
+            energy_level = "Moderate"
+            carbon_level = "Moderate"
+            recycle_level = "Moderate"
+        elif any(term in text for term in low_energy_keywords):
+            energy_level = "Low"
+            carbon_level = "Low"
+            recycle_level = "High"
+        # Adjust metrics if explicitly sustainable terms present
+        if any(term in text for term in ["sustainable", "renewable", "green"]):
+            if energy_level == "High":
+                energy_level = "Moderate"
+            if carbon_level == "High":
+                carbon_level = "Moderate"
+            recycle_level = "High"
+        # Assign numeric values for each level (simulated)
+        energy_usage = "50 kWh/year" if energy_level == "Low" else ("200 kWh/year" if energy_level == "Moderate" else "1000 kWh/year")
+        carbon_fp = "20 kg CO2/year" if carbon_level == "Low" else ("100 kg CO2/year" if carbon_level == "Moderate" else "500 kg CO2/year")
+        recyclability = "90%" if recycle_level == "High" else ("50%" if recycle_level == "Moderate" else "20%")
+        # Return a dictionary of metrics
+        return {
+            "Energy Usage": energy_usage,
+            "Carbon Footprint": carbon_fp,
+            "Recyclability": recyclability,
+        }

--- a/plugins/plugin_base.py
+++ b/plugins/plugin_base.py
@@ -1,0 +1,60 @@
+"""Base classes for the plugin architecture.
+
+This module defines the :class:`Plugin` interface that all plugins must
+implement. Plugins expose a ``name`` and ``description`` attribute and
+provide a :meth:`run` method that performs the plugin's action.
+"""
+
+from __future__ import annotations
+
+class Plugin:
+    """Base class for extendable plugins in the system.
+
+    Plugins should set a unique :attr:`name` and optionally provide a
+    human-readable :attr:`description`. Subclasses must override
+    :meth:`run` to implement their functionality.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the base plugin with empty metadata.
+
+        Subclasses typically override this method to populate
+        :attr:`name` and :attr:`description`.
+        """
+        self.name: str = ""
+        self.description: str = ""
+
+    def run(self, task: str, context: str):
+        """Execute the plugin's action.
+
+        Parameters
+        ----------
+        task:
+            A short description of the work to perform.
+        context:
+            Additional contextual information for the plugin.
+
+        Returns
+        -------
+        Any
+            The result of the plugin's computation. The type depends on
+            the concrete plugin implementation.
+
+        Raises
+        ------
+        NotImplementedError
+            If a subclass does not implement this method.
+
+        Examples
+        --------
+        Creating a simple plugin that echoes the task::
+
+            class EchoPlugin(Plugin):
+                def __init__(self):
+                    super().__init__()
+                    self.name = "echo"
+
+                def run(self, task: str, context: str = ""):
+                    return task
+        """
+        raise NotImplementedError("Plugin must implement the run method.")

--- a/plugins/plugin_manager.py
+++ b/plugins/plugin_manager.py
@@ -1,0 +1,82 @@
+"""Utilities for discovering and invoking plugins.
+
+The :class:`PluginManager` class scans the :mod:`plugins` package for
+subclasses of :class:`~plugins.plugin_base.Plugin` and provides a simple
+interface for running them by name.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import inspect
+from plugins.plugin_base import Plugin
+
+
+class PluginManager:
+    """Manages discovery and execution of plugins.
+
+    Examples
+    --------
+    >>> pm = PluginManager()
+    >>> sorted(pm.plugins)  # doctest: +SKIP
+    ['eco_impact']
+    """
+
+    def __init__(self) -> None:
+        """Discover and register available plugins.
+
+        On instantiation, the manager imports all modules in the
+        ``plugins`` directory and registers any subclasses of
+        :class:`Plugin` using their declared ``name`` attribute.
+        """
+        # Automatically register all plugins in the plugins directory
+        self.plugins = {}
+        plugins_dir = os.path.dirname(__file__)
+        for filename in os.listdir(plugins_dir):
+            if filename.endswith(".py") and filename not in ["__init__.py", "plugin_base.py", "plugin_manager.py"]:
+                module_name = f"plugins.{filename[:-3]}"
+                module = importlib.import_module(module_name)
+                # Find Plugin subclasses in the module
+                for name, cls in inspect.getmembers(module, inspect.isclass):
+                    if issubclass(cls, Plugin) and cls is not Plugin:
+                        instance = cls()
+                        # Register plugin by its name
+                        if instance.name:
+                            self.plugins[instance.name] = instance
+
+    def run_plugin(self, name: str, task: str, context: str = ""):
+        """Run the specified plugin by name.
+
+        Parameters
+        ----------
+        name:
+            The registered name of the plugin to execute.
+        task:
+            Description of the work to pass to the plugin.
+        context:
+            Additional context for the plugin, if any.
+
+        Returns
+        -------
+        Any
+            The value returned by the plugin's :meth:`run` method.
+
+        Raises
+        ------
+        ValueError
+            If the requested plugin is not found.
+
+        Examples
+        --------
+        >>> pm = PluginManager()
+        >>> pm.run_plugin("eco_impact", "Build a cloud service")  # doctest: +SKIP
+        {'Energy Usage': '200 kWh/year', ...}
+        """
+        if name not in self.plugins:
+            raise ValueError(f"Plugin '{name}' not found.")
+        # Log plugin invocation and increment call count
+        import streamlit as st
+        st.session_state["plugin_calls"] = st.session_state.get("plugin_calls", 0) + 1
+        plugin = self.plugins[name]
+        return plugin.run(task, context)


### PR DESCRIPTION
## Summary
- Introduce `plugins` package with automatic module discovery
- Add detailed docstrings for `Plugin`, `PluginManager`, and `EcoImpactPlugin`
- Provide usage examples and parameter documentation across plugin architecture

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d8ecfc7c0832c821aa006c356f333