### PR TITLE
Persist HRM report and use dr_rd_projects collection

### DIFF
--- a/memory/memory_manager.py
+++ b/memory/memory_manager.py
@@ -35,7 +35,7 @@ class MemoryManager:
 
             db = firestore.Client()
             doc_id = name or str(uuid.uuid4())
-            db.collection("projects").document(doc_id).set(entry)
+            db.collection("dr_rd_projects").document(doc_id).set(entry)
         except Exception as e:  # pylint: disable=broad-except
             logging.info(f"Firestore save skipped/failed: {e}")
 


### PR DESCRIPTION
## Summary
- Persist auto-mode HRM report and results in session state to prevent UI reset after downloading
- Load and save projects from the `dr_rd_projects` Firestore collection

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68951005925c832cb5bafc4d05798457