### PR TITLE
feat: task-level cache + depth selector + Firestore backend

### DIFF
--- a/app/agent_runner.py
+++ b/app/agent_runner.py
@@ -1,0 +1,73 @@
+# Command-line runner for DR-RD agents with Firestore caching.
+from __future__ import annotations
+
+import argparse
+import hashlib
+from typing import Optional
+
+from dr_rd import cache
+
+try:
+    import openai
+except Exception:  # pragma: no cover - openai optional in tests
+    openai = None
+
+_DEF_PROMPTS = {
+    "Low": "Provide a brief high-level summary.",
+    "Medium": "Provide a balanced level of technical detail.",
+    "High": "Provide exhaustive technical depth with all relevant details.",
+}
+
+
+def run_agent(role: str, prompt: str, depth: str = "Low") -> str:
+    """Run an agent for ``role`` with ``prompt`` and ``design depth``.
+
+    The result is cached in Firestore keyed by a SHA1 hash of the inputs.
+    """
+    depth_norm = depth.capitalize()
+    task_hash = hashlib.sha1(f"{role}|{prompt}|{depth_norm}".encode()).hexdigest()
+
+    cached = cache.get_result(task_hash)
+    if cached:
+        return cached
+
+    if openai is None:
+        raise RuntimeError("openai package not available")
+
+    depth_suffix = _DEF_PROMPTS.get(depth_norm, _DEF_PROMPTS["Low"])
+    message = f"{prompt}\n\n{depth_suffix}"
+
+    response = openai.chat.completions.create(
+        model="gpt-3.5-turbo",
+        messages=[
+            {"role": "system", "content": f"You are acting as {role}."},
+            {"role": "user", "content": message},
+        ],
+    )
+    result = response.choices[0].message.content.strip()
+    cache.save_result(task_hash, result)
+    return result
+
+
+def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run a single DR-RD agent")
+    parser.add_argument("role", help="Agent role to execute")
+    parser.add_argument("prompt", help="Prompt/task for the agent")
+    parser.add_argument(
+        "--design_depth",
+        default="low",
+        choices=["low", "medium", "high"],
+        help="Desired design depth for the response",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    args = _parse_args(argv)
+    depth = args.design_depth.capitalize()
+    output = run_agent(args.role, args.prompt, depth)
+    print(output)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/dr_rd/__init__.py
+++ b/dr_rd/__init__.py
@@ -1,0 +1,1 @@
+"""DR-RD core package."""

--- a/dr_rd/cache.py
+++ b/dr_rd/cache.py
@@ -1,0 +1,45 @@
+"""Firestore-backed result cache for DR-RD."""
+from __future__ import annotations
+from typing import Optional
+from google.cloud import firestore
+
+_client: Optional[firestore.Client] = None
+
+
+def _get_client() -> Optional[firestore.Client]:
+    """Return a Firestore client, creating it if needed.
+    If the client cannot be created (e.g. credentials missing), ``None`` is returned.
+    """
+    global _client
+    if _client is None:
+        try:
+            _client = firestore.Client()
+        except Exception:
+            _client = None
+    return _client
+
+
+def get_result(hash: str) -> Optional[str]:
+    """Retrieve cached result for ``hash`` or ``None`` if not found."""
+    client = _get_client()
+    if client is None:
+        return None
+    try:
+        doc = client.collection("task_cache").document(hash).get()
+        if doc.exists:
+            data = doc.to_dict() or {}
+            return data.get("content")
+    except Exception:
+        return None
+    return None
+
+
+def save_result(hash: str, content: str) -> None:
+    """Store ``content`` for ``hash``. Best effort – failures are ignored."""
+    client = _get_client()
+    if client is None:
+        return
+    try:
+        client.collection("task_cache").document(hash).set({"content": content})
+    except Exception:
+        pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ streamlit>=1.35.0
 openai>=1.25.0
 requests>=2.32.3
 google-cloud-logging
+google-cloud-firestore

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,20 @@
+"""Simple Streamlit interface for running DR-RD agents."""
+import streamlit as st
+from app.agent_runner import run_agent
+
+
+def main():
+    st.title("DR-RD Agent Runner")
+    role = st.text_input("Role")
+    prompt = st.text_area("Prompt")
+    depth = st.selectbox("Design Depth", ["Low", "Medium", "High"], index=0)
+    if st.button("Run"):
+        if not role or not prompt:
+            st.warning("Please provide role and prompt")
+        else:
+            result = run_agent(role, prompt, depth)
+            st.write(result)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- add Firestore-backed caching utilities
- integrate cache and design-depth option into CLI agent runner
- expose design depth selector in Streamlit app and enable Firestore dependency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e9bc1fb04832cb8364d272855409d