### PR TITLE
Improve plan generation error handling

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -57,21 +57,21 @@ if st.button("1⃣ Generate Research Plan"):
             logging.debug(f"Filtered plan: {plan}, dropped roles: {dropped}")
             if dropped:
                 st.warning(f"Dropped unrecognized roles: {', '.join(dropped)}")
+        st.session_state["plan"] = plan
+        # Log the plan generation step
+        safe_log_step(st.session_state["project_id"], "Planner", "Output", "Plan generated", success=True)
     except openai.OpenAIError as e:
         logging.exception("OpenAI error during plan generation: %s", e)
         st.error("Planning failed: Unable to generate plan. Please check your API key or try again later.")
-        st.stop()
+        st.write("Plan generation failed:", e)
     except json.JSONDecodeError as e:
         logging.exception("JSON decode error during plan generation: %s", e)
         st.error("Planning failed: Plan generation output was not understood – the AI did not return a proper plan.")
-        st.stop()
+        st.write("Plan generation failed:", e)
     except Exception as e:
         logging.exception("Unexpected error during plan generation: %s", e)
         st.error("Planning failed: An unexpected error occurred.")
-        st.stop()
-    st.session_state["plan"] = plan
-    # Log the plan generation step
-    safe_log_step(st.session_state["project_id"], "Planner", "Output", "Plan generated", success=True)
+        st.write("Plan generation failed:", e)
 
 # Display the plan if it exists in session state
 if "plan" in st.session_state:


### PR DESCRIPTION
## Summary
- Avoid halting the app when plan generation fails by replacing `st.stop()` with `st.write()` to surface errors
- Move plan storage and logging inside the try block so failed generations don't set state

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e882587f8832ca0b7aed17e5ea7c7