### PR TITLE
Handle unsupported response_format in planner

### DIFF
--- a/tests/test_planner_agent.py
+++ b/tests/test_planner_agent.py
@@ -11,8 +11,24 @@ def make_openai_response(text: str):
 
 @patch.dict(os.environ, {"OPENAI_API_KEY": "x"})
 @patch('openai.chat.completions.create')
-def test_planner_agent_returns_dict(mock_create):
+def test_planner_agent_returns_dict_without_response_format(mock_create):
+    """Legacy models should not receive the response_format parameter."""
     mock_create.return_value = make_openai_response('{"X": "Y"}')
     agent = PlannerAgent("gpt-4")
     result = agent.run('idea', 'task')
+
     assert result == {"X": "Y"}
+    # Ensure response_format was not supplied for unsupported models
+    _, kwargs = mock_create.call_args
+    assert "response_format" not in kwargs
+
+
+@patch.dict(os.environ, {"OPENAI_API_KEY": "x"})
+@patch('openai.chat.completions.create')
+def test_planner_agent_uses_response_format_for_new_models(mock_create):
+    mock_create.return_value = make_openai_response('{"X": "Y"}')
+    agent = PlannerAgent("gpt-4o-mini")
+    agent.run('idea', 'task')
+
+    _, kwargs = mock_create.call_args
+    assert kwargs.get("response_format") == {"type": "json_object"}


### PR DESCRIPTION
## Summary
- avoid passing response_format for models that reject it
- add tests ensuring response_format is conditionally applied

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d9bd66cf8832c8a12ea552e644553