### PR TITLE
Add mode-aware routing and updated pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,13 @@ and limits such as `k_search` and `max_loops`.
 Token pricing lives in `config/prices.yaml` (override via `PRICES_PATH`).
 
 Set the mode via `DRRD_MODE` or the Streamlit dropdown. The Streamlit interface now includes an **Agent Trace** expander showing which agent handled each task, token counts and a brief finding.
+
+### Modes & Cost
+
+| Mode     | Plan model | Exec model  | Synth model | max_loops | Notes |
+|----------|------------|-------------|-------------|-----------|-------|
+| Test     | 4o         | 4o-mini     | 4o          | 1         | images disabled |
+| Balanced | 4o         | 4o-mini     | 4o          | 2         | images disabled |
+| Deep     | 4o         | 4o-mini     | gpt-5       | 1         | images enabled |
+
+Images are disabled by default for the Test and Balanced modes.

--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -10,10 +10,12 @@ Call:
     from agents.orchestrator import refine_once
     enriched = refine_once(plan, answers)
 """
+
 from typing import Dict
 import openai
 from agents.obfuscator import obfuscate_task
 from agents.router import route
+
 
 def _needs_follow_up(domain: str, task: str, answer: str) -> str | None:
     """Return a follow-up question *or* None if answer is judged complete."""
@@ -43,6 +45,7 @@ def _needs_follow_up(domain: str, task: str, answer: str) -> str | None:
     proposal = review.choices[0].message.content.strip()
     return None if proposal.upper().startswith("COMPLETE") else proposal
 
+
 def refine_once(plan: Dict[str, str], answers: Dict[str, str]) -> Dict[str, str]:
     """Return answers, optionally enriched with one follow-up per domain."""
     updated = answers.copy()
@@ -53,7 +56,7 @@ def refine_once(plan: Dict[str, str], answers: Dict[str, str]) -> Dict[str, str]
 
         # Obfuscate & re-query
         obf = obfuscate_task(domain, follow_up)
-        extra = route(domain, obf)
+        extra = route(obf)
 
         updated[domain] += "\n\n--- *(Loop-refined)* ---\n" + extra
     return updated

--- a/config/feature_flags.py
+++ b/config/feature_flags.py
@@ -18,6 +18,7 @@ SIM_OPTIMIZER_MAX_EVALS: int = int(os.getenv("SIM_OPTIMIZER_MAX_EVALS", "50"))
 RAG_ENABLED = _flag("RAG_ENABLED")
 RAG_TOPK: int = int(os.getenv("RAG_TOPK", "5"))
 RAG_SNIPPET_TOKENS: int = int(os.getenv("RAG_SNIPPET_TOKENS", "200"))
+DISABLE_IMAGES_BY_DEFAULT = {"test": True, "balanced": True, "deep": False}
 
 # Default evaluator weights and threshold. ``EVALUATOR_WEIGHTS`` can be
 # overridden via an environment variable containing a JSON object.
@@ -48,9 +49,9 @@ def get_env_defaults() -> dict:
         "TOT_BEAM": TOT_BEAM,
         "TOT_MAX_DEPTH": TOT_MAX_DEPTH,
         "EVALUATORS_ENABLED": EVALUATORS_ENABLED,
-        "EVALUATOR_MIN_OVERALL": EVALUATOR_MIN_OVERALL
-        if "EVALUATOR_MIN_OVERALL" in globals()
-        else 0.0,
+        "EVALUATOR_MIN_OVERALL": (
+            EVALUATOR_MIN_OVERALL if "EVALUATOR_MIN_OVERALL" in globals() else 0.0
+        ),
         "REFLECTION_ENABLED": REFLECTION_ENABLED,
         "REFLECTION_PATIENCE": REFLECTION_PATIENCE,
         "RAG_ENABLED": RAG_ENABLED,

--- a/config/prices.yaml
+++ b/config/prices.yaml
@@ -1,5 +1,4 @@
 models:
-  gpt-3.5-turbo: { in_per_1k: 0.0005, out_per_1k: 0.0015 }
-  gpt-4o-mini:   { in_per_1k: 0.003,  out_per_1k: 0.006 }
-  gpt-4o:        { in_per_1k: 0.005,  out_per_1k: 0.015 }
-  gpt-5:         { in_per_1k: 0.01,   out_per_1k: 0.03 }
+  gpt-4o:      { in: 0.00500, out: 0.02000 }
+  gpt-4o-mini: { in: 0.00060, out: 0.00240 }
+  gpt-5:       { in: 0.00125, out: 0.01000 }

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -2,12 +2,16 @@ from __future__ import annotations
 
 from typing import Dict, List, Tuple
 
+import streamlit as st
 from agents.planner_agent import PlannerAgent
+from agents.orchestrator import refine_once
 from core.agents.registry import build_agents, get_agent_for_task, load_mode_models
 from core.synthesizer import synthesize
 
 
-def run_pipeline(idea: str, mode: str = "test") -> Tuple[str, Dict[str, List[dict]], List[dict]]:
+def run_pipeline(
+    idea: str, mode: str = "test"
+) -> Tuple[str, Dict[str, List[dict]], List[dict]]:
     """Run planner → specialists → synthesis pipeline."""
     models = load_mode_models(mode)
     planner_model = models.get("Planner", models.get("default", "gpt-3.5-turbo"))
@@ -16,6 +20,7 @@ def run_pipeline(idea: str, mode: str = "test") -> Tuple[str, Dict[str, List[dic
     tasks = [{"title": task, "role": role} for role, task in plan.items()]
 
     agents = build_agents(mode)
+    answers: Dict[str, str] = {}
     results_by_role: Dict[str, List[dict]] = {}
     context: Dict[str, List[str]] = {"idea": idea, "summaries": []}
     trace: List[dict] = []
@@ -24,6 +29,7 @@ def run_pipeline(idea: str, mode: str = "test") -> Tuple[str, Dict[str, List[dic
         result = agent.act(t.get("title", ""), context)
         results_by_role.setdefault(agent.name, []).append(result)
         summary_line = result.get("findings", [""])[0] if result.get("findings") else ""
+        answers[agent.name] = summary_line
         context["summaries"].append(summary_line)
         usage = result.get("usage", {})
         tokens = usage.get("total_tokens") or (
@@ -31,5 +37,19 @@ def run_pipeline(idea: str, mode: str = "test") -> Tuple[str, Dict[str, List[dic
         )
         trace.append({"agent": agent.name, "tokens": tokens, "finding": summary_line})
 
-    final = synthesize(idea, results_by_role, model_id=models.get("default", planner_model))
-    return final, results_by_role, trace
+    def _answers_to_results(ans: Dict[str, str]) -> Dict[str, List[dict]]:
+        return {role: [{"findings": [txt]}] for role, txt in ans.items()}
+
+    answers_by_role = _answers_to_results(answers)
+    final = synthesize(
+        idea, answers_by_role, model_id=models.get("synth", planner_model)
+    )
+    loops = int(st.session_state.get("MODE_CFG", {}).get("max_loops", 1))
+    for _ in range(max(0, loops - 1)):
+        answers = refine_once(plan, answers)
+        answers_by_role = _answers_to_results(answers)
+        final = synthesize(
+            idea, answers_by_role, model_id=models.get("synth", planner_model)
+        )
+
+    return final, answers_by_role, trace

--- a/dr_rd/config/model_routing.py
+++ b/dr_rd/config/model_routing.py
@@ -2,26 +2,27 @@ from dataclasses import dataclass
 
 # === Fill with your tenant’s actual prices ===
 MODEL_PRICES = {
-    "gpt-5":       {"in": 1.25/1000, "out": 10/1000},
-    "gpt-5-mini":  {"in": 0.25/1000, "out":  2/1000},
-    "gpt-5-nano":  {"in": 0.05/1000, "out":  0.40/1000},
-    "o4-mini":     {"in": 0.20/1000, "out":  0.80/1000},   # TODO: update
-    "o3":          {"in": 0.60/1000, "out":  2.40/1000},   # TODO: update
-    "gpt-4o-mini": {"in": 0.15/1000, "out":  0.60/1000},
+    "gpt-5": {"in": 1.25 / 1000, "out": 10 / 1000},
+    "gpt-5-mini": {"in": 0.25 / 1000, "out": 2 / 1000},
+    "gpt-5-nano": {"in": 0.05 / 1000, "out": 0.40 / 1000},
+    "o4-mini": {"in": 0.20 / 1000, "out": 0.80 / 1000},  # TODO: update
+    "o3": {"in": 0.60 / 1000, "out": 2.40 / 1000},  # TODO: update
+    "gpt-4o-mini": {"in": 0.15 / 1000, "out": 0.60 / 1000},
 }
 
 DEFAULTS = {
-    "PLANNER":        "gpt-5-mini",
-    "RESEARCHER":     "gpt-4o-mini",
-    "EVALUATOR":      "gpt-4o-mini",
-    "SYNTHESIZER":    "gpt-5-mini",
-    "FINAL_SYNTH":    "gpt-5",
-    "BRAIN_MODE_LOOP":"o4-mini",
+    "PLANNER": "gpt-5-mini",
+    "RESEARCHER": "gpt-4o-mini",
+    "EVALUATOR": "gpt-4o-mini",
+    "SYNTHESIZER": "gpt-5-mini",
+    "FINAL_SYNTH": "gpt-4o",
+    "BRAIN_MODE_LOOP": "o4-mini",
 }
+
 
 @dataclass
 class CallHints:
-    stage: str                 # "plan"|"exec"|"eval"|"synth"|"brain"
-    difficulty: str = "normal" # "easy"|"normal"|"hard"
+    stage: str  # "plan"|"exec"|"eval"|"synth"|"brain"
+    difficulty: str = "normal"  # "easy"|"normal"|"hard"
     deep_reasoning: bool = False
     final_pass: bool = False

--- a/dr_rd/config/pricing.py
+++ b/dr_rd/config/pricing.py
@@ -1,9 +1,10 @@
 PRICES = {
-  "gpt-4o":      {"in": 0.005,  "out": 0.015},   # $ per 1K tokens (tune as needed)
-  "gpt-4o-mini": {"in": 0.00015,"out": 0.00060},
-  "gpt-5":       {"in": 0.010,  "out": 0.030}
+    "gpt-4o": {"in": 0.00500, "out": 0.02000},
+    "gpt-4o-mini": {"in": 0.00060, "out": 0.00240},
+    "gpt-5": {"in": 0.00125, "out": 0.01000},
 }
+
 
 def cost_usd(model: str, prompt_toks: int, completion_toks: int) -> float:
     p = PRICES.get(model, PRICES["gpt-4o"])
-    return (prompt_toks/1000.0)*p["in"] + (completion_toks/1000.0)*p["out"]
+    return (prompt_toks / 1000.0) * p["in"] + (completion_toks / 1000.0) * p["out"]

--- a/dr_rd/utils/model_router.py
+++ b/dr_rd/utils/model_router.py
@@ -41,6 +41,15 @@ def pick_model(h: CallHints) -> dict:
         params["max_tokens"] = min(800, params.get("max_tokens", 800))
         params["temperature"] = min(0.3, params.get("temperature", 0.3))
         sel["params"] = params
+
+    if "MODE_CFG" in st.session_state and "models" in st.session_state["MODE_CFG"]:
+        stage_map = st.session_state["MODE_CFG"].get("models", {})
+        if h.stage == "plan":
+            sel["model"] = stage_map.get("plan", sel["model"])
+        elif h.stage == "exec":
+            sel["model"] = stage_map.get("exec", sel["model"])
+        elif h.stage == "synth":
+            sel["model"] = stage_map.get("synth", sel["model"])
     return sel
 
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,5 +1,8 @@
 """Simple Streamlit interface for running DR-RD multi-agent pipeline."""
-import streamlit as st
+
+from app.config_loader import load_mode
+from dr_rd.utils.llm_client import set_budget_manager
+import uuid, streamlit as st
 from core.orchestrator import run_pipeline
 
 
@@ -7,16 +10,28 @@ def main():
     st.title("DR-RD Multi-Agent Runner")
     idea = st.text_area("Project Idea")
     mode = st.selectbox("Mode", ["test", "balanced", "deep"], index=0)
-    if st.button("Run" ):
+    if st.button("Run"):
         if not idea:
             st.warning("Please provide an idea")
         else:
+            mode_cfg, budget = load_mode(mode)
+            set_budget_manager(budget)
+            st.session_state["MODE"] = mode
+            st.session_state["MODE_CFG"] = mode_cfg
+
+            run_key = (mode, (idea or "").strip())
+            if st.session_state.get("LAST_RUN") == run_key:
+                st.stop()
+            st.session_state["LAST_RUN"] = run_key
+
             final, _, trace = run_pipeline(idea, mode=mode)
             st.subheader("Synthesis")
             st.write(final)
             with st.expander("Agent Trace"):
                 for item in trace:
-                    st.write(f"{item['agent']} ({item['tokens']} tokens): {item['finding']}")
+                    st.write(
+                        f"{item['agent']} ({item['tokens']} tokens): {item['finding']}"
+                    )
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_mode_caps.py
+++ b/tests/test_mode_caps.py
@@ -10,25 +10,30 @@ class DummyClient:
             def create(self, model, messages, **params):
                 prompt = sum(len(m.get("content", "").split()) for m in messages)
                 completion = params.get("max_tokens", 0)
+
                 class Choice:
                     usage = {
                         "prompt_tokens": prompt,
                         "completion_tokens": completion,
                     }
                     message = type("msg", (), {"content": "ok"})()
+
                 class Resp:
                     choices = [Choice()]
+
                 return Resp()
+
         completions = _Completions()
+
     chat = _Chat()
 
 
 PRICE_TABLE = {
     "models": {
         "gpt-3.5-turbo": {"in_per_1k": 0.0005, "out_per_1k": 0.0015},
-        "gpt-4o-mini": {"in_per_1k": 0.003, "out_per_1k": 0.006},
-        "gpt-4o": {"in_per_1k": 0.005, "out_per_1k": 0.015},
-        "gpt-5": {"in_per_1k": 0.01, "out_per_1k": 0.03},
+        "gpt-4o-mini": {"in_per_1k": 0.00060, "out_per_1k": 0.00240},
+        "gpt-4o": {"in_per_1k": 0.00500, "out_per_1k": 0.02000},
+        "gpt-5": {"in_per_1k": 0.00125, "out_per_1k": 0.01000},
     }
 }
 MODE_CFG = {
@@ -42,7 +47,9 @@ def test_fallback_and_summarize():
     budget = BudgetManager(MODE_CFG, PRICE_TABLE)
     set_budget_manager(budget)
     messages = [{"role": "user", "content": "word " * 10000}]
-    llm_call(DummyClient(), "gpt-5", stage="synth", messages=messages, max_tokens_hint=10000)
+    llm_call(
+        DummyClient(), "gpt-5", stage="synth", messages=messages, max_tokens_hint=10000
+    )
     log = st.session_state["usage_log"][-1]
     # Final model should be the cheapest one
     assert log["model"] == "gpt-3.5-turbo"

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -8,44 +8,46 @@ def make_openai_response(text: str):
     return Mock(choices=[mock_choice])
 
 
-@patch('agents.orchestrator.openai')
+@patch("agents.orchestrator.openai")
 def test_needs_follow_up_returns_none(mock_openai):
     mock_openai.chat.completions.create.return_value = make_openai_response("COMPLETE")
-    result = orch._needs_follow_up('Physics', 'task', 'answer')
+    result = orch._needs_follow_up("Physics", "task", "answer")
     assert result is None
 
 
-@patch('agents.orchestrator.openai')
+@patch("agents.orchestrator.openai")
 def test_needs_follow_up_returns_question(mock_openai):
-    mock_openai.chat.completions.create.return_value = make_openai_response("Please clarify")
-    result = orch._needs_follow_up('Physics', 'task', 'answer')
+    mock_openai.chat.completions.create.return_value = make_openai_response(
+        "Please clarify"
+    )
+    result = orch._needs_follow_up("Physics", "task", "answer")
     assert result == "Please clarify"
 
 
-@patch('agents.orchestrator.route')
-@patch('agents.orchestrator.obfuscate_task')
-@patch('agents.orchestrator.openai')
+@patch("agents.orchestrator.route")
+@patch("agents.orchestrator.obfuscate_task")
+@patch("agents.orchestrator.openai")
 def test_refine_once_no_follow_up(mock_openai, mock_obfuscate, mock_route):
     mock_openai.chat.completions.create.return_value = make_openai_response("COMPLETE")
-    plan = {'Physics': 'task1'}
-    answers = {'Physics': 'answer1'}
+    plan = {"Physics": "task1"}
+    answers = {"Physics": "answer1"}
     result = orch.refine_once(plan, answers)
     assert result == answers
     mock_obfuscate.assert_not_called()
     mock_route.assert_not_called()
 
 
-@patch('agents.orchestrator.route', return_value='extra info')
-@patch('agents.orchestrator.obfuscate_task', return_value='obf')
-@patch('agents.orchestrator.openai')
+@patch("agents.orchestrator.route", return_value="extra info")
+@patch("agents.orchestrator.obfuscate_task", return_value="obf")
+@patch("agents.orchestrator.openai")
 def test_refine_once_with_follow_up(mock_openai, mock_obfuscate, mock_route):
-    mock_openai.chat.completions.create.return_value = make_openai_response('More details?')
-    plan = {'Chemistry': 'task2'}
-    answers = {'Chemistry': 'answer2'}
+    mock_openai.chat.completions.create.return_value = make_openai_response(
+        "More details?"
+    )
+    plan = {"Chemistry": "task2"}
+    answers = {"Chemistry": "answer2"}
     result = orch.refine_once(plan, answers)
-    expected = {
-        'Chemistry': 'answer2\n\n--- *(Loop-refined)* ---\nextra info'
-    }
+    expected = {"Chemistry": "answer2\n\n--- *(Loop-refined)* ---\nextra info"}
     assert result == expected
-    mock_obfuscate.assert_called_once_with('Chemistry', 'More details?')
-    mock_route.assert_called_once_with('Chemistry', 'obf')
+    mock_obfuscate.assert_called_once_with("Chemistry", "More details?")
+    mock_route.assert_called_once_with("obf")


### PR DESCRIPTION
## Summary
- add budget-aware mode setup and duplicate run guard in Streamlit app
- allow mode-based model overrides and add simple refinement loop
- refresh pricing tables and disable images by default for cheaper modes

## Testing
- `black streamlit_app.py dr_rd/config/model_routing.py dr_rd/utils/model_router.py core/orchestrator.py dr_rd/config/pricing.py config/feature_flags.py dr_rd/utils/image_visuals.py agents/orchestrator.py agents/router.py tests/test_orchestrator.py tests/test_mode_caps.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f81f2ac58832cab02f9051d28c0c8