### PR TITLE
Improve simulation type resolution for specialized agents

### DIFF
--- a/agents/simulation_agent.py
+++ b/agents/simulation_agent.py
@@ -1,36 +1,52 @@
+from typing import Dict
 from simulation.simulation_manager import SimulationManager
 
+
+def determine_sim_type(role: str, design_spec: str) -> str:
+    """Determine which simulation to run based on the role name and design spec."""
+    role = role.lower()
+    if "mechanical" in role or "motion" in role:
+        return "structural"
+    elif "electronics" in role or "embedded" in role:
+        return "electronics"
+    elif "chemical" in role or "surface" in role:
+        return "chemical"
+    elif "thermal" in design_spec.lower():
+        return "thermal"
+    else:
+        return ""
+
+
 class SimulationAgent:
-    """Agent that selects and runs the appropriate simulation for a given role's design."""
+    """Agent that selects and runs simulations for design specifications."""
+
     def __init__(self):
         # Initialize a SimulationManager to handle simulation calls
         self.sim_manager = SimulationManager()
 
-    def run_simulation(self, role: str, design_spec: str) -> str:
-        """
-        Determine the simulation type based on the role or content, run the simulation,
-        and return the results formatted as Markdown.
-        """
-        # Decide simulation type by role (or design content for Research Scientist)
-        role_lower = role.lower()
-        if "engineer" in role_lower:
-            sim_type = "structural"
-        elif "cto" in role_lower:
-            sim_type = "electronics"
-        elif "research scientist" in role_lower:
-            # Heuristic: choose thermal vs chemical based on keywords in the design spec
-            spec_lower = design_spec.lower()
-            if any(term in spec_lower for term in ["chemical", "chemistry", "compound", "reaction", "material"]):
-                sim_type = "chemical"
-            else:
-                sim_type = "thermal"
-        else:
-            # Roles without a designated simulation type
-            return ""
+    def append_simulations(self, answers: Dict[str, str]) -> Dict[str, str]:
+        """Append simulation results to each role output when applicable."""
+        updated = {}
+        for role, spec in answers.items():
+            sim_type = determine_sim_type(role, spec)
+            if not sim_type:
+                updated[role] = spec  # No simulation required for this role
+                continue  # Skip simulation
+            metrics = self.sim_manager.simulate(sim_type, spec)
+            lines = [f"**Simulation ({sim_type.capitalize()}) Results:**"]
+            for metric, value in metrics.items():
+                if metric in ["pass", "failed"]:
+                    continue  # skip internal status keys in output
+                lines.append(f"- **{metric}**: {value}")
+            updated[role] = f"{spec}\n\n" + "\n".join(lines)
+        return updated
 
-        # Run the chosen simulation and get metrics (including pass/fail info)
+    def run_simulation(self, role: str, design_spec: str) -> str:
+        """Run a simulation for a single role's design specification."""
+        sim_type = determine_sim_type(role, design_spec)
+        if not sim_type:
+            return ""  # No simulation needed for this role
         metrics = self.sim_manager.simulate(sim_type, design_spec)
-        # Format the metrics as a Markdown section (excluding internal pass/fail keys)
         lines = [f"**Simulation ({sim_type.capitalize()}) Results:**"]
         for metric, value in metrics.items():
             if metric in ["pass", "failed"]:

--- a/simulation/simulation_manager.py
+++ b/simulation/simulation_manager.py
@@ -2,11 +2,11 @@ class SimulationManager:
     """Manages different types of simulations (structural, thermal, electronics, chemical)."""
     def __init__(self):
         # Register simulation handler stubs for each simulation type
-        self.simulators = {
+        self.sim_functions = {
             "structural": self._simulate_structural,
-            "thermal": self._simulate_thermal,
             "electronics": self._simulate_electronics,
-            "chemical": self._simulate_chemical
+            "chemical": self._simulate_chemical,
+            "thermal": self._simulate_thermal,
         }
 
     def simulate(self, sim_type: str, design_spec: str) -> dict:
@@ -15,8 +15,8 @@ class SimulationManager:
         Returns a dictionary of performance metrics, including a boolean pass/fail and list of failed criteria.
         """
         sim_type = sim_type.lower()
-        if sim_type in self.simulators:
-            metrics = self.simulators[sim_type](design_spec)
+        if sim_type in self.sim_functions:
+            metrics = self.sim_functions[sim_type](design_spec)
         else:
             raise ValueError(f"Simulation type '{sim_type}' is not supported.")
 
@@ -76,8 +76,8 @@ class SimulationManager:
         return {"Max Load": "1.5 tons", "Safety Factor": 3.2}
 
     def _simulate_thermal(self, design_spec: str) -> dict:
-        # Stub: simulate thermal performance (e.g., temperature, heat dissipation)
-        return {"Max Temperature": "85°C", "Heat Dissipation": "120 W"}
+        # Placeholder thermal simulation (e.g., max temperature and cooling margin)
+        return {"Max Temperature": "85°C", "Cooling Margin": "−5°C", "Pass": False}
 
     def _simulate_electronics(self, design_spec: str) -> dict:
         # Stub: simulate electronics performance (e.g., power usage, speed)


### PR DESCRIPTION
## Summary
- add `determine_sim_type` utility and append_simulations to skip non-applicable simulations
- expand simulation manager with dedicated function map and thermal stub

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689111faf78c832c8d51b65297fa2ad4