### PR TITLE
Handle Photonic Electronics Engineer alias

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -22,26 +22,64 @@ from config.agent_models import AGENT_MODEL_MAP
 
 
 def initialize_agents():
+    photonics = PhotonicsElectronicsEngineerAgent(
+        AGENT_MODEL_MAP["Photonics Electronics Engineer"]
+    )
     return {
         "Planner": PlannerAgent(AGENT_MODEL_MAP["Planner"]),
-        "Mechanical Systems Lead": MechanicalSystemsLeadAgent(AGENT_MODEL_MAP["Mechanical Systems Lead"]),
-        "Materials & Process Engineer": MaterialsProcessEngineerAgent(AGENT_MODEL_MAP["Materials & Process Engineer"]),
-        "Chemical & Surface Science Specialist": ChemicalSurfaceScienceSpecialistAgent(AGENT_MODEL_MAP["Chemical & Surface Science Specialist"]),
-        "Quantum Optics Physicist": QuantumOpticsPhysicistAgent(AGENT_MODEL_MAP["Quantum Optics Physicist"]),
-        "Nonlinear Optics / Crystal Engineer": NonlinearOpticsEngineerAgent(AGENT_MODEL_MAP["Nonlinear Optics / Crystal Engineer"]),
-        "Optical Systems Engineer": OpticalSystemsEngineerAgent(AGENT_MODEL_MAP["Optical Systems Engineer"]),
-        "Mechanical & Precision-Motion Engineer": MechanicalPrecisionMotionEngineerAgent(AGENT_MODEL_MAP["Mechanical & Precision-Motion Engineer"]),
-        "Photonics Electronics Engineer": PhotonicsElectronicsEngineerAgent(AGENT_MODEL_MAP["Photonics Electronics Engineer"]),
-        "Electronics & Embedded Controls Engineer": ElectronicsEmbeddedControlsEngineerAgent(AGENT_MODEL_MAP["Electronics & Embedded Controls Engineer"]),
-        "Software / Image-Processing Specialist": SoftwareImageProcessingSpecialistAgent(AGENT_MODEL_MAP["Software / Image-Processing Specialist"]),
-        "Fluorescence / Biological Sample Expert": FluorescenceBiologicalSampleExpertAgent(AGENT_MODEL_MAP["Fluorescence / Biological Sample Expert"]),
-        "Systems Integration & Validation Engineer": SystemsIntegrationValidationEngineerAgent(AGENT_MODEL_MAP["Systems Integration & Validation Engineer"]),
-        "Data Scientist / Analytics Engineer": DataScientistAnalyticsEngineerAgent(AGENT_MODEL_MAP["Data Scientist / Analytics Engineer"]),
-        "Regulatory & Compliance Lead": RegulatoryComplianceLeadAgent(AGENT_MODEL_MAP["Regulatory & Compliance Lead"]),
-        "Prototyping & Test Lab Manager": PrototypingTestLabManagerAgent(AGENT_MODEL_MAP["Prototyping & Test Lab Manager"]),
-        "Project Manager / Principal Investigator": ProjectManagerPrincipalInvestigatorAgent(AGENT_MODEL_MAP["Project Manager / Principal Investigator"]),
-        "Product Manager / Translational Lead": ProductManagerTranslationalLeadAgent(AGENT_MODEL_MAP["Product Manager / Translational Lead"]),
-        "AI R&D Coordinator": AIResearchDevelopmentCoordinatorAgent(AGENT_MODEL_MAP["AI R&D Coordinator"]),
-        "Synthesizer": SynthesizerAgent(AGENT_MODEL_MAP["Synthesizer"])
+        "Mechanical Systems Lead": MechanicalSystemsLeadAgent(
+            AGENT_MODEL_MAP["Mechanical Systems Lead"]
+        ),
+        "Materials & Process Engineer": MaterialsProcessEngineerAgent(
+            AGENT_MODEL_MAP["Materials & Process Engineer"]
+        ),
+        "Chemical & Surface Science Specialist": ChemicalSurfaceScienceSpecialistAgent(
+            AGENT_MODEL_MAP["Chemical & Surface Science Specialist"]
+        ),
+        "Quantum Optics Physicist": QuantumOpticsPhysicistAgent(
+            AGENT_MODEL_MAP["Quantum Optics Physicist"]
+        ),
+        "Nonlinear Optics / Crystal Engineer": NonlinearOpticsEngineerAgent(
+            AGENT_MODEL_MAP["Nonlinear Optics / Crystal Engineer"]
+        ),
+        "Optical Systems Engineer": OpticalSystemsEngineerAgent(
+            AGENT_MODEL_MAP["Optical Systems Engineer"]
+        ),
+        "Mechanical & Precision-Motion Engineer": MechanicalPrecisionMotionEngineerAgent(
+            AGENT_MODEL_MAP["Mechanical & Precision-Motion Engineer"]
+        ),
+        "Photonics Electronics Engineer": photonics,
+        "Photonic Electronics Engineer": photonics,
+        "Electronics & Embedded Controls Engineer": ElectronicsEmbeddedControlsEngineerAgent(
+            AGENT_MODEL_MAP["Electronics & Embedded Controls Engineer"]
+        ),
+        "Software / Image-Processing Specialist": SoftwareImageProcessingSpecialistAgent(
+            AGENT_MODEL_MAP["Software / Image-Processing Specialist"]
+        ),
+        "Fluorescence / Biological Sample Expert": FluorescenceBiologicalSampleExpertAgent(
+            AGENT_MODEL_MAP["Fluorescence / Biological Sample Expert"]
+        ),
+        "Systems Integration & Validation Engineer": SystemsIntegrationValidationEngineerAgent(
+            AGENT_MODEL_MAP["Systems Integration & Validation Engineer"]
+        ),
+        "Data Scientist / Analytics Engineer": DataScientistAnalyticsEngineerAgent(
+            AGENT_MODEL_MAP["Data Scientist / Analytics Engineer"]
+        ),
+        "Regulatory & Compliance Lead": RegulatoryComplianceLeadAgent(
+            AGENT_MODEL_MAP["Regulatory & Compliance Lead"]
+        ),
+        "Prototyping & Test Lab Manager": PrototypingTestLabManagerAgent(
+            AGENT_MODEL_MAP["Prototyping & Test Lab Manager"]
+        ),
+        "Project Manager / Principal Investigator": ProjectManagerPrincipalInvestigatorAgent(
+            AGENT_MODEL_MAP["Project Manager / Principal Investigator"]
+        ),
+        "Product Manager / Translational Lead": ProductManagerTranslationalLeadAgent(
+            AGENT_MODEL_MAP["Product Manager / Translational Lead"]
+        ),
+        "AI R&D Coordinator": AIResearchDevelopmentCoordinatorAgent(
+            AGENT_MODEL_MAP["AI R&D Coordinator"]
+        ),
+        "Synthesizer": SynthesizerAgent(AGENT_MODEL_MAP["Synthesizer"]),
     }
 

--- a/config/agent_models.py
+++ b/config/agent_models.py
@@ -10,6 +10,7 @@ AGENT_MODEL_MAP = {
     "Optical Systems Engineer": "gpt-4o",
     "Mechanical & Precision-Motion Engineer": "gpt-4o",
     "Photonics Electronics Engineer": "gpt-4o",
+    "Photonic Electronics Engineer": "gpt-4o",
     "Electronics & Embedded Controls Engineer": "gpt-4o",
     "Software / Image-Processing Specialist": "gpt-4o",
     "Fluorescence / Biological Sample Expert": "gpt-4o",


### PR DESCRIPTION
## Summary
- allow tasks targeting "Photonic Electronics Engineer" to resolve by sharing the existing photonics agent
- map the new alias to the same model as the canonical role

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68943031134c832ca85335cd75bcb613