### PR TITLE
Add auto-generated project visuals with GCS persistence

### DIFF
--- a/dr_rd/utils/image_visuals.py
+++ b/dr_rd/utils/image_visuals.py
@@ -1,0 +1,89 @@
+"""Utilities for generating and storing project visuals."""
+
+import base64
+import os
+import time
+from io import BytesIO
+
+from openai import OpenAI
+from PIL import Image
+
+from .storage_gcs import upload_bytes_to_gcs
+
+
+def _openai():
+    return OpenAI()
+
+
+SCHEMATIC_PROMPT = (
+    "Technical line-art schematic of the proposed prototype. "
+    "Style: clean black lines on white background, labeled blocks, arrows for signal/power flow, no photorealism. "
+    "Summarize and diagram the subsystems from this brief:\n\n{brief}"
+)
+
+RENDER_PROMPT = (
+    "Photorealistic studio render of the prototype exterior on a neutral background. "
+    "High detail, no text, perspective three-quarter view. Brief:\n\n{brief}"
+)
+
+
+def _decode_to_bytes(b64: str) -> bytes:
+    return base64.b64decode(b64)
+
+
+def _gen_image(prompt: str, fmt: str = "png", size: str = "1024x1024", quality: str = "high"):
+    client = _openai()
+    res = client.images.generate(
+        model="gpt-image-1",
+        prompt=prompt,
+        size=size,
+        output_format=("png" if fmt == "png" else "jpeg"),
+        quality=quality,
+    )
+    return res.data[0].b64_json
+
+
+def make_visuals_for_project(idea: str, plan_roles: list[str] | None, bucket: str | None) -> list[dict]:
+    """Generate schematic and render images for a project."""
+
+    brief = idea or ""
+    if plan_roles:
+        brief += "\n\nKey subsystems: " + ", ".join(plan_roles)
+
+    items = [
+        ("schematic", "png", SCHEMATIC_PROMPT.format(brief=brief)),
+        ("appearance", "jpeg", RENDER_PROMPT.format(brief=brief)),
+    ]
+    out: list[dict] = []
+    ts = str(int(time.time()))
+
+    for kind, fmt, prompt in items:
+        try:
+            b64 = _gen_image(prompt, fmt=fmt)
+            data = _decode_to_bytes(b64)
+
+            img = Image.open(BytesIO(data))
+            bio = BytesIO()
+            if fmt == "png":
+                img.save(bio, format="PNG", optimize=True)
+                content_type = "image/png"
+            else:
+                img.save(bio, format="JPEG", quality=90, optimize=True)
+                content_type = "image/jpeg"
+            data = bio.getvalue()
+
+            if bucket:
+                filename = f"{ts}-{kind}.{fmt}"
+                try:
+                    url = upload_bytes_to_gcs(data, filename, content_type, bucket)
+                except Exception:
+                    url = f"data:{content_type};base64,{base64.b64encode(data).decode()}"
+            else:
+                url = f"data:{content_type};base64,{base64.b64encode(data).decode()}"
+
+            out.append({"kind": kind, "url": url, "caption": kind.capitalize()})
+        except Exception:
+            continue
+
+    return out
+

--- a/dr_rd/utils/storage_gcs.py
+++ b/dr_rd/utils/storage_gcs.py
@@ -1,0 +1,14 @@
+from google.cloud import storage
+
+
+def _client():
+    """Return a storage client using default credentials."""
+    return storage.Client()
+
+
+def upload_bytes_to_gcs(data: bytes, filename: str, content_type: str, bucket_name: str, prefix: str = "rd_results/") -> str:
+    """Upload data to a GCS bucket and return the public URL."""
+    bkt = _client().bucket(bucket_name)
+    blob = bkt.blob(prefix + filename)
+    blob.upload_from_string(data, content_type=content_type)
+    return f"https://storage.googleapis.com/{bucket_name}/{blob.name}"

--- a/memory/memory_manager.py
+++ b/memory/memory_manager.py
@@ -28,14 +28,15 @@ class MemoryManager:
         if not isinstance(self.data, list):
             self.data = []
 
-    def store_project(self, name, idea, plan, outputs, proposal):
-        """Save a completed project (name, idea, plan, outputs, proposal) to memory (and Firestore if available)."""
+    def store_project(self, name, idea, plan, outputs, proposal, images=None):
+        """Save a completed project to memory (and Firestore if available)."""
         entry = {
             "name": name,
             "idea": idea,
             "plan": plan,
             "outputs": outputs,
             "proposal": proposal,
+            "images": images or [],
         }
 
         try:  # pragma: no cover - depends on external Firestore service

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ openai>=1.25.0
 requests>=2.32.3
 google-cloud-logging
 google-cloud-firestore
+google-cloud-storage
+Pillow
 markdown-pdf
 trimesh
 scikit-image

--- a/tests/test_app_ui.py
+++ b/tests/test_app_ui.py
@@ -57,6 +57,8 @@ def make_streamlit(text_input, buttons, state=None, raise_on_stop=False):
         form_submit_button=MagicMock(return_value=True),
         write=MagicMock(),
         sidebar=DummySidebar(),
+        image=MagicMock(),
+        caption=MagicMock(),
     )
     return st
 
@@ -138,7 +140,7 @@ def test_compile_final_proposal(monkeypatch):
     )
     patches = {
         "agents.synthesizer.compose_final_proposal": (
-            lambda idea, answers, include_simulations=False: "final"
+            lambda idea, answers, include_simulations=False: {"document": "final", "images": []}
         )
     }
     reload_app(monkeypatch, st, patches)

--- a/tests/test_synthesizer.py
+++ b/tests/test_synthesizer.py
@@ -11,8 +11,9 @@ def make_openai_response(text: str):
 
 
 @patch.dict(os.environ, {"OPENAI_API_KEY": "x"})
+@patch("agents.synthesizer.make_visuals_for_project", return_value=[{"kind": "schematic", "url": "u", "caption": "S"}])
 @patch('openai.chat.completions.create')
-def test_compose_final_proposal(mock_create):
+def test_compose_final_proposal(mock_create, _mock_vis):
     fake_response = (
         "## Executive Summary\nOverview\n\n"
         "## Bill of Materials\n|Component|Quantity|Specs|\n|---|---|---|\n|Part|1|Spec|\n\n"
@@ -26,5 +27,6 @@ def test_compose_final_proposal(mock_create):
         "AI R&D Coordinator": "ai tasks",
     }
     result = compose_final_proposal("idea", answers, include_simulations=True)
-    assert "## Executive Summary" in result
-    assert "## Step-by-Step Instructions" in result
+    assert "## Executive Summary" in result["document"]
+    assert "## Step-by-Step Instructions" in result["document"]
+    assert result["images"][0]["url"] == "u"


### PR DESCRIPTION
## Summary
- generate schematic and render images via OpenAI, upload to GCS or fall back to data URIs
- surface visuals in final proposal, persist with project data, and display gallery in UI
- store image metadata in memory and Firestore so saved projects reload visuals

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689767bfda08832c804f6bc6861e4474