### PR TITLE
Add comprehensive test suite

### DIFF
--- a/tests/test_agent_initialization.py
+++ b/tests/test_agent_initialization.py
@@ -1,0 +1,48 @@
+import pytest
+from config.agent_models import AGENT_MODEL_MAP
+from agents.mechanical_systems_lead_agent import MechanicalSystemsLeadAgent
+from agents.materials_process_engineer_agent import MaterialsProcessEngineerAgent
+from agents.chemical_surface_science_specialist_agent import ChemicalSurfaceScienceSpecialistAgent
+from agents.quantum_optics_physicist_agent import QuantumOpticsPhysicistAgent
+from agents.nonlinear_optics_engineer_agent import NonlinearOpticsEngineerAgent
+from agents.optical_systems_engineer_agent import OpticalSystemsEngineerAgent
+from agents.mechanical_precision_motion_engineer_agent import MechanicalPrecisionMotionEngineerAgent
+from agents.photonics_electronics_engineer_agent import PhotonicsElectronicsEngineerAgent
+from agents.electronics_embedded_controls_engineer_agent import ElectronicsEmbeddedControlsEngineerAgent
+from agents.software_image_processing_specialist_agent import SoftwareImageProcessingSpecialistAgent
+from agents.fluorescence_biological_sample_expert_agent import FluorescenceBiologicalSampleExpertAgent
+from agents.systems_integration_validation_engineer_agent import SystemsIntegrationValidationEngineerAgent
+from agents.data_scientist_analytics_engineer_agent import DataScientistAnalyticsEngineerAgent
+from agents.regulatory_compliance_lead_agent import RegulatoryComplianceLeadAgent
+from agents.prototyping_test_lab_manager_agent import PrototypingTestLabManagerAgent
+from agents.project_manager_principal_investigator_agent import ProjectManagerPrincipalInvestigatorAgent
+from agents.product_manager_translational_lead_agent import ProductManagerTranslationalLeadAgent
+from agents.ai_rd_coordinator_agent import AIResearchDevelopmentCoordinatorAgent
+
+AGENT_CLASSES = [
+    ("Mechanical Systems Lead", MechanicalSystemsLeadAgent),
+    ("Materials & Process Engineer", MaterialsProcessEngineerAgent),
+    ("Chemical & Surface Science Specialist", ChemicalSurfaceScienceSpecialistAgent),
+    ("Quantum Optics Physicist", QuantumOpticsPhysicistAgent),
+    ("Nonlinear Optics / Crystal Engineer", NonlinearOpticsEngineerAgent),
+    ("Optical Systems Engineer", OpticalSystemsEngineerAgent),
+    ("Mechanical & Precision-Motion Engineer", MechanicalPrecisionMotionEngineerAgent),
+    ("Photonics Electronics Engineer", PhotonicsElectronicsEngineerAgent),
+    ("Electronics & Embedded Controls Engineer", ElectronicsEmbeddedControlsEngineerAgent),
+    ("Software / Image-Processing Specialist", SoftwareImageProcessingSpecialistAgent),
+    ("Fluorescence / Biological Sample Expert", FluorescenceBiologicalSampleExpertAgent),
+    ("Systems Integration & Validation Engineer", SystemsIntegrationValidationEngineerAgent),
+    ("Data Scientist / Analytics Engineer", DataScientistAnalyticsEngineerAgent),
+    ("Regulatory & Compliance Lead", RegulatoryComplianceLeadAgent),
+    ("Prototyping & Test Lab Manager", PrototypingTestLabManagerAgent),
+    ("Project Manager / Principal Investigator", ProjectManagerPrincipalInvestigatorAgent),
+    ("Product Manager / Translational Lead", ProductManagerTranslationalLeadAgent),
+    ("AI R&D Coordinator", AIResearchDevelopmentCoordinatorAgent),
+]
+
+
+@pytest.mark.parametrize("role,cls", AGENT_CLASSES)
+def test_agent_initialization(role, cls):
+    model = AGENT_MODEL_MAP[role]
+    agent = cls(model=model)
+    assert agent.model == model

--- a/tests/test_agent_output_structure.py
+++ b/tests/test_agent_output_structure.py
@@ -1,0 +1,30 @@
+from unittest.mock import Mock, patch
+import os
+import pytest
+from agents.mechanical_systems_lead_agent import MechanicalSystemsLeadAgent
+from agents.optical_systems_engineer_agent import OpticalSystemsEngineerAgent
+from agents.ai_rd_coordinator_agent import AIResearchDevelopmentCoordinatorAgent
+
+def make_openai_response(text: str):
+    mock_choice = Mock()
+    mock_choice.message = Mock(content=text)
+    return Mock(choices=[mock_choice])
+
+AGENTS = [
+    MechanicalSystemsLeadAgent,
+    OpticalSystemsEngineerAgent,
+    AIResearchDevelopmentCoordinatorAgent,
+]
+
+@patch.dict(os.environ, {"OPENAI_API_KEY": "x"})
+@patch('openai.chat.completions.create')
+@pytest.mark.parametrize("cls", AGENTS)
+def test_agent_output_structure(mock_create, cls):
+    fake_md = "Result\n```json\n{\"key\": 1}\n```"
+    mock_create.return_value = make_openai_response(fake_md)
+    agent = cls("gpt-4o")
+    result = agent.run("idea", "task")
+    stripped = result.strip()
+    assert stripped.endswith("```")
+    assert "```json" in stripped
+

--- a/tests/test_pdf_generator.py
+++ b/tests/test_pdf_generator.py
@@ -1,0 +1,25 @@
+import importlib.util
+import os
+import pytest
+from app import generate_pdf
+
+md_spec = importlib.util.find_spec("markdown_pdf")
+pytestmark = pytest.mark.skipif(md_spec is None, reason="markdown_pdf not installed")
+
+if md_spec:
+    from markdown_pdf import MarkdownPdf
+
+
+def test_generate_pdf_smoke(monkeypatch, tmp_path):
+    if md_spec:
+        if not hasattr(MarkdownPdf, "export"):
+            def fake_export(self):
+                path = tmp_path / "tmp.pdf"
+                self.save(path)
+                return path.read_bytes()
+            monkeypatch.setattr(MarkdownPdf, "export", fake_export, raising=False)
+    md = "# Title\n\n- Item 1\n- Item 2\n\n![alt](https://example.com/image.png)"
+    pdf_bytes = generate_pdf(md)
+    assert isinstance(pdf_bytes, (bytes, bytearray))
+    assert len(pdf_bytes) > 1000
+    (tmp_path / "test_report.pdf").write_bytes(pdf_bytes)

--- a/tests/test_planner_output.py
+++ b/tests/test_planner_output.py
@@ -1,0 +1,27 @@
+import json
+from unittest.mock import Mock, patch
+import os
+import pytest
+from agents.planner_agent import PlannerAgent
+from config.agent_models import AGENT_MODEL_MAP
+
+
+def make_openai_response(text: str):
+    mock_choice = Mock()
+    mock_choice.message = Mock(content=text)
+    return Mock(choices=[mock_choice])
+
+
+ALLOWED_ROLES = set(AGENT_MODEL_MAP.keys()) - {"Planner", "Synthesizer"}
+
+
+@patch.dict(os.environ, {"OPENAI_API_KEY": "x"})
+@patch('openai.chat.completions.create')
+def test_planner_output_validity(mock_create):
+    mock_create.return_value = make_openai_response('{"Mechanical Systems Lead": "Design the frame"}')
+    agent = PlannerAgent("gpt-4o")
+    result = agent.run("a quantum entangled laser alignment tool with an FPGA controller", "Develop a plan")
+
+    assert isinstance(result, dict)
+    assert result
+    assert set(result.keys()).issubset(ALLOWED_ROLES)

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,0 +1,16 @@
+import pytest
+from agents.simulation_agent import determine_sim_type
+
+
+@pytest.mark.parametrize(
+    "role,spec,expected",
+    [
+        ("Mechanical & Precision-Motion Engineer", "spec", "structural"),
+        ("Photonics Electronics Engineer", "spec", "electronics"),
+        ("Chemical & Surface Science Specialist", "spec", "chemical"),
+        ("Project Manager", "This device needs thermal dissipation.", "thermal"),
+        ("Project Manager", "spec", ""),
+    ],
+)
+def test_determine_sim_type(role, spec, expected):
+    assert determine_sim_type(role, spec) == expected

--- a/tests/test_simulation_toggle.py
+++ b/tests/test_simulation_toggle.py
@@ -1,0 +1,27 @@
+from unittest.mock import patch
+import pytest
+from agents.simulation_agent import SimulationAgent
+from simulation.simulation_manager import SimulationManager
+
+@pytest.fixture
+def sample_outputs():
+    return {
+        "Mechanical & Precision-Motion Engineer": "spec1",
+        "Photonics Electronics Engineer": "spec2",
+        "Chemical & Surface Science Specialist": "spec3",
+        "Project Manager / Principal Investigator": "overview",
+    }
+
+def test_simulation_toggle(sample_outputs):
+    sim_agent = SimulationAgent()
+    with patch.object(SimulationManager, 'simulate') as mock_sim:
+        simulate_enabled = False
+        if simulate_enabled:
+            sim_agent.append_simulations(sample_outputs)
+        assert mock_sim.call_count == 0
+    with patch.object(SimulationManager, 'simulate') as mock_sim:
+        simulate_enabled = True
+        if simulate_enabled:
+            sim_agent.append_simulations(sample_outputs)
+        assert mock_sim.call_count == 3
+

--- a/tests/test_synthesizer.py
+++ b/tests/test_synthesizer.py
@@ -1,0 +1,25 @@
+from unittest.mock import Mock, patch
+import os
+import pytest
+from agents.synthesizer import compose_final_proposal
+
+
+def make_openai_response(text: str):
+    mock_choice = Mock()
+    mock_choice.message = Mock(content=text)
+    return Mock(choices=[mock_choice])
+
+
+@patch.dict(os.environ, {"OPENAI_API_KEY": "x"})
+@patch('openai.chat.completions.create')
+def test_compose_final_proposal(mock_create):
+    fake_response = "Summary of project\n\n## Mechanical Systems Lead\nDetails here\n\n## Simulation Results\nData"
+    mock_create.return_value = make_openai_response(fake_response)
+    answers = {
+        "Mechanical Systems Lead": "design",
+        "Optical Systems Engineer": "optics",
+        "AI R&D Coordinator": "ai tasks",
+    }
+    result = compose_final_proposal("idea", answers, include_simulations=True)
+    assert result.startswith("Summary")
+    assert "## Mechanical Systems Lead" in result


### PR DESCRIPTION
## Summary
- add initialization test to instantiate each specialist agent with its configured model
- cover determine_sim_type routing and planner output validation
- exercise agent prompts, synthesizer composition, simulation toggle behavior, and pdf generation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68912f2e2f74832caaf170a634e2dbfe