### PR TITLE
feat(budget): per-mode caps with dynamic token/model control + HUD

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ DR-RD now performs a three stage pipeline:
 
 3. A synthesizer combines the findings into a unified plan.
 
-Model selections for different modes live in `config/modes.yaml`:
+Model selections and **budget caps** for different modes live in `config/modes.yaml`.
+Each mode specifies a `target_cost_usd`, default models for the planning/execution/synthesis stages,
+and limits such as `k_search` and `max_loops`.
 
-- `test` – all agents use `gpt-3.5-turbo`.
-- `balanced` – uses `gpt-4o-mini`.
-- `deep` – higher quality with per-agent overrides.
+Token pricing lives in `config/prices.yaml` (override via `PRICES_PATH`).
 
 Set the mode via `DRRD_MODE` or the Streamlit dropdown. The Streamlit interface now includes an **Agent Trace** expander showing which agent handled each task, token counts and a brief finding.

--- a/app/config_loader.py
+++ b/app/config_loader.py
@@ -1,0 +1,23 @@
+"""Helpers to load mode and pricing configuration and create a BudgetManager."""
+
+from pathlib import Path
+import os
+import yaml
+from core.budget import BudgetManager
+
+CONFIG_DIR = Path(__file__).resolve().parent.parent / "config"
+
+
+def load_mode(mode: str) -> tuple[dict, BudgetManager]:
+    modes_path = CONFIG_DIR / "modes.yaml"
+    prices_path = Path(os.getenv("PRICES_PATH", CONFIG_DIR / "prices.yaml"))
+
+    with open(modes_path) as fh:
+        modes = yaml.safe_load(fh) or {}
+    mode_cfg = modes.get(mode, modes.get("test", {}))
+
+    with open(prices_path) as fh:
+        prices = yaml.safe_load(fh) or {}
+
+    budget = BudgetManager(mode_cfg, prices)
+    return mode_cfg, budget

--- a/config/modes.yaml
+++ b/config/modes.yaml
@@ -1,12 +1,24 @@
-{
-  "test": {"Planner": "gpt-3.5-turbo", "default": "gpt-3.5-turbo"},
-  "balanced": {"Planner": "gpt-4o-mini", "default": "gpt-4o-mini"},
-  "deep": {
-    "Planner": "gpt-4o",
-    "CTO": "gpt-4o",
-    "Research": "gpt-4o-mini",
-    "Regulatory": "gpt-4o-mini",
-    "Finance": "gpt-3.5-turbo",
-    "default": "gpt-4o-mini"
-  }
-}
+test:
+  target_cost_usd: 0.50
+  models: { plan: gpt-3.5-turbo, exec: gpt-3.5-turbo, synth: gpt-3.5-turbo }
+  k_search: 2
+  max_loops: 1
+  stage_weights: { plan: 0.25, exec: 0.45, synth: 0.30 }
+fast:
+  target_cost_usd: 0.75
+  models: { plan: gpt-4o-mini, exec: gpt-4o-mini, synth: gpt-4o-mini }
+  k_search: 3
+  max_loops: 1
+  stage_weights: { plan: 0.25, exec: 0.45, synth: 0.30 }
+balanced:
+  target_cost_usd: 1.00
+  models: { plan: gpt-4o, exec: gpt-4o-mini, synth: gpt-4o }
+  k_search: 4
+  max_loops: 2
+  stage_weights: { plan: 0.25, exec: 0.45, synth: 0.30 }
+deep:
+  target_cost_usd: 2.50
+  models: { plan: gpt-4o, exec: gpt-4o, synth: gpt-5 }
+  k_search: 6
+  max_loops: 3
+  stage_weights: { plan: 0.20, exec: 0.50, synth: 0.30 }

--- a/config/prices.yaml
+++ b/config/prices.yaml
@@ -1,0 +1,5 @@
+models:
+  gpt-3.5-turbo: { in_per_1k: 0.0005, out_per_1k: 0.0015 }
+  gpt-4o-mini:   { in_per_1k: 0.003,  out_per_1k: 0.006 }
+  gpt-4o:        { in_per_1k: 0.005,  out_per_1k: 0.015 }
+  gpt-5:         { in_per_1k: 0.01,   out_per_1k: 0.03 }

--- a/core/budget.py
+++ b/core/budget.py
@@ -1,0 +1,99 @@
+import math
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+
+class BudgetExhausted(Exception):
+    """Raised when the budget cannot accommodate a request."""
+
+
+@dataclass
+class Reservation:
+    stage: str
+    model: str
+    prompt_tokens: int
+    completion_tokens: int
+    cost: float
+
+
+class BudgetManager:
+    """Track spend against a target dollar budget for a run."""
+
+    def __init__(self, mode_cfg: Dict, price_table: Dict, safety_margin: float = 0.05):
+        self.target_cost_usd: float = float(mode_cfg.get("target_cost_usd", 0.0))
+        self.price_table: Dict = price_table or {"models": {}}
+        self.stage_weights: Dict[str, float] = mode_cfg.get("stage_weights", {})
+        self.safety_margin: float = safety_margin
+        self.reset_run()
+
+    # ------------------------------------------------------------------
+    def reset_run(self) -> None:
+        self.spend: float = 0.0
+        self.stage_spend: Dict[str, float] = {s: 0.0 for s in self.stage_weights}
+
+    # ------------------------------------------------------------------
+    def _price(self, model_id: str) -> Dict[str, float]:
+        models = self.price_table.get("models", {})
+        return models.get(model_id, models.get("default", {"in_per_1k": 0.0, "out_per_1k": 0.0}))
+
+    def cost_of(self, model_id: str, prompt_tokens: int, completion_tokens: int) -> float:
+        p = self._price(model_id)
+        return (prompt_tokens / 1000.0) * p.get("in_per_1k", 0.0) + (
+            completion_tokens / 1000.0
+        ) * p.get("out_per_1k", 0.0)
+
+    # ------------------------------------------------------------------
+    def remaining_usd(self) -> float:
+        cap = self.target_cost_usd * (1.0 - self.safety_margin)
+        return max(0.0, cap - self.spend)
+
+    def _remaining_stage_usd(self, stage: str) -> float:
+        if not self.stage_weights:
+            return self.remaining_usd()
+        cap = self.target_cost_usd * self.stage_weights.get(stage, 0)
+        return max(0.0, cap - self.stage_spend.get(stage, 0.0))
+
+    def remaining_tokens(self, model_id: str, direction: str = "prompt") -> int:
+        price = self._price(model_id)
+        rate = price.get("in_per_1k" if direction == "prompt" else "out_per_1k", 0.0)
+        if rate <= 0:
+            return math.inf
+        return int(self.remaining_usd() / rate * 1000)
+
+    # ------------------------------------------------------------------
+    def can_afford(
+        self,
+        next_stage_name: str,
+        model_id: str,
+        est_prompt_tokens: int,
+        est_completion_tokens: int,
+    ) -> bool:
+        cost = self.cost_of(model_id, est_prompt_tokens, est_completion_tokens)
+        return cost <= self.remaining_usd() and cost <= self._remaining_stage_usd(next_stage_name)
+
+    def reserve(
+        self,
+        next_stage_name: str,
+        model_id: str,
+        est_prompt_tokens: int,
+        est_completion_tokens: int,
+    ) -> Reservation:
+        if not self.can_afford(next_stage_name, model_id, est_prompt_tokens, est_completion_tokens):
+            raise BudgetExhausted("Budget would be exceeded")
+        cost = self.cost_of(model_id, est_prompt_tokens, est_completion_tokens)
+        self.stage_spend[next_stage_name] = self.stage_spend.get(next_stage_name, 0.0) + cost
+        self.spend += cost
+        return Reservation(next_stage_name, model_id, est_prompt_tokens, est_completion_tokens, cost)
+
+    def consume(
+        self,
+        actual_prompt_tokens: int,
+        actual_completion_tokens: int,
+        model_id: str,
+        stage: Optional[str] = None,
+    ) -> float:
+        cost = self.cost_of(model_id, actual_prompt_tokens, actual_completion_tokens)
+        self.spend += cost
+        if stage:
+            self.stage_spend[stage] = self.stage_spend.get(stage, 0.0) + cost
+        return cost

--- a/dr_rd/utils/llm_client.py
+++ b/dr_rd/utils/llm_client.py
@@ -1,26 +1,81 @@
+"""LLM client with budget awareness."""
+
 from dr_rd.utils.token_meter import TokenMeter
-from dr_rd.config.pricing import cost_usd
+from dr_rd.utils import tokenizer
+from core.budget import BudgetManager, BudgetExhausted
 import streamlit as st
+import logging
 
 METER = TokenMeter()
+BUDGET: BudgetManager | None = None
 
-ALLOWED_PARAMS = {
-    "temperature",
-    "response_format",
-    "max_tokens",
-    "top_p",
-}
+ALLOWED_PARAMS = {"temperature", "response_format", "max_tokens", "top_p"}
 
 
-def log_usage(stage, model, pt, ct):
+def set_budget_manager(budget: BudgetManager | None) -> None:
+    """Install a :class:`BudgetManager` to enforce spending caps."""
+    global BUDGET
+    BUDGET = budget
+
+
+def log_usage(stage, model, pt, ct, cost=0.0):
     if "usage_log" not in st.session_state:
         st.session_state["usage_log"] = []
-    st.session_state["usage_log"].append({"stage": stage, "model": model, "pt": pt, "ct": ct})
+    st.session_state["usage_log"].append(
+        {"stage": stage, "model": model, "pt": pt, "ct": ct, "cost": cost}
+    )
 
 
-def llm_call(client, model_id: str, stage: str, messages: list, **params):
+def _cheaper_model(stage: str, current: str) -> str | None:
+    fallbacks = {
+        "synth": ["gpt-5", "gpt-4o", "gpt-4o-mini", "gpt-3.5-turbo"],
+        "exec": ["gpt-4o", "gpt-4o-mini", "gpt-3.5-turbo"],
+        "plan": ["gpt-4o", "gpt-4o-mini", "gpt-3.5-turbo"],
+    }
+    seq = fallbacks.get(stage, [])
+    if current not in seq:
+        return None
+    idx = seq.index(current)
+    return seq[idx + 1] if idx + 1 < len(seq) else None
+
+
+def _summarize_messages(messages: list, target: int) -> list:
+    """Truncate message contents to roughly ``target`` tokens."""
+    out = []
+    for m in messages:
+        words = m.get("content", "").split()
+        if len(words) > target:
+            words = words[:target]
+        out.append({**m, "content": " ".join(words)})
+    return out
+
+
+def llm_call(client, model_id: str, stage: str, messages: list, max_tokens_hint: int | None = None, **params):
     safe = {k: v for k, v in params.items() if k in ALLOWED_PARAMS}
-    resp = client.chat.completions.create(model=model_id, messages=messages, **safe)
+
+    chosen_model = model_id
+    est_prompt = tokenizer.estimate(messages)
+    est_completion = max(64, max_tokens_hint or safe.get("max_tokens", 0) or 64)
+
+    if BUDGET:
+        while not BUDGET.can_afford(stage, chosen_model, est_prompt, est_completion):
+            cheaper = _cheaper_model(stage, chosen_model)
+            if cheaper:
+                logging.info(f"budget fallback: {chosen_model} -> {cheaper}")
+                chosen_model = cheaper
+                continue
+            if est_prompt > 20:
+                messages = _summarize_messages(messages, max(1, int(est_prompt * 0.8)))
+                est_prompt = tokenizer.estimate(messages)
+                continue
+            est_completion = max(16, int(est_completion * 0.8))
+            if est_completion <= 16:
+                raise BudgetExhausted("Unable to fit call under budget")
+
+        safe["max_tokens"] = min(est_completion, BUDGET.remaining_tokens(chosen_model, "completion"))
+
+    resp = client.chat.completions.create(model=chosen_model, messages=messages, **safe)
+
     usage_obj = resp.choices[0].usage if hasattr(resp.choices[0], "usage") else getattr(resp, "usage", None)
     if isinstance(usage_obj, dict):
         usage = {
@@ -34,8 +89,16 @@ def llm_call(client, model_id: str, stage: str, messages: list, **params):
             "completion_tokens": getattr(usage_obj, "completion_tokens", 0),
             "total_tokens": getattr(usage_obj, "total_tokens", 0),
         }
+
+    cost = 0.0
     try:
-        METER.add_usage(model_id, stage, usage)
+        METER.add_usage(chosen_model, stage, usage)
+        if BUDGET:
+            cost = BUDGET.consume(
+                usage["prompt_tokens"], usage["completion_tokens"], chosen_model, stage=stage
+            )
     except Exception:
         pass
+
+    log_usage(stage, chosen_model, usage["prompt_tokens"], usage["completion_tokens"], cost)
     return resp

--- a/dr_rd/utils/tokenizer.py
+++ b/dr_rd/utils/tokenizer.py
@@ -1,0 +1,12 @@
+from typing import List, Dict
+
+
+def estimate(messages: List[Dict[str, str]]) -> int:
+    """Rough token estimate based on whitespace splitting."""
+    if not messages:
+        return 0
+    total = 0
+    for m in messages:
+        text = m.get("content", "")
+        total += len(str(text).split())
+    return total

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1,0 +1,28 @@
+import pytest
+from core.budget import BudgetManager
+
+
+PRICE_TABLE = {
+    "models": {
+        "gpt-4o": {"in_per_1k": 0.005, "out_per_1k": 0.015},
+        "gpt-3.5-turbo": {"in_per_1k": 0.0005, "out_per_1k": 0.0015},
+    }
+}
+MODE_CFG = {"target_cost_usd": 1.0, "stage_weights": {"plan": 1.0}}
+
+
+def test_cost_math():
+    bm = BudgetManager(MODE_CFG, PRICE_TABLE, safety_margin=0)
+    cost = bm.cost_of("gpt-4o", 1000, 1000)
+    assert cost == pytest.approx(0.02, rel=1e-6)
+
+
+def test_cap_behavior():
+    bm = BudgetManager(MODE_CFG, PRICE_TABLE, safety_margin=0)
+    assert bm.can_afford("plan", "gpt-4o", 100, 100)
+    bm.consume(800, 800, "gpt-4o", stage="plan")  # cost 0.016
+    assert pytest.approx(bm.spend, rel=1e-6) == 0.016
+    # Remaining budget 0.984 -> can afford next small call
+    assert bm.can_afford("plan", "gpt-4o", 100, 100)
+    # But large call would exceed
+    assert not bm.can_afford("plan", "gpt-4o", 50000, 50000)

--- a/tests/test_mode_caps.py
+++ b/tests/test_mode_caps.py
@@ -1,0 +1,51 @@
+import streamlit as st
+
+from core.budget import BudgetManager
+from dr_rd.utils.llm_client import llm_call, set_budget_manager
+
+
+class DummyClient:
+    class _Chat:
+        class _Completions:
+            def create(self, model, messages, **params):
+                prompt = sum(len(m.get("content", "").split()) for m in messages)
+                completion = params.get("max_tokens", 0)
+                class Choice:
+                    usage = {
+                        "prompt_tokens": prompt,
+                        "completion_tokens": completion,
+                    }
+                    message = type("msg", (), {"content": "ok"})()
+                class Resp:
+                    choices = [Choice()]
+                return Resp()
+        completions = _Completions()
+    chat = _Chat()
+
+
+PRICE_TABLE = {
+    "models": {
+        "gpt-3.5-turbo": {"in_per_1k": 0.0005, "out_per_1k": 0.0015},
+        "gpt-4o-mini": {"in_per_1k": 0.003, "out_per_1k": 0.006},
+        "gpt-4o": {"in_per_1k": 0.005, "out_per_1k": 0.015},
+        "gpt-5": {"in_per_1k": 0.01, "out_per_1k": 0.03},
+    }
+}
+MODE_CFG = {
+    "target_cost_usd": 0.01,
+    "stage_weights": {"synth": 1.0},
+}
+
+
+def test_fallback_and_summarize():
+    st.session_state.clear()
+    budget = BudgetManager(MODE_CFG, PRICE_TABLE)
+    set_budget_manager(budget)
+    messages = [{"role": "user", "content": "word " * 10000}]
+    llm_call(DummyClient(), "gpt-5", stage="synth", messages=messages, max_tokens_hint=10000)
+    log = st.session_state["usage_log"][-1]
+    # Final model should be the cheapest one
+    assert log["model"] == "gpt-3.5-turbo"
+    # Ensure tokens were summarized to fit budget
+    assert log["pt"] < 10000
+    assert budget.spend <= budget.target_cost_usd * (1 - budget.safety_margin) + 1e-6


### PR DESCRIPTION
## Summary
- add BudgetManager to enforce mode-specific dollar caps and track spend
- introduce YAML configs for modes and model pricing
- wire LLM client with budget-aware model fallback, token trimming, and logging
- include unit tests for budget math and cap handling

## Testing
- `pytest tests/test_budget.py tests/test_mode_caps.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a14318f58832c9d7af3fac6252365