### PR TITLE
Use slugged project names for Firestore docs

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,13 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /existingProjects/{projectId} {
+      allow read: if true;
+      allow create: if request.auth != null
+                    && request.resource.data.slug == projectId
+                    && request.resource.data.name != '';
+      allow update, delete: if request.auth != null
+                            && request.resource.data.slug == projectId;
+    }
+  }
+}

--- a/memory/memory_manager.py
+++ b/memory/memory_manager.py
@@ -40,21 +40,24 @@ class MemoryManager:
         }
 
         try:  # pragma: no cover - depends on external Firestore service
-            import streamlit as st
-            from google.cloud import firestore
-            from google.oauth2 import service_account
+            if name:
+                import streamlit as st
+                from google.cloud import firestore
+                from google.oauth2 import service_account
 
-            if "gcp_service_account" in st.secrets:
-                creds = service_account.Credentials.from_service_account_info(
-                    st.secrets["gcp_service_account"]
-                )
-                db = firestore.Client(credentials=creds, project=creds.project_id)
-                doc_id = _slugify(name or "project")
-                db.collection("dr_rd_projects").document(doc_id).set(entry)
+                if "gcp_service_account" in st.secrets:
+                    creds = service_account.Credentials.from_service_account_info(
+                        st.secrets["gcp_service_account"]
+                    )
+                    db = firestore.Client(credentials=creds, project=creds.project_id)
+                    doc_id = _slugify(name)
+                    db.collection("dr_rd_projects").document(doc_id).set(entry)
+                else:
+                    logging.info(
+                        "Firestore save skipped: missing gcp_service_account secret"
+                    )
             else:
-                logging.info(
-                    "Firestore save skipped: missing gcp_service_account secret"
-                )
+                logging.info("Firestore save skipped: project name is required")
         except Exception as e:  # pylint: disable=broad-except
             logging.info(
                 f"Firestore save skipped: invalid gcp_service_account secret ({e})"

--- a/scripts/cleanupOrphanProjects.mjs
+++ b/scripts/cleanupOrphanProjects.mjs
@@ -1,0 +1,34 @@
+import { initializeApp, applicationDefault } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+
+initializeApp({ credential: applicationDefault() });
+const db = getFirestore();
+
+function isUuidv4(id) {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(id);
+}
+
+async function main() {
+  const snap = await db.collection('existingProjects').get();
+  let count = 0;
+  for (const doc of snap.docs) {
+    const data = doc.data() || {};
+    if (
+      isUuidv4(doc.id) &&
+      (data.idea === '' || data.idea === undefined) &&
+      (data.cycle === 0 || data.cycle === undefined) &&
+      !data.name &&
+      !data.slug
+    ) {
+      await doc.ref.delete();
+      count++;
+      console.log('Deleted orphan project', doc.id);
+    }
+  }
+  console.log('Cleanup complete, removed', count, 'docs');
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/data/upsertProjectByName.ts
+++ b/src/data/upsertProjectByName.ts
@@ -1,0 +1,17 @@
+import { doc, setDoc, serverTimestamp } from 'firebase/firestore';
+import { db } from '../firebase';
+import { slugify } from '../utils/slugify';
+
+export async function upsertProjectByName(name: string, data: Record<string, any> = {}) {
+  const slug = slugify(name || '');
+  if (!slug) throw new Error('Project name is required.');
+  const ref = doc(db, 'existingProjects', slug);
+  const base = {
+    name,
+    slug,
+    updatedAt: serverTimestamp(),
+    createdAt: serverTimestamp(),
+  };
+  await setDoc(ref, { ...base, ...data }, { merge: true });
+  return { id: slug, ref };
+}

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -1,0 +1,2 @@
+export const slugify = (s: string) =>
+  s.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');


### PR DESCRIPTION
## Summary
- add slugify and upsertProjectByName helpers
- gate Firestore project creation on provided name and slug
- add Firestore rules and cleanup script for orphaned UUID docs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f6cfba608832c934e38e35964dce3