### PR TITLE
chore(ci): add smoke test + minimal run() entrypoint

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,21 @@
+name: Smoke Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt || echo "Failed to install some optional dependencies"
+          pip install pytest
+      - name: Run smoke test
+        run: pytest tests/test_smoke.py -q

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,19 @@
+import importlib
+
+
+def test_feature_flags_default_false():
+    flags = importlib.reload(importlib.import_module("config.feature_flags"))
+    assert not flags.EVALUATORS_ENABLED
+    assert not flags.PARALLEL_EXEC_ENABLED
+    assert not flags.TOT_PLANNING_ENABLED
+    assert not flags.REFLECTION_ENABLED
+    assert not flags.SIM_OPTIMIZER_ENABLED
+    assert not flags.RAG_ENABLED
+
+
+def test_run_smoke():
+    from dr_rd.hrm_engine import run
+
+    result = run("test idea")
+    assert isinstance(result, dict)
+    assert result


### PR DESCRIPTION
## Summary
- expose a lightweight `run()` helper that performs one HRM cycle with all features disabled
- add a smoke test verifying feature flags and `run()` behavior
- wire up a GitHub Actions workflow to exercise the smoke test on pushes and PRs

## Testing
- `pytest tests/test_smoke.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68961e99981c832c8aa518a18fe32d84