### PR TITLE
Streamline mode presets and Firestore project storage

### DIFF
--- a/app/ui_cost_meter.py
+++ b/app/ui_cost_meter.py
@@ -1,35 +1,32 @@
 import streamlit as st
 from dr_rd.config.model_routing import MODEL_PRICES
+from dr_rd.config.mode_profiles import UI_PRESETS
 
 
-def estimate_tokens_brief(
-    brief_len_tokens: int,
-    base_exec_tokens: int,
-    agent_hrm_factor: float = 1.35,
-    eval_calls: int = 3,
-    help_prob: float = 0.3,
-):
+def estimate_tokens_brief(brief_len_tokens: int, base_exec_tokens: int, help_prob: float = 0.3):
     plan_tokens = int(1.2 * brief_len_tokens)
-    exec_tokens = int(base_exec_tokens * agent_hrm_factor)
-    eval_tokens = 800 * eval_calls
+    exec_tokens = int(base_exec_tokens * 1.35)        # slight expansion during exec
+    eval_tokens = 800 * 3                              # heuristic evaluator overhead
     extra = help_prob * (int(0.7 * plan_tokens) + base_exec_tokens + eval_tokens)
     return plan_tokens + exec_tokens + eval_tokens + int(extra)
 
 
-def render_estimator(
-    default_brief_tokens: int = 2000,
-    default_exec_tokens: int = 80000,
-    price_per_1k: float = 0.005,
-    help_prob: float = 0.3,
-):
+def _rough_tokens_from_text(txt: str) -> int:
+    # ~4 chars per token heuristic
+    if not txt:
+        return 500
+    return max(500, int(len(txt) / 4))
+
+
+def render_estimator(mode: str, idea_text: str, price_per_1k: float = 0.005):
     st.subheader("Run Cost Estimate")
-    brief = st.number_input("Brief size (tokens)", value=default_brief_tokens, step=500)
-    exec_base = st.number_input(
-        "Base exec tokens (classic)", value=default_exec_tokens, step=5000
-    )
-    p = st.slider("Chance of help step", 0.0, 1.0, help_prob, 0.05)
-    est = estimate_tokens_brief(brief, exec_base, help_prob=p)
+    preset = UI_PRESETS.get(mode, UI_PRESETS["balanced"])
+    brief_tokens = _rough_tokens_from_text(idea_text)
+    base_exec = preset["estimator"]["exec_tokens"]
+    help_prob = preset["estimator"]["help_prob"]
+    est = estimate_tokens_brief(brief_tokens, base_exec, help_prob=help_prob)
     st.metric("Estimated tokens", f"{est:,}")
     st.metric("Estimated $", f"${est/1000*price_per_1k:,.4f}")
     with st.expander("Model prices"):
         st.json(MODEL_PRICES)
+

--- a/dr_rd/config/mode_profiles.py
+++ b/dr_rd/config/mode_profiles.py
@@ -14,18 +14,29 @@ PROFILES = {
         "TOT_PLANNING_ENABLED": True, "TOT_K": 3, "TOT_BEAM": 2, "TOT_MAX_DEPTH": 2,
         "EVALUATORS_ENABLED": True, "EVALUATOR_MIN_OVERALL": 0.60,
         "REFLECTION_ENABLED": True, "REFLECTION_PATIENCE": 2,
-        "RAG_ENABLED": True, "RAG_TOPK": 4, "RAG_SNIPPET_TOKENS": 120,
-        "SIM_OPTIMIZER_ENABLED": False,
+        "RAG_ENABLED": True, "RAG_TOPK": 6, "RAG_SNIPPET_TOKENS": 160,
+        "SIM_OPTIMIZER_ENABLED": True, "SIM_OPTIMIZER_STRATEGY": "random", "SIM_OPTIMIZER_MAX_EVALS": 16,
     },
-    "explore": {
+    "deep": {
         "PARALLEL_EXEC_ENABLED": True,
-        "TOT_PLANNING_ENABLED": True, "TOT_K": 5, "TOT_BEAM": 3, "TOT_MAX_DEPTH": 3,
+        "TOT_PLANNING_ENABLED": True, "TOT_K": 4, "TOT_BEAM": 3, "TOT_MAX_DEPTH": 3,
         "EVALUATORS_ENABLED": True, "EVALUATOR_MIN_OVERALL": 0.70,
         "REFLECTION_ENABLED": True, "REFLECTION_PATIENCE": 1,
         "RAG_ENABLED": True, "RAG_TOPK": 8, "RAG_SNIPPET_TOKENS": 180,
         "SIM_OPTIMIZER_ENABLED": True, "SIM_OPTIMIZER_STRATEGY": "random", "SIM_OPTIMIZER_MAX_EVALS": 30,
     },
 }
+
+# Backward compatibility: treat "explore" as "deep"
+PROFILES["explore"] = PROFILES["deep"]
+
+# UI presets baked into the three modes. The app reads these to hide knobs.
+UI_PRESETS = {
+    "fast":     {"simulate_enabled": False, "design_depth": "Low",    "refinement_rounds": 1, "rerun_sims_each_round": False, "estimator": {"exec_tokens": 20000, "help_prob": 0.15}},
+    "balanced": {"simulate_enabled": True,  "design_depth": "Medium", "refinement_rounds": 1, "rerun_sims_each_round": False, "estimator": {"exec_tokens": 45000, "help_prob": 0.30}},
+    "deep":     {"simulate_enabled": True,  "design_depth": "High",   "refinement_rounds": 3, "rerun_sims_each_round": True,  "estimator": {"exec_tokens": 90000, "help_prob": 0.50}},
+}
+
 
 def apply_profile(env_defaults: dict, mode: str, overrides: dict | None = None) -> dict:
     out = deepcopy(env_defaults)
@@ -34,3 +45,4 @@ def apply_profile(env_defaults: dict, mode: str, overrides: dict | None = None) 
     if overrides:
         out.update({k: v for k, v in overrides.items() if v is not None})
     return out
+

--- a/memory/memory_manager.py
+++ b/memory/memory_manager.py
@@ -2,7 +2,15 @@ import json
 import logging
 import os
 import uuid
+import re
 from difflib import SequenceMatcher
+
+
+def _slugify(name: str) -> str:
+    s = name.strip().lower()
+    s = re.sub(r"[^a-z0-9\s-]", "", s)
+    s = re.sub(r"\s+", "-", s)
+    return s[:64] or "project"
 
 class MemoryManager:
     def __init__(self, file_path="memory/project_memory.json"):
@@ -40,7 +48,7 @@ class MemoryManager:
                     st.secrets["gcp_service_account"]
                 )
                 db = firestore.Client(credentials=creds, project=creds.project_id)
-                doc_id = name or str(uuid.uuid4())
+                doc_id = _slugify(name or "project")
                 db.collection("dr_rd_projects").document(doc_id).set(entry)
             else:
                 logging.info(


### PR DESCRIPTION
## Summary
- Add deep mode and baked UI presets for fast, balanced, and deep profiles; expose presets to UI while keeping explore alias.
- Replace manual cost inputs with read-only estimator tied to selected run mode and idea text.
- Slugify project IDs for Firestore, persist plan/outputs/proposal, and add persistent project chat panel.
- Support optional schematic image generation in final proposals.
- Store projects in Firestore using slug IDs via memory manager.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896acdc8f80832cb83e1d00ff6f11df