### PR TITLE
feat: add model routing and cost meter

### DIFF
--- a/app/ui_cost_meter.py
+++ b/app/ui_cost_meter.py
@@ -1,0 +1,35 @@
+import streamlit as st
+from dr_rd.config.model_routing import MODEL_PRICES
+
+
+def estimate_tokens_brief(
+    brief_len_tokens: int,
+    base_exec_tokens: int,
+    agent_hrm_factor: float = 1.35,
+    eval_calls: int = 3,
+    help_prob: float = 0.3,
+):
+    plan_tokens = int(1.2 * brief_len_tokens)
+    exec_tokens = int(base_exec_tokens * agent_hrm_factor)
+    eval_tokens = 800 * eval_calls
+    extra = help_prob * (int(0.7 * plan_tokens) + base_exec_tokens + eval_tokens)
+    return plan_tokens + exec_tokens + eval_tokens + int(extra)
+
+
+def render_estimator(
+    default_brief_tokens: int = 2000,
+    default_exec_tokens: int = 80000,
+    price_per_1k: float = 0.005,
+    help_prob: float = 0.3,
+):
+    st.subheader("Run Cost Estimate")
+    brief = st.number_input("Brief size (tokens)", value=default_brief_tokens, step=500)
+    exec_base = st.number_input(
+        "Base exec tokens (classic)", value=default_exec_tokens, step=5000
+    )
+    p = st.slider("Chance of help step", 0.0, 1.0, help_prob, 0.05)
+    est = estimate_tokens_brief(brief, exec_base, help_prob=p)
+    st.metric("Estimated tokens", f"{est:,}")
+    st.metric("Estimated $", f"${est/1000*price_per_1k:,.4f}")
+    with st.expander("Model prices"):
+        st.json(MODEL_PRICES)

--- a/collaboration.py
+++ b/collaboration.py
@@ -1,4 +1,7 @@
 import openai
+import logging
+from dr_rd.utils.model_router import pick_model, CallHints
+from dr_rd.utils.llm_client import llm_call
 
 def agent_chat(agentA, agentB, idea, outputA, outputB):
     """
@@ -14,9 +17,14 @@ def agent_chat(agentA, agentB, idea, outputA, outputB):
         "After this exchange, update both the CTO's and the Research Scientist's outputs with any new insights. "
         "Provide only the final revised outputs, labeled as 'CTO Updated Output:' and 'Research Scientist Updated Output:'."
     )
-    response = openai.chat.completions.create(
-        model="gpt-4",
-        messages=[{"role": "user", "content": prompt}]
+    sel = pick_model(CallHints(stage="exec"))
+    logging.info(f"Model[exec]={sel['model']} params={sel['params']}")
+    response = llm_call(
+        openai,
+        sel["model"],
+        stage="exec",
+        messages=[{"role": "user", "content": prompt}],
+        **sel["params"],
     )
     content = response.choices[0].message.content.strip()
     # Extract updated outputs from the response content

--- a/dr_rd/config/model_routing.py
+++ b/dr_rd/config/model_routing.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+
+# === Fill with your tenant’s actual prices ===
+MODEL_PRICES = {
+    "gpt-5":       {"in": 1.25/1000, "out": 10/1000},
+    "gpt-5-mini":  {"in": 0.25/1000, "out":  2/1000},
+    "gpt-5-nano":  {"in": 0.05/1000, "out":  0.40/1000},
+    "o4-mini":     {"in": 0.20/1000, "out":  0.80/1000},   # TODO: update
+    "o3":          {"in": 0.60/1000, "out":  2.40/1000},   # TODO: update
+    "gpt-4o-mini": {"in": 0.15/1000, "out":  0.60/1000},
+}
+
+DEFAULTS = {
+    "PLANNER":        "gpt-5-mini",
+    "RESEARCHER":     "gpt-4o-mini",
+    "EVALUATOR":      "gpt-4o-mini",
+    "SYNTHESIZER":    "gpt-5-mini",
+    "FINAL_SYNTH":    "gpt-5",
+    "BRAIN_MODE_LOOP":"o4-mini",
+}
+
+@dataclass
+class CallHints:
+    stage: str                 # "plan"|"exec"|"eval"|"synth"|"brain"
+    difficulty: str = "normal" # "easy"|"normal"|"hard"
+    deep_reasoning: bool = False
+    final_pass: bool = False

--- a/dr_rd/utils/llm_client.py
+++ b/dr_rd/utils/llm_client.py
@@ -1,0 +1,32 @@
+from dr_rd.utils.token_meter import TokenMeter
+
+METER = TokenMeter()
+
+
+ALLOWED_PARAMS = {
+    "reasoning_effort",
+    "verbosity",
+    "temperature",
+    "response_format",
+    "max_tokens",
+    "top_p",
+}
+
+
+def llm_call(client, model_id: str, stage: str, messages: list, **params):
+    safe = {k: v for k, v in params.items() if k in ALLOWED_PARAMS}
+    resp = client.chat.completions.create(model=model_id, messages=messages, **safe)
+    usage = getattr(resp, "usage", None) or {}
+    try:
+        METER.add_usage(
+            model_id,
+            stage,
+            {
+                "prompt_tokens": usage.get("prompt_tokens", 0),
+                "completion_tokens": usage.get("completion_tokens", 0),
+                "total_tokens": usage.get("total_tokens", 0),
+            },
+        )
+    except Exception:
+        pass
+    return resp

--- a/dr_rd/utils/model_router.py
+++ b/dr_rd/utils/model_router.py
@@ -1,0 +1,59 @@
+from dr_rd.config.model_routing import DEFAULTS, CallHints
+
+
+def pick_model(h: CallHints) -> dict:
+    # plan
+    if h.stage == "plan":
+        model = DEFAULTS["PLANNER"]
+        params = {"reasoning_effort": "minimal", "verbosity": "low"}
+        if h.difficulty == "hard":
+            model = "o4-mini"
+            params["reasoning_effort"] = "medium"
+        return {"model": model, "params": params}
+
+    # exec (researchers/retrievers/agents)
+    if h.stage == "exec":
+        model = DEFAULTS["RESEARCHER"]
+        params = {"reasoning_effort": "minimal", "verbosity": "low"}
+        if h.difficulty == "hard":
+            model = "gpt-5-mini"
+        return {"model": model, "params": params}
+
+    # eval
+    if h.stage == "eval":
+        return {
+            "model": DEFAULTS["EVALUATOR"],
+            "params": {"reasoning_effort": "minimal", "verbosity": "low"},
+        }
+
+    # brain loop
+    if h.stage == "brain":
+        model = DEFAULTS["BRAIN_MODE_LOOP"]
+        params = {"reasoning_effort": "medium", "verbosity": "low"}
+        if h.deep_reasoning:
+            model = "o3"
+            params["reasoning_effort"] = "high"
+        return {"model": model, "params": params}
+
+    # synth
+    if h.stage == "synth":
+        model = DEFAULTS["SYNTHESIZER"]
+        params = {"reasoning_effort": "minimal", "verbosity": "medium"}
+        if h.final_pass:
+            model = DEFAULTS["FINAL_SYNTH"]
+            params["reasoning_effort"] = "medium"
+            params["verbosity"] = "high"
+        return {"model": model, "params": params}
+
+    return {
+        "model": DEFAULTS["RESEARCHER"],
+        "params": {"reasoning_effort": "minimal", "verbosity": "low"},
+    }
+
+
+def difficulty_from_signals(score: float, coverage: float) -> str:
+    if score >= 0.82 and coverage >= 0.65:
+        return "easy"
+    if score < 0.72 or coverage < 0.45:
+        return "hard"
+    return "normal"

--- a/dr_rd/utils/token_meter.py
+++ b/dr_rd/utils/token_meter.py
@@ -1,0 +1,29 @@
+from collections import defaultdict
+from dr_rd.config.model_routing import MODEL_PRICES
+
+
+class TokenMeter:
+    def __init__(self):
+        self.total_tokens = 0
+        self.per_model = defaultdict(int)
+        self.per_stage = defaultdict(int)
+
+    def add_usage(self, model_id: str, stage: str, usage: dict):
+        t = int(usage.get("total_tokens", 0) or 0)
+        self.total_tokens += t
+        self.per_model[model_id] += t
+        self.per_stage[stage] += t
+
+    def total(self):
+        return self.total_tokens
+
+    def by_model(self):
+        return dict(self.per_model)
+
+    def by_stage(self):
+        return dict(self.per_stage)
+
+
+def dollars_from_usage(model_id: str, prompt_tokens: int, completion_tokens: int) -> float:
+    p = MODEL_PRICES.get(model_id, {"in": 0.0, "out": 0.0})
+    return (prompt_tokens / 1000.0) * p["in"] + (completion_tokens / 1000.0) * p["out"]


### PR DESCRIPTION
## Summary
- introduce configurable model routing and pricing
- track token usage and render cost estimates in Streamlit UI
- wrap LLM calls with router-based selection and usage logging

## Testing
- `pytest -q` *(fails: google.auth.exceptions.DefaultCredentialsError, AttributeError: 'HRMAgent' object has no attribute 'revise_plan')*

------
https://chatgpt.com/codex/tasks/task_e_6896452ff2d4832ca6a16d8fa1dd08af