### PR TITLE
feat(core): extension registry + feature flags (no behavior change)

### DIFF
--- a/config/feature_flags.py
+++ b/config/feature_flags.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import os
+
+
+def _flag(name: str) -> bool:
+    return os.getenv(name, "false").lower() == "true"
+
+
+EVALUATORS_ENABLED = _flag("EVALUATORS_ENABLED")
+PARALLEL_EXEC_ENABLED = _flag("PARALLEL_EXEC_ENABLED")
+TOT_PLANNING_ENABLED = _flag("TOT_PLANNING_ENABLED")
+REFLECTION_ENABLED = _flag("REFLECTION_ENABLED")
+SIM_OPTIMIZER_ENABLED = _flag("SIM_OPTIMIZER_ENABLED")
+RAG_ENABLED = _flag("RAG_ENABLED")

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,0 +1,19 @@
+# Extensions
+
+This project supports registries for pluggable components. Each registry
+maintains a simple mapping from a string name to a class.
+
+## Example: Register an evaluator
+
+```python
+from dr_rd.extensions.abcs import BaseEvaluator
+from dr_rd.extensions.registry import EvaluatorRegistry
+
+class MyEval(BaseEvaluator):
+    def evaluate(self, state: dict) -> dict:
+        return {"score": 1.0}
+
+EvaluatorRegistry.register("my_eval", MyEval)
+```
+
+Use ``EvaluatorRegistry.get("my_eval")`` to retrieve the class later.

--- a/dr_rd/agents/engine.py
+++ b/dr_rd/agents/engine.py
@@ -4,6 +4,12 @@ from dr_rd.utils.firestore_workspace import FirestoreWorkspace
 from dr_rd.agents.planner_agent import PlannerAgent
 from dr_rd.agents.simulation_agent import SimulationAgent
 from dr_rd.agents.synthesizer_agent import SynthesizerAgent
+from dr_rd.extensions.registry import (
+    EvaluatorRegistry,
+    PlannerStrategyRegistry,
+    SimulatorRegistry,
+    MetaAgentRegistry,
+)
 
 # HRM‐loop parameters
 MAX_CYCLES = 5

--- a/dr_rd/extensions/__init__.py
+++ b/dr_rd/extensions/__init__.py
@@ -1,0 +1,1 @@
+"""Extension points for DR-RD."""

--- a/dr_rd/extensions/abcs.py
+++ b/dr_rd/extensions/abcs.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List
+
+
+class BaseEvaluator(ABC):
+    """Evaluator extension point."""
+
+    @abstractmethod
+    def evaluate(self, state: Dict[str, Any]) -> Dict[str, Any]:
+        """Return evaluation data for the given state."""
+
+    def weight(self) -> float:  # pragma: no cover - default implementation
+        return 1.0
+
+    def name(self) -> str:  # pragma: no cover - default implementation
+        return self.__class__.__name__
+
+
+class BasePlannerStrategy(ABC):
+    """Planning strategy extension point."""
+
+    @abstractmethod
+    def plan(self, state: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Produce a list of tasks for the given state."""
+
+
+class BaseSimulator(ABC):
+    """Simulation extension point."""
+
+    @abstractmethod
+    def run(self, design: Dict[str, Any], constraints: Dict[str, Any]) -> Dict[str, Any]:
+        """Run a simulation and return the result."""
+
+
+class BaseMetaAgent(ABC):
+    """Meta agent extension point."""
+
+    @abstractmethod
+    def reflect(self, history: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Adjust strategy based on execution history."""

--- a/dr_rd/extensions/registry.py
+++ b/dr_rd/extensions/registry.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Type
+
+from .abcs import BaseEvaluator, BasePlannerStrategy, BaseSimulator, BaseMetaAgent
+
+
+class Registry:
+    """Simple class registry."""
+
+    def __init__(self) -> None:
+        self._items: Dict[str, Type[Any]] = {}
+
+    def register(self, name: str, cls: Type[Any]) -> None:
+        self._items[name] = cls
+
+    def get(self, name: str) -> Optional[Type[Any]]:
+        return self._items.get(name)
+
+    def list(self) -> List[str]:
+        return list(self._items.keys())
+
+
+EvaluatorRegistry = Registry()
+PlannerStrategyRegistry = Registry()
+SimulatorRegistry = Registry()
+MetaAgentRegistry = Registry()

--- a/dr_rd/hrm_engine.py
+++ b/dr_rd/hrm_engine.py
@@ -5,6 +5,12 @@ from typing import Tuple, Callable, Optional, Dict, Any
 
 from dr_rd.utils.firestore_workspace import FirestoreWorkspace as WS
 from agents import initialize_agents
+from dr_rd.extensions.registry import (
+    EvaluatorRegistry,
+    PlannerStrategyRegistry,
+    SimulatorRegistry,
+    MetaAgentRegistry,
+)
 
 
 class HRMLoop:

--- a/tests/test_extension_registry.py
+++ b/tests/test_extension_registry.py
@@ -1,0 +1,12 @@
+from dr_rd.extensions.registry import Registry
+
+
+class Dummy:
+    pass
+
+
+def test_registry_add_get_list():
+    reg = Registry()
+    reg.register("dummy", Dummy)
+    assert reg.get("dummy") is Dummy
+    assert "dummy" in reg.list()

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -1,0 +1,22 @@
+import importlib
+
+
+def test_feature_flags_default_false(monkeypatch):
+    for name in [
+        "EVALUATORS_ENABLED",
+        "PARALLEL_EXEC_ENABLED",
+        "TOT_PLANNING_ENABLED",
+        "REFLECTION_ENABLED",
+        "SIM_OPTIMIZER_ENABLED",
+        "RAG_ENABLED",
+    ]:
+        monkeypatch.delenv(name, raising=False)
+
+    flags = importlib.reload(importlib.import_module("config.feature_flags"))
+
+    assert not flags.EVALUATORS_ENABLED
+    assert not flags.PARALLEL_EXEC_ENABLED
+    assert not flags.TOT_PLANNING_ENABLED
+    assert not flags.REFLECTION_ENABLED
+    assert not flags.SIM_OPTIMIZER_ENABLED
+    assert not flags.RAG_ENABLED


### PR DESCRIPTION
## Summary
- add generic registries for Evaluator, PlannerStrategy, Simulator and MetaAgent
- introduce config-driven feature flags, all disabled by default
- document and test the new extension layer

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68952be7e370832cb099cc9eb904e5fa