### PR TITLE
Handle missing simulation types

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -195,8 +195,12 @@ def main():
                         )
                     else:
                         sim_type = ""
-                    logging.info(f"Running {sim_type or 'default'} simulation for role {role}")
-                    sim_metrics = simulation_agent.sim_manager.simulate(sim_type, result)
+                    if sim_type:
+                        logging.info(f"Running {sim_type} simulation for role {role}")
+                        sim_metrics = simulation_agent.sim_manager.simulate(sim_type, result)
+                    else:
+                        logging.info(f"No simulation available for role {role}; skipping.")
+                        sim_metrics = {"pass": True, "failed": []}
                     # Check simulation results
                     if not sim_metrics.get("pass", True):
                         # Log initial output failure


### PR DESCRIPTION
## Summary
- Avoid running simulations when no simulation type is determined
- Provide default pass metrics and log skipped simulation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68912c4c2750832c85867271217a0dea