### PR TITLE
Add token-based truncation for RAG snippets

### DIFF
--- a/config/feature_flags.py
+++ b/config/feature_flags.py
@@ -16,6 +16,7 @@ SIM_OPTIMIZER_STRATEGY: str = os.getenv("SIM_OPTIMIZER_STRATEGY", "random")
 SIM_OPTIMIZER_MAX_EVALS: int = int(os.getenv("SIM_OPTIMIZER_MAX_EVALS", "50"))
 RAG_ENABLED = _flag("RAG_ENABLED")
 RAG_TOPK: int = int(os.getenv("RAG_TOPK", "5"))
+RAG_SNIPPET_TOKENS: int = int(os.getenv("RAG_SNIPPET_TOKENS", "200"))
 
 # Parameters for Tree-of-Thoughts planning. These remain inexpensive to
 # access even when the feature flag is disabled.

--- a/tests/test_rag_prompt.py
+++ b/tests/test_rag_prompt.py
@@ -45,3 +45,26 @@ def test_rag_skipped_when_disabled(mock_create, monkeypatch):
     agent.run("idea", "do something")
     prompt = mock_create.call_args.kwargs["messages"][1]["content"]
     assert "Research Bundle" not in prompt
+
+
+@patch.dict(os.environ, {"OPENAI_API_KEY": "x"})
+@patch("openai.chat.completions.create")
+def test_rag_snippet_token_truncation(mock_create, monkeypatch):
+    mock_create.return_value = make_openai_response("ok")
+    monkeypatch.setenv("RAG_ENABLED", "true")
+    monkeypatch.setenv("RAG_TOPK", "1")
+    monkeypatch.setenv("RAG_SNIPPET_TOKENS", "3")
+
+    class LongRetriever:
+        def query(self, text: str, top_k: int):
+            return [("one two three four five", "doc.txt")]
+
+    import config.feature_flags as ff
+    importlib.reload(ff)
+    import agents.base_agent as ba
+    importlib.reload(ba)
+    agent = ba.BaseAgent("Test", "gpt-4o", "sys", "Task: {task}", retriever=LongRetriever())
+    agent.run("idea", "do something")
+    prompt = mock_create.call_args.kwargs["messages"][1]["content"]
+    assert "one two three" in prompt
+    assert "four" not in prompt


### PR DESCRIPTION
## Summary
- trim retrieval snippets to a configurable token limit and include source citations
- expose `RAG_SNIPPET_TOKENS` feature flag for snippet token cap
- test RAG snippet token truncation

## Testing
- `pytest tests/test_rag_prompt.py::test_rag_snippet_token_truncation -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68960f3533ec832c8bdd439ba3c601a9