### PR TITLE
feat: wire geometry_tool into app.py

### DIFF
--- a/agents/geometry_tool.py
+++ b/agents/geometry_tool.py
@@ -1,4 +1,3 @@
-```python
 import numpy as np
 import trimesh
 import streamlit as st
@@ -34,9 +33,9 @@ def generate_mesh(spec: dict) -> bytes:
 
 def show_geometry(spec: dict):
     """Renders the STL in Streamlit via model-viewer."""
-    st.spinner("Building 3D model…")
     st.write("Spec:", spec)
-    stl = generate_mesh(spec)
+    with st.spinner("Building 3D model…"):
+        stl = generate_mesh(spec)
     b64 = base64.b64encode(stl).decode()
     html = f'''
     <model-viewer src="data:model/stl;base64,{b64}"

--- a/app.py
+++ b/app.py
@@ -2,11 +2,34 @@
 
 This file exists so that ``streamlit run app.py`` finds the application
 module. The bulk of the app lives in the ``app`` package; this script
-imports the package and executes ``main()`` to build the interface.
+provides a small router that can either launch the main application or
+invoke additional tools such as the geometry previewer.
 """
 
 from app import main
+from agents.geometry_tool import show_geometry
+import streamlit as st
+
+
+def tool_router():
+    """Route to the main app or a registered tool."""
+    tool = st.sidebar.selectbox("Action", ["app", "geometry"], index=0)
+
+    if tool == "geometry":
+        with st.form("geometry_form"):
+            width = st.number_input("Width", value=1.0)
+            height = st.number_input("Height", value=2.0)
+            depth = st.number_input("Depth", value=3.0)
+            submitted = st.form_submit_button("Preview")
+        if submitted:
+            spec = {
+                "type": "cube",
+                "params": {"width": width, "height": height, "depth": depth},
+            }
+            show_geometry(spec)
+    else:
+        main()
 
 
 if __name__ == "__main__":
-    main()
+    tool_router()


### PR DESCRIPTION
## Summary
- add geometry tool to app entry point with simple tool router
- clean up geometry_tool and wrap mesh generation in spinner

## Testing
- `pip install -r requirements.txt`
- `timeout 5 streamlit run app.py --server.headless true`
- `python - <<'PY'
from agents.geometry_tool import show_geometry
import streamlit as st
show_geometry({"type":"sphere","params":{"radius":1}})
print("rendered")
PY`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892b17ffed8832ca63d7390038c5541