### PR TITLE
fix: update planner agent to new openai api

### DIFF
--- a/agents/planner_agent.py
+++ b/agents/planner_agent.py
@@ -87,11 +87,13 @@ class PlannerAgent(BaseAgent):
             "Respond with JSON: { \"updated_tasks\": [ { \"role\": \"...\", \"task\": \"...\" } , ... ] }"
         )
         user = json.dumps(workspace_state, indent=2)[:8000]
-        resp = openai.ChatCompletion.create(
+        resp = openai.chat.completions.create(
             model="gpt-4o-mini",
             temperature=0.2,
-            messages=[{"role":"system","content":sys},
-                      {"role":"user","content":user}]
+            messages=[
+                {"role": "system", "content": sys},
+                {"role": "user", "content": user},
+            ],
         )
         try:
             data = resp.choices[0].message.content


### PR DESCRIPTION
## Summary
- swap deprecated `openai.ChatCompletion.create` with `openai.chat.completions.create`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68942bfb7a2c832ca09c04d5dcbaf549