### PR TITLE
Handle missing PDF link destinations

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -21,7 +21,12 @@ def generate_pdf(markdown_text):
     pdf.add_section(Section(markdown_text))
     pdf.writer.close()
     pdf.out_file.seek(0)
-    doc = fitz.Story.add_pdf_links(pdf.out_file, pdf.hrefs)
+    try:
+        doc = fitz.Story.add_pdf_links(pdf.out_file, pdf.hrefs)
+    except Exception as e:
+        logging.warning(f"Failed to add PDF links: {e}")
+        pdf.out_file.seek(0)
+        doc = fitz.open(stream=pdf.out_file, filetype="pdf")
     doc.set_metadata(pdf.meta)
     if pdf.toc_level > 0:
         doc.set_toc(pdf.toc)


### PR DESCRIPTION
## Summary
- avoid crashes when generating PDFs by catching errors from `fitz.Story.add_pdf_links`
- fallback to opening the PDF directly and log a warning when a link target is missing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68914933733c832c84196cd47b707682