### PR TITLE
Fix app builder llm_call client missing

### DIFF
--- a/orchestrators/app_builder.py
+++ b/orchestrators/app_builder.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 import json, os, re
 from typing import Dict, Tuple, List
+
+import openai
+
 from dr_rd.utils.model_router import pick_model, CallHints
 from dr_rd.utils.llm_client import llm_call
 from app_builder.spec import AppSpec, PageSpec
@@ -34,8 +37,9 @@ def plan_app_spec(idea: str, packages_extra: List[str] | None = None) -> AppSpec
         {"role": "user", "content": PROMPT.format(idea=idea)},
     ]
     response = llm_call(
+        openai,
+        sel["model"],
         stage="plan",
-        model=sel["model"],
         messages=messages,
         **sel.get("params", {})
     )
@@ -50,8 +54,9 @@ def plan_app_spec(idea: str, packages_extra: List[str] | None = None) -> AppSpec
             messages[1],
         ]
         response = llm_call(
+            openai,
+            sel["model"],
             stage="plan",
-            model=sel["model"],
             messages=retry_messages,
             **sel.get("params", {})
         )


### PR DESCRIPTION
## Summary
- pass OpenAI client to `llm_call` in `plan_app_spec`
- import `openai` in `app_builder`

## Testing
- `pytest tests/test_planner_output.py tests/test_planner_remediation.py tests/test_qa_agent_unit.py tests/test_reflection_meta_agent.py tests/test_reflection_role_tweak.py tests/test_registry.py tests/test_scorecard.py tests/test_sim_optimizer.py tests/test_sim_optimizer_logging.py tests/test_simulation.py tests/test_simulation_toggle.py tests/test_synthesizer.py tests/test_tot_planner_strategy.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689abb699528832c92fe352f96b38d52