### PR TITLE
feat(evaluation): default evaluators + scorecard integration

### DIFF
--- a/config/feature_flags.py
+++ b/config/feature_flags.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import json
 
 
 def _flag(name: str) -> bool:
@@ -17,6 +18,16 @@ SIM_OPTIMIZER_MAX_EVALS: int = int(os.getenv("SIM_OPTIMIZER_MAX_EVALS", "50"))
 RAG_ENABLED = _flag("RAG_ENABLED")
 RAG_TOPK: int = int(os.getenv("RAG_TOPK", "5"))
 RAG_SNIPPET_TOKENS: int = int(os.getenv("RAG_SNIPPET_TOKENS", "200"))
+
+# Default evaluator weights and threshold. ``EVALUATOR_WEIGHTS`` can be
+# overridden via an environment variable containing a JSON object.
+EVALUATOR_WEIGHTS = json.loads(
+    os.getenv(
+        "EVALUATOR_WEIGHTS",
+        '{"cost": 0.25, "feasibility": 0.35, "novelty": 0.25, "compliance": 0.15}',
+    )
+)
+EVALUATOR_MIN_OVERALL: float = float(os.getenv("EVALUATOR_MIN_OVERALL", "0.6"))
 
 # Parameters for Tree-of-Thoughts planning. These remain inexpensive to
 # access even when the feature flag is disabled.

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -1,0 +1,33 @@
+# Evaluation Extensions
+
+The engine supports pluggable **evaluators** that score the workspace state
+after each execution cycle. Evaluators implement the
+`dr_rd.extensions.abcs.BaseEvaluator` interface:
+
+```python
+class BaseEvaluator(ABC):
+    def evaluate(self, state: Dict[str, Any]) -> Dict[str, Any]:
+        ...
+```
+
+The `evaluate` method should return a mapping with at least a `score` field
+and an optional list of `notes`.
+
+## Registering an evaluator
+
+Create a module under `dr_rd/evaluators/` that subclasses `BaseEvaluator` and
+registers it with the `EvaluatorRegistry`:
+
+```python
+from dr_rd.extensions.abcs import BaseEvaluator
+from dr_rd.extensions.registry import EvaluatorRegistry
+
+class MyEvaluator(BaseEvaluator):
+    def evaluate(self, state: dict) -> dict:
+        return {"score": 0.5, "notes": []}
+
+EvaluatorRegistry.register("my_eval", MyEvaluator)
+```
+
+Once registered and `EVALUATORS_ENABLED` is set, the evaluator will be invoked
+by the orchestrator and its score will contribute to the per‑cycle scorecard.

--- a/dr_rd/evaluation/__init__.py
+++ b/dr_rd/evaluation/__init__.py
@@ -1,0 +1,3 @@
+from .scorecard import Scorecard
+
+__all__ = ["Scorecard"]

--- a/dr_rd/evaluation/scorecard.py
+++ b/dr_rd/evaluation/scorecard.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class Scorecard:
+    """Aggregate evaluator results into a weighted scorecard."""
+
+    def __init__(self, weights: Dict[str, float]):
+        self.weights = weights
+
+    def aggregate(self, results: Dict[str, Dict[str, Any]]) -> Dict[str, Any]:
+        metrics: Dict[str, Dict[str, Any]] = {}
+        total_weight = 0.0
+        overall = 0.0
+        for name, data in results.items():
+            weight = float(self.weights.get(name, 1.0))
+            score = float(data.get("score", 0.0))
+            metrics[name] = {
+                "score": score,
+                "weight": weight,
+                "notes": data.get("notes", []),
+            }
+            overall += score * weight
+            total_weight += weight
+        if total_weight:
+            overall /= total_weight
+        return {"overall": overall, "metrics": metrics}

--- a/dr_rd/evaluators/__init__.py
+++ b/dr_rd/evaluators/__init__.py
@@ -1,0 +1,20 @@
+"""Built-in evaluators and registration."""
+from dr_rd.extensions.registry import EvaluatorRegistry
+
+from .cost import CostEvaluator
+from .feasibility import FeasibilityEvaluator
+from .novelty import NoveltyEvaluator
+from .compliance import ComplianceEvaluator
+
+# Register default evaluators
+EvaluatorRegistry.register("cost", CostEvaluator)
+EvaluatorRegistry.register("feasibility", FeasibilityEvaluator)
+EvaluatorRegistry.register("novelty", NoveltyEvaluator)
+EvaluatorRegistry.register("compliance", ComplianceEvaluator)
+
+__all__ = [
+    "CostEvaluator",
+    "FeasibilityEvaluator",
+    "NoveltyEvaluator",
+    "ComplianceEvaluator",
+]

--- a/dr_rd/evaluators/compliance.py
+++ b/dr_rd/evaluators/compliance.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from dr_rd.extensions.abcs import BaseEvaluator
+
+
+class ComplianceEvaluator(BaseEvaluator):
+    """Simple compliance evaluator."""
+
+    def evaluate(self, state: Dict[str, Any]) -> Dict[str, Any]:
+        text = " ".join(str(state.get(k, "")) for k in ["results", "tasks"])
+        if "compliance" in text.lower() or "regulation" in text.lower():
+            return {"score": 0.8, "notes": ["compliance considered"]}
+        return {"score": 0.5, "notes": ["compliance not addressed"]}

--- a/dr_rd/evaluators/cost.py
+++ b/dr_rd/evaluators/cost.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from dr_rd.extensions.abcs import BaseEvaluator
+
+
+class CostEvaluator(BaseEvaluator):
+    """Naive cost evaluator.
+
+    This stub implementation simply checks for a ``cost`` field in the
+    workspace state. If present, lower costs yield higher scores. In the
+    absence of explicit information it returns a neutral score.
+    """
+
+    def evaluate(self, state: Dict[str, Any]) -> Dict[str, Any]:
+        cost = state.get("cost") or state.get("results", {}).get("cost")
+        if cost is None:
+            return {"score": 0.5, "notes": ["no cost data"]}
+        try:
+            cost = float(cost)
+        except Exception:  # pragma: no cover - defensive
+            return {"score": 0.5, "notes": ["invalid cost data"]}
+        # Simple heuristic: lower cost -> higher score, assuming cost in [0,1]
+        score = max(0.0, min(1.0, 1.0 - cost))
+        return {"score": score, "notes": []}

--- a/dr_rd/evaluators/feasibility.py
+++ b/dr_rd/evaluators/feasibility.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from dr_rd.extensions.abcs import BaseEvaluator
+
+
+class FeasibilityEvaluator(BaseEvaluator):
+    """Crude feasibility evaluator."""
+
+    def evaluate(self, state: Dict[str, Any]) -> Dict[str, Any]:
+        text = " ".join(str(state.get(k, "")) for k in ["results", "tasks"])
+        if "feasible" in text.lower():
+            return {"score": 0.8, "notes": ["feasibility addressed"]}
+        return {"score": 0.5, "notes": ["feasibility unclear"]}

--- a/dr_rd/evaluators/novelty.py
+++ b/dr_rd/evaluators/novelty.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from dr_rd.extensions.abcs import BaseEvaluator
+
+
+class NoveltyEvaluator(BaseEvaluator):
+    """Basic novelty evaluator."""
+
+    def evaluate(self, state: Dict[str, Any]) -> Dict[str, Any]:
+        text = " ".join(str(state.get(k, "")) for k in ["results", "tasks"])
+        if any(w in text.lower() for w in ["novel", "innovative", "new"]):
+            return {"score": 0.8, "notes": ["novelty mentioned"]}
+        return {"score": 0.5, "notes": ["novelty not demonstrated"]}

--- a/dr_rd/planning/strategies/tot.py
+++ b/dr_rd/planning/strategies/tot.py
@@ -25,6 +25,9 @@ from config.feature_flags import (
 from dr_rd.extensions.abcs import BasePlannerStrategy
 from dr_rd.extensions.registry import EvaluatorRegistry, PlannerStrategyRegistry
 
+if EVALUATORS_ENABLED:
+    from dr_rd import evaluators  # noqa: F401
+
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_planner_remediation.py
+++ b/tests/test_planner_remediation.py
@@ -1,0 +1,21 @@
+from unittest.mock import Mock, patch
+import os
+
+from agents.planner_agent import PlannerAgent
+from config.feature_flags import EVALUATOR_MIN_OVERALL
+
+
+def make_openai_response(text: str):
+    mock_choice = Mock()
+    mock_choice.message = Mock(content=text)
+    return Mock(choices=[mock_choice])
+
+
+@patch.dict(os.environ, {"OPENAI_API_KEY": "x"})
+@patch('openai.chat.completions.create')
+def test_planner_adds_remediation_task(mock_create):
+    mock_create.return_value = make_openai_response('{"updated_tasks": []}')
+    agent = PlannerAgent("gpt-4o-mini")
+    workspace = {"tasks": [], "scorecard": {"overall": EVALUATOR_MIN_OVERALL - 0.1, "metrics": {}}}
+    tasks = agent.revise_plan(workspace)
+    assert any("Improve" in t["task"] or "Address" in t["task"] for t in tasks)

--- a/tests/test_scorecard.py
+++ b/tests/test_scorecard.py
@@ -1,0 +1,22 @@
+import pytest
+
+from dr_rd.evaluation import Scorecard
+from dr_rd.extensions.abcs import BaseEvaluator
+
+
+class EvalA(BaseEvaluator):
+    def evaluate(self, state):
+        return {"score": 0.2, "notes": []}
+
+
+class EvalB(BaseEvaluator):
+    def evaluate(self, state):
+        return {"score": 0.8, "notes": []}
+
+
+def test_scorecard_aggregation():
+    weights = {"a": 0.6, "b": 0.4}
+    results = {"a": EvalA().evaluate({}), "b": EvalB().evaluate({})}
+    sc = Scorecard(weights).aggregate(results)
+    assert sc["overall"] == pytest.approx(0.44)
+    assert set(sc["metrics"].keys()) == {"a", "b"}


### PR DESCRIPTION
## Summary
- add default cost, feasibility, novelty and compliance evaluators and registry
- aggregate evaluator outputs via weighted Scorecard and attach to state each cycle
- planner appends remediation tasks when scorecard fails threshold

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68961342c20c832cb5a47739f3010b98