### PR TITLE
Persist research plan across reruns

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -47,14 +47,16 @@ if st.button("1⃣ Generate Research Plan"):
         except Exception as e:
             st.error(f"Planner failed: {e}")
             st.stop()
-    st.subheader("Project Plan (Role → Task)")
-    st.json(plan)
     st.session_state["plan"] = plan
     # Log the plan generation step
     audit_logger.log_step(st.session_state["project_id"], "Planner", "Output", "Plan generated", success=True)
 
-# 3. Execute each specialist agent (with optional refinement rounds, simulations, and design depth)
+# Display the plan if it exists in session state
 if "plan" in st.session_state:
+    st.subheader("Project Plan (Role → Task)")
+    st.json(st.session_state["plan"])
+
+    # 3. Execute each specialist agent (with optional refinement rounds, simulations, and design depth)
     refinement_rounds = st.slider("🔁 Refinement Rounds", 1, 3, value=1)
     design_depth_choice = st.selectbox("🎛️ Design Depth", ["Low", "Medium", "High"], index=1)
     simulate_enabled = st.checkbox("Enable Simulations", value=False)


### PR DESCRIPTION
## Summary
- keep generated research plan visible by rendering from `st.session_state`
- show the plan outside the generate button so reruns don't hide it

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e61e79014832c88533c20f6e1a1c3