### PR TITLE
Remove HRM R&D tool and add HRM auto mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,44 +6,15 @@ provides a small router that can either launch the main application or
 invoke additional tools.
 """
 
-from app import main, generate_pdf
+from app import main
 import streamlit as st
 
 
 def tool_router():
-    """Route to the main app or a registered tool."""
-    tool = st.sidebar.selectbox("Action", ["app", "HRM R&D"], index=0)
+    """Route to the main app."""
+    tool = st.sidebar.selectbox("Action", ["app"], index=0)
 
-    if tool == "HRM R&D":
-        st.title("🧠 Hierarchical R&D Runner")
-        idea = st.text_area("Project idea")
-        pid = st.text_input("Project ID", value="demo-project")
-        if st.button("Run HRM Loop"):
-            from dr_rd.hrm_engine import HRMLoop
-            log_box = st.empty()
-            logs = []
-
-            def cb(msg: str) -> None:
-                logs.append(msg)
-                log_box.write("\n".join(logs))
-
-            with st.spinner("Working…"):
-                state, report = HRMLoop(pid, idea).run(log_callback=cb)
-
-            st.success("Done! See results below and history in Firestore 📑")
-            if report:
-                st.subheader("Final Report")
-                st.markdown(report)
-                pdf_bytes = generate_pdf(report)
-                st.download_button(
-                    label="📄 Download Final Report as PDF",
-                    data=pdf_bytes,
-                    file_name="R&D_Report.pdf",
-                    mime="application/pdf",
-                )
-            st.subheader("Results")
-            st.json(state.get("results", {}))
-    else:
+    if tool == "app":
         main()
 
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -437,37 +437,39 @@ def main():
             else False
         )
 
+        def run_pipeline(project_id: str, idea: str) -> None:
+            run_manual_pipeline(
+                agents,
+                memory_manager,
+                similar_ideas,
+                idea,
+                refinement_rounds,
+                simulate_enabled,
+                design_depth,
+                re_run_simulations,
+            )
+
         if st.button("2⃣ Run All Domain Experts"):
             project_id = st.session_state["project_id"]
             if auto_mode:
                 from dr_rd.hrm_engine import HRMLoop
-                log_box = st.empty()
-                logs: list[str] = []
-
-                def cb(msg: str) -> None:
-                    logs.append(msg)
-                    log_box.write("\n".join(logs))
-
                 with st.spinner("🤖 Running hierarchical plan → execute → revise…"):
-                    state, report = HRMLoop(project_id, idea).run(log_callback=cb)
-
-                st.success("✅ HRM automatic R&D complete.")
+                    state, report = HRMLoop(project_id, idea).run()
+                st.success("✅ HRM Automatic R&D complete!")
                 if report:
                     st.subheader("Final Report")
                     st.markdown(report)
+                    pdf = generate_pdf(report)
+                    st.download_button(
+                        "📄 Download Report",
+                        data=pdf,
+                        file_name="R&D_Report.pdf",
+                        mime="application/pdf",
+                    )
                 st.subheader("Results")
                 st.json(state.get("results", {}))
             else:
-                run_manual_pipeline(
-                    agents,
-                    memory_manager,
-                    similar_ideas,
-                    idea,
-                    refinement_rounds,
-                    simulate_enabled,
-                    design_depth,
-                    re_run_simulations,
-                )
+                run_pipeline(project_id, idea)
 
     # 4. Synthesize final proposal
     if "answers" in st.session_state:


### PR DESCRIPTION
## Summary
- simplify Streamlit entry point to only expose main app
- integrate HRM automatic R&D option with PDF report download and manual pipeline fallback

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894c26cac24832c916faccefc623ac3