### PR TITLE
Add dev test mode

### DIFF
--- a/app/ui_cost_meter.py
+++ b/app/ui_cost_meter.py
@@ -8,6 +8,22 @@ PRIORS = {
     "synth": {"gpt-5": 4000},
 }
 
+
+def render_estimator(mode: str, idea_text: str, price_per_1k: float = 0.005):
+    st.subheader("Run Cost Estimate")
+    if mode == "test":
+        st.info("**Test mode:** minimal-cost dry run to exercise all features.")
+    preset = UI_PRESETS.get(mode, UI_PRESETS["balanced"]).get("estimator", {})
+    tokens = preset.get("exec_tokens", 0)
+    est_cost = tokens / 1000 * price_per_1k
+    metric = getattr(st, "metric", None)
+    if callable(metric):
+        label = "Estimated Cost"
+        if mode == "test":
+            metric(label, f"${est_cost:.4f}", help="dev-only")
+        else:
+            metric(label, f"${est_cost:.2f}")
+
 def render_cost_summary(mode: str, plan: dict | None):
     log = st.session_state.get("usage_log", [])
     actual = 0.0

--- a/dr_rd/config/mode_profiles.py
+++ b/dr_rd/config/mode_profiles.py
@@ -27,6 +27,24 @@ PROFILES = {
     },
 }
 
+PROFILES["test"] = {
+    "PARALLEL_EXEC_ENABLED": True,
+    "TOT_PLANNING_ENABLED": True, "TOT_K": 1, "TOT_BEAM": 1, "TOT_MAX_DEPTH": 1,
+    "EVALUATORS_ENABLED": False,
+    "REFLECTION_ENABLED": False,
+    "RAG_ENABLED": False,
+    "SIM_OPTIMIZER_ENABLED": False,
+    # Optional hints used by downstream code:
+    "TEST_MODE": True,
+    "MODEL_PLANNER": "gpt-4o-mini",
+    "MODEL_EXEC": "gpt-4o-mini",
+    "MODEL_SYNTH": "gpt-4o-mini",
+    "IMAGES_SIZE": "256x256",
+    "IMAGES_QUALITY": "low",
+    "MAX_DOMAINS": 2,
+    "MAX_OUTPUT_CHARS": 900
+}
+
 # Backward compatibility: treat "explore" as "deep"
 PROFILES["explore"] = PROFILES["deep"]
 
@@ -35,6 +53,13 @@ UI_PRESETS = {
     "fast":     {"simulate_enabled": False, "design_depth": "Low",    "refinement_rounds": 1, "rerun_sims_each_round": False, "estimator": {"exec_tokens": 20000, "help_prob": 0.15}},
     "balanced": {"simulate_enabled": True,  "design_depth": "Medium", "refinement_rounds": 1, "rerun_sims_each_round": False, "estimator": {"exec_tokens": 45000, "help_prob": 0.30}},
     "deep":     {"simulate_enabled": True,  "design_depth": "High",   "refinement_rounds": 3, "rerun_sims_each_round": True,  "estimator": {"exec_tokens": 90000, "help_prob": 0.50}},
+    "test": {
+        "simulate_enabled": True,  # exercise the switch
+        "design_depth": "DevCheck",
+        "refinement_rounds": 1,
+        "rerun_sims_each_round": False,
+        "estimator": {"exec_tokens": 6000, "help_prob": 0.05},
+    },
 }
 
 

--- a/tests/test_synthesizer.py
+++ b/tests/test_synthesizer.py
@@ -30,3 +30,4 @@ def test_compose_final_proposal(mock_create, _mock_vis):
     assert "## Executive Summary" in result["document"]
     assert "## Step-by-Step Instructions" in result["document"]
     assert result["images"][0]["url"] == "u"
+    assert result["test"] is False


### PR DESCRIPTION
## Summary
- introduce lightweight "test" profile and UI preset for minimal-cost dry runs
- gate "Test (dev)" run mode behind `DEV_TEST_MODE` and flag Firestore docs
- exercise all stages cheaply: planner caps domains, outputs truncated, models downgraded, single low-quality image generation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897790d62e0832c895b1a487613aad3