### PR TITLE
Remove sidebar tool router selectbox

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,15 +7,11 @@ invoke additional tools.
 """
 
 from app import main
-import streamlit as st
 
 
 def tool_router():
-    """Route to the main app."""
-    tool = st.sidebar.selectbox("Action", ["app"], index=0)
-
-    if tool == "app":
-        main()
+    """Route directly to the main app."""
+    main()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- simplify `tool_router` by invoking `main()` directly
- drop unused Streamlit sidebar select box and import

## Testing
- `pytest -q`
- `flake8 app.py`


------
https://chatgpt.com/codex/tasks/task_e_6894e268142c832c9321004259231e30