### PR TITLE
Remove unsupported OpenAI parameters

### DIFF
--- a/dr_rd/utils/llm_client.py
+++ b/dr_rd/utils/llm_client.py
@@ -4,8 +4,6 @@ METER = TokenMeter()
 
 
 ALLOWED_PARAMS = {
-    "reasoning_effort",
-    "verbosity",
     "temperature",
     "response_format",
     "max_tokens",

--- a/dr_rd/utils/model_router.py
+++ b/dr_rd/utils/model_router.py
@@ -5,50 +5,36 @@ def pick_model(h: CallHints) -> dict:
     # plan
     if h.stage == "plan":
         model = DEFAULTS["PLANNER"]
-        params = {"reasoning_effort": "minimal", "verbosity": "medium"}
         if h.difficulty == "hard":
             model = "o4-mini"
-            params["reasoning_effort"] = "medium"
-        return {"model": model, "params": params}
+        return {"model": model, "params": {}}
 
     # exec (researchers/retrievers/agents)
     if h.stage == "exec":
         model = DEFAULTS["RESEARCHER"]
-        params = {"reasoning_effort": "minimal", "verbosity": "medium"}
         if h.difficulty == "hard":
             model = "gpt-5-mini"
-        return {"model": model, "params": params}
+        return {"model": model, "params": {}}
 
     # eval
     if h.stage == "eval":
-        return {
-            "model": DEFAULTS["EVALUATOR"],
-            "params": {"reasoning_effort": "minimal", "verbosity": "medium"},
-        }
+        return {"model": DEFAULTS["EVALUATOR"], "params": {}}
 
     # brain loop
     if h.stage == "brain":
         model = DEFAULTS["BRAIN_MODE_LOOP"]
-        params = {"reasoning_effort": "medium", "verbosity": "medium"}
         if h.deep_reasoning:
             model = "o3"
-            params["reasoning_effort"] = "high"
-        return {"model": model, "params": params}
+        return {"model": model, "params": {}}
 
     # synth
     if h.stage == "synth":
         model = DEFAULTS["SYNTHESIZER"]
-        params = {"reasoning_effort": "minimal", "verbosity": "medium"}
         if h.final_pass:
             model = DEFAULTS["FINAL_SYNTH"]
-            params["reasoning_effort"] = "medium"
-            params["verbosity"] = "high"
-        return {"model": model, "params": params}
+        return {"model": model, "params": {}}
 
-    return {
-        "model": DEFAULTS["RESEARCHER"],
-        "params": {"reasoning_effort": "minimal", "verbosity": "medium"},
-    }
+    return {"model": DEFAULTS["RESEARCHER"], "params": {}}
 
 
 def difficulty_from_signals(score: float, coverage: float) -> str:


### PR DESCRIPTION
## Summary
- drop reasoning_effort and verbosity from allowed API params
- simplify model routing to stop supplying unsupported parameters

## Testing
- `pytest` *(fails: DefaultCredentialsError, HRMAgent missing revise_plan)*

------
https://chatgpt.com/codex/tasks/task_e_68965aae2c7c832c93932aca2a1dcfe7