### PR TITLE
feat(sim): log optimizer trials + optional scorecard-aware objective

### DIFF
--- a/agents/simulation_agent.py
+++ b/agents/simulation_agent.py
@@ -55,12 +55,15 @@ class SimulationAgent:
         design_spec: str,
         design_space: Optional[DesignSpace] = None,
         objective_fn: Optional[Callable[[Dict[str, Any], Dict[str, Any]], float]] = None,
+        scorecard: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Run a simulation for a single role's design specification.
 
         When a ``design_space`` and ``objective_fn`` are provided and the
         optimizer feature flag is enabled, parameter search is performed and
-        the best design is reported.
+        the best design is reported. When a ``scorecard`` is supplied and
+        evaluator support is enabled, the optimizer will blend the simulation
+        score with ``scorecard['overall']``.
         """
 
         sim_type = determine_sim_type(role, design_spec)
@@ -80,6 +83,7 @@ class SimulationAgent:
                 simulator,
                 strategy=SIM_OPTIMIZER_STRATEGY,
                 max_evals=SIM_OPTIMIZER_MAX_EVALS,
+                scorecard=scorecard,
             )
         else:
             metrics = self.sim_manager.simulate(sim_type, design_spec)

--- a/dr_rd/simulation/design_space.py
+++ b/dr_rd/simulation/design_space.py
@@ -42,3 +42,16 @@ class DesignSpace:
             else:
                 design[key] = random.choice(list(opts))
         return design
+
+    def summarize(self, design: Dict[str, Any], limit: int = 3) -> str:
+        """Return a concise string summary of ``design`` parameters.
+
+        Only the first ``limit`` parameters are included to keep logs brief.
+        """
+        parts: List[str] = []
+        for key in self.space.keys():
+            if key in design:
+                parts.append(f"{key}={design[key]}")
+                if len(parts) >= limit:
+                    break
+        return ", ".join(parts)

--- a/dr_rd/simulation/optimizer.py
+++ b/dr_rd/simulation/optimizer.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import logging
 import os
 import random
-from typing import Callable, Dict, Tuple, Any
+from typing import Callable, Dict, Tuple, Any, Optional
 
+from config.feature_flags import EVALUATORS_ENABLED
 from .design_space import DesignSpace
 
 
@@ -15,6 +17,7 @@ def optimize(
     *,
     strategy: str = "random",
     max_evals: int = 50,
+    scorecard: Optional[Dict[str, Any]] = None,
 ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     """Search for the best design within ``design_space``.
 
@@ -34,16 +37,35 @@ def optimize(
     if seed is not None:
         random.seed(int(seed))
 
+    logger = logging.getLogger(__name__)
+
     best_design = None
     best_metrics = None
     best_score = float("-inf")
+    best_idx = -1
+    trial = 0
+
+    def _summarize(d: Dict[str, Any], limit: int = 3) -> str:
+        items = list(d.items())[:limit]
+        return ", ".join(f"{k}={v}" for k, v in items)
 
     def evaluate(candidate: Dict[str, Any]):
-        nonlocal best_design, best_metrics, best_score
+        nonlocal best_design, best_metrics, best_score, best_idx, trial
+        trial += 1
         metrics = simulator(candidate)
         score = objective_fn(candidate, metrics)
+        if EVALUATORS_ENABLED and scorecard and "overall" in scorecard:
+            alpha = float(os.getenv("SIM_OBJECTIVE_ALPHA", "0.7"))
+            score = alpha * score + (1 - alpha) * float(scorecard.get("overall", 0.0))
+        logger.info(
+            "trial %d: params=%s metrics=%s score=%.3f",
+            trial,
+            design_space.summarize(candidate),
+            _summarize(metrics),
+            score,
+        )
         if score > best_score:
-            best_design, best_metrics, best_score = candidate, metrics, score
+            best_design, best_metrics, best_score, best_idx = candidate, metrics, score, trial
 
     if design:
         evaluate(design)
@@ -55,5 +77,14 @@ def optimize(
         for _ in range(max_evals):
             candidate = design_space.sample()
             evaluate(candidate)
+
+    if best_design is not None:
+        logger.info(
+            "best: idx=%d params=%s metrics=%s score=%.3f",
+            best_idx,
+            design_space.summarize(best_design),
+            _summarize(best_metrics),
+            best_score,
+        )
 
     return best_design, best_metrics

--- a/tests/test_sim_optimizer_logging.py
+++ b/tests/test_sim_optimizer_logging.py
@@ -1,0 +1,22 @@
+import logging
+
+from dr_rd.simulation.design_space import DesignSpace
+from dr_rd.simulation.optimizer import optimize
+
+
+def test_optimizer_logs_best_trial(caplog):
+    space = DesignSpace({"x": [0, 1, 2]})
+
+    def simulator(d):
+        return {"score": d["x"]}
+
+    def objective(d, metrics):
+        return metrics["score"]
+
+    with caplog.at_level(logging.INFO, logger="dr_rd.simulation.optimizer"):
+        best_design, _ = optimize({}, space, objective, simulator, strategy="grid")
+
+    assert best_design["x"] == 2
+    logs = caplog.text
+    assert "best" in logs
+    assert "idx=3" in logs


### PR DESCRIPTION
## Summary
- log every optimizer trial and report best result
- allow blending objective with scorecard when evaluators enabled
- test logging includes winning trial index

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68961a8c291c832c97fe0ab4a5a7f4f6