### PR TITLE
Disable Streamlit file watcher by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 __pycache__/
+memory/audit_log/
+memory/project_memory.json

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,2 @@
+[server]
+fileWatcherType = "none"


### PR DESCRIPTION
## Summary
- disable Streamlit's file system watcher to avoid inotify limit errors in constrained environments
- ignore generated memory log files

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e70a9ce64832c8061188c17e8d746