### PR TITLE
feat: display HRM progress and report in app

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,9 +20,22 @@ def tool_router():
         pid = st.text_input("Project ID", value="demo-project")
         if st.button("Run HRM Loop"):
             from dr_rd.hrm_engine import HRMLoop
+            log_box = st.empty()
+            logs = []
+
+            def cb(msg: str) -> None:
+                logs.append(msg)
+                log_box.write("\n".join(logs))
+
             with st.spinner("Working…"):
-                HRMLoop(pid, idea).run()
-            st.success("Done! view history in Firestore 📑")
+                state, report = HRMLoop(pid, idea).run(log_callback=cb)
+
+            st.success("Done! See results below and history in Firestore 📑")
+            if report:
+                st.subheader("Final Report")
+                st.markdown(report)
+            st.subheader("Results")
+            st.json(state.get("results", {}))
     else:
         main()
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -441,9 +441,22 @@ def main():
             project_id = st.session_state["project_id"]
             if auto_mode:
                 from dr_rd.hrm_engine import HRMLoop
+                log_box = st.empty()
+                logs: list[str] = []
+
+                def cb(msg: str) -> None:
+                    logs.append(msg)
+                    log_box.write("\n".join(logs))
+
                 with st.spinner("🤖 Running hierarchical plan → execute → revise…"):
-                    HRMLoop(project_id, idea).run()
-                st.success("✅ HRM automatic R&D complete! See Firestore for details.")
+                    state, report = HRMLoop(project_id, idea).run(log_callback=cb)
+
+                st.success("✅ HRM automatic R&D complete.")
+                if report:
+                    st.subheader("Final Report")
+                    st.markdown(report)
+                st.subheader("Results")
+                st.json(state.get("results", {}))
             else:
                 run_manual_pipeline(
                     agents,


### PR DESCRIPTION
## Summary
- add progress callback and final report return to HRMLoop
- show HRM execution logs, results, and final report in Streamlit apps

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894413d2448832cadff51e45d87ad6b