### PR TITLE
Add GitHub Actions workflow for running tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: Run DR-RD Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # Continue even if optional dependencies like markdown_pdf fail to install
+          pip install -r requirements.txt || echo "Failed to install some optional dependencies"
+          pip install pytest pytest-mock
+      - name: Run Pytest
+        run: |
+          set -o pipefail
+          pytest --maxfail=5 --disable-warnings -q | tee pytest.log
+      - name: Show test results
+        if: ${{ always() }}
+        run: |
+          tail -n 20 pytest.log
+          echo '## Pytest results' >> $GITHUB_STEP_SUMMARY
+          tail -n 20 pytest.log >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run pytest on push and PR
- install dependencies and test tools, then execute pytest
- publish tail of pytest output to workflow summary

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68913895cd1c832c83956a0e5bbf39c2