### PR TITLE
feat: add automatic HRM toggle

### DIFF
--- a/tests/test_app_ui.py
+++ b/tests/test_app_ui.py
@@ -19,6 +19,8 @@ def make_streamlit(text_input, buttons, state=None, raise_on_stop=False):
             return False
 
     class DummySidebar:
+        def checkbox(self, *args, **kwargs):
+            return False
         def expander(self, *args, **kwargs):
             class DummyExpander:
                 def __enter__(self_inner):


### PR DESCRIPTION
## Summary
- add sidebar checkbox to enable automatic HRM R&D
- route "Run All Domain Experts" to HRMLoop when auto mode is enabled, keep manual pipeline otherwise
- update unit tests for new sidebar checkbox

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68943a0f4870832c94193840c64f0e42