### PR TITLE
feat: add configuration and pdf export

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ openai>=1.25.0
 requests>=2.32.3
 google-cloud-logging
 google-cloud-firestore
+markdown-pdf


### PR DESCRIPTION
## Summary
- allow simulation toggle and design depth selection in sidebar
- pass design depth and simulation settings to agents and final proposal
- enable PDF report downloads using markdown-pdf library

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891155a0278832cb00a150730313a1a