### PR TITLE
Use LLM rubric scoring for evaluators

### DIFF
--- a/dr_rd/evaluation/llm_rubric.py
+++ b/dr_rd/evaluation/llm_rubric.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+"""Helpers for scoring text against an LLM-provided rubric."""
+
+import json
+import os
+from typing import Any, Dict
+
+
+def _clip(x: float) -> float:
+    """Clip ``x`` into the inclusive range [0.0, 1.0]."""
+
+    return max(0.0, min(1.0, float(x)))
+
+
+def workspace_to_text(workspace: Any) -> str:
+    """Return textual representation of a workspace for evaluation.
+
+    The helper tries a few strategies in order:
+
+    1. ``workspace.joined_results_text()`` if callable.
+    2. Join ``workspace.results`` with double newlines.
+    3. Fallback to ``str(workspace)``.
+    """
+
+    if hasattr(workspace, "joined_results_text") and callable(
+        getattr(workspace, "joined_results_text")
+    ):
+        try:
+            return str(workspace.joined_results_text())
+        except Exception:
+            pass
+
+    if hasattr(workspace, "results"):
+        try:
+            iterable = getattr(workspace, "results")
+            return "\n\n".join(map(str, iterable))
+        except Exception:
+            pass
+
+    return str(workspace)
+
+
+def score_with_rubric(text: str, rubric: str) -> float:
+    """Score ``text`` against ``rubric`` using the configured LLM.
+
+    The function attempts to obtain a JSON response like ``{"score": 0.5, ...}``
+    from either an internal ``dr_rd.llm`` client or the OpenAI API. Any errors
+    or malformed responses result in a score of ``0.0``. The final score is
+    clipped to the range [0.0, 1.0].
+    """
+
+    prompt = (
+        "You are an impartial evaluator.\n"
+        "Return STRICT JSON with keys: score (float 0..1) and rationale (string).\n"
+        "Do not include any extra commentary.\n\n"
+        f"RUBRIC:\n{rubric}\n\n"
+        "TEXT TO EVALUATE:\n"
+        f"{text}\n"
+    )
+
+    # Prefer an internal helper if available.
+    try:  # pragma: no cover - exercised via monkeypatch in tests
+        from dr_rd.llm import chat_json  # type: ignore
+
+        try:
+            resp = chat_json(prompt)
+            score = float(resp.get("score", 0.0))
+            return _clip(score)
+        except Exception:
+            pass
+    except Exception:
+        pass
+
+    # Fallback to OpenAI; tests monkeypatch this function so no network call.
+    try:  # pragma: no cover - network not exercised in tests
+        import openai  # type: ignore
+
+        model = (
+            os.getenv("DRRD_LLM_MODEL")
+            or os.getenv("OPENAI_MODEL")
+            or "gpt-4o-mini"
+        )
+
+        try:
+            client = openai.OpenAI()  # type: ignore[attr-defined]
+            completion = client.chat.completions.create(
+                model=model,
+                messages=[
+                    {"role": "system", "content": "Return only valid JSON."},
+                    {"role": "user", "content": prompt},
+                ],
+                response_format={"type": "json_object"},
+                temperature=0,
+            )
+            content = completion.choices[0].message.content  # type: ignore[index]
+        except Exception:
+            content = openai.ChatCompletion.create(  # type: ignore[attr-defined]
+                model=model,
+                messages=[
+                    {"role": "system", "content": "Return only valid JSON."},
+                    {"role": "user", "content": prompt},
+                ],
+                temperature=0,
+            )["choices"][0]["message"]["content"]
+
+        data: Dict[str, Any] = json.loads(content or "{}")
+        score = float(data.get("score", 0.0))
+        return _clip(score)
+    except Exception:
+        return 0.0
+
+
+__all__ = ["score_with_rubric", "workspace_to_text"]
+

--- a/dr_rd/evaluators/compliance.py
+++ b/dr_rd/evaluators/compliance.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
-from typing import Any, Dict
-
+import dr_rd.evaluation.llm_rubric as lr
 from dr_rd.extensions.abcs import BaseEvaluator
 
 
-class ComplianceEvaluator(BaseEvaluator):
-    """Simple compliance evaluator."""
+COMPLIANCE_RUBRIC = (
+    "Assess privacy posture, adherence to platform Terms of Service, and regulatory fit "
+    "(e.g., GDPR/CCPA/COPPA as relevant). Return 0–1 where 0 = non‑compliant, 1 = strongly compliant."
+)
 
-    def evaluate(self, state: Dict[str, Any]) -> Dict[str, Any]:
-        text = " ".join(str(state.get(k, "")) for k in ["results", "tasks"])
-        if "compliance" in text.lower() or "regulation" in text.lower():
-            return {"score": 0.8, "notes": ["compliance considered"]}
-        return {"score": 0.5, "notes": ["compliance not addressed"]}
+
+class ComplianceEvaluator(BaseEvaluator):
+    """Compliance evaluator backed by an LLM rubric."""
+
+    def evaluate(self, workspace) -> float:  # type: ignore[override]
+        text = lr.workspace_to_text(workspace)
+        return lr.score_with_rubric(text, COMPLIANCE_RUBRIC)

--- a/dr_rd/evaluators/feasibility.py
+++ b/dr_rd/evaluators/feasibility.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
-from typing import Any, Dict
-
+import dr_rd.evaluation.llm_rubric as lr
 from dr_rd.extensions.abcs import BaseEvaluator
 
 
-class FeasibilityEvaluator(BaseEvaluator):
-    """Crude feasibility evaluator."""
+FEASIBILITY_RUBRIC = (
+    "Assess realism of resources, time, dependencies, and risk mitigations. "
+    "Return a single 0–1 score where 0 = not feasible, 1 = highly feasible."
+)
 
-    def evaluate(self, state: Dict[str, Any]) -> Dict[str, Any]:
-        text = " ".join(str(state.get(k, "")) for k in ["results", "tasks"])
-        if "feasible" in text.lower():
-            return {"score": 0.8, "notes": ["feasibility addressed"]}
-        return {"score": 0.5, "notes": ["feasibility unclear"]}
+
+class FeasibilityEvaluator(BaseEvaluator):
+    """Feasibility evaluator backed by an LLM rubric."""
+
+    def evaluate(self, workspace) -> float:  # type: ignore[override]
+        text = lr.workspace_to_text(workspace)
+        return lr.score_with_rubric(text, FEASIBILITY_RUBRIC)

--- a/dr_rd/evaluators/novelty.py
+++ b/dr_rd/evaluators/novelty.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
-from typing import Any, Dict
-
+import dr_rd.evaluation.llm_rubric as lr
 from dr_rd.extensions.abcs import BaseEvaluator
 
 
-class NoveltyEvaluator(BaseEvaluator):
-    """Basic novelty evaluator."""
+NOVELTY_RUBRIC = (
+    "Assess originality vs. standard solutions for this domain. "
+    "Return a single 0–1 score where 0 = derivative/common, 1 = highly novel."
+)
 
-    def evaluate(self, state: Dict[str, Any]) -> Dict[str, Any]:
-        text = " ".join(str(state.get(k, "")) for k in ["results", "tasks"])
-        if any(w in text.lower() for w in ["novel", "innovative", "new"]):
-            return {"score": 0.8, "notes": ["novelty mentioned"]}
-        return {"score": 0.5, "notes": ["novelty not demonstrated"]}
+
+class NoveltyEvaluator(BaseEvaluator):
+    """Novelty evaluator backed by an LLM rubric."""
+
+    def evaluate(self, workspace) -> float:  # type: ignore[override]
+        text = lr.workspace_to_text(workspace)
+        return lr.score_with_rubric(text, NOVELTY_RUBRIC)

--- a/tests/test_evaluators_llm_rubric.py
+++ b/tests/test_evaluators_llm_rubric.py
@@ -1,0 +1,65 @@
+import math
+
+import pytest
+
+import dr_rd.evaluation.llm_rubric as lr
+from dr_rd.evaluators.feasibility import FeasibilityEvaluator
+from dr_rd.evaluators.novelty import NoveltyEvaluator
+from dr_rd.evaluators.compliance import ComplianceEvaluator
+from dr_rd.evaluators.cost import CostEvaluator
+
+
+class FakeWorkspace:
+    def __init__(self, text: str):
+        self._text = text
+
+    def joined_results_text(self) -> str:
+        return self._text
+
+    @property
+    def results(self):
+        return [self._text]
+
+
+def test_feasibility_uses_llm_rubric(monkeypatch):
+    monkeypatch.setattr(lr, "score_with_rubric", lambda text, rubric: 0.33)
+    s = FeasibilityEvaluator().evaluate(FakeWorkspace("feasibility text"))
+    assert isinstance(s, float)
+    assert math.isclose(s, 0.33, rel_tol=1e-9)
+
+
+def test_novelty_uses_llm_rubric(monkeypatch):
+    monkeypatch.setattr(lr, "score_with_rubric", lambda text, rubric: 0.91)
+    s = NoveltyEvaluator().evaluate(FakeWorkspace("novelty text"))
+    assert math.isclose(s, 0.91, rel_tol=1e-9)
+
+
+def test_compliance_uses_llm_rubric(monkeypatch):
+    monkeypatch.setattr(lr, "score_with_rubric", lambda text, rubric: 0.72)
+    s = ComplianceEvaluator().evaluate(FakeWorkspace("compliance text"))
+    assert math.isclose(s, 0.72, rel_tol=1e-9)
+
+
+def test_cost_numeric_uses_one_minus_cost(monkeypatch):
+    def _should_not_be_called(*args, **kwargs):
+        raise AssertionError("LLM was called but should not be for numeric cost.")
+
+    monkeypatch.setattr(lr, "score_with_rubric", _should_not_be_called)
+    s = CostEvaluator().evaluate(FakeWorkspace("Estimated cost: 0.2"))
+    assert math.isclose(s, 0.8, rel_tol=1e-9)
+
+
+def test_cost_percentage_is_normalized(monkeypatch):
+    def _should_not_be_called(*args, **kwargs):
+        raise AssertionError("LLM was called but should not be for percentage cost.")
+
+    monkeypatch.setattr(lr, "score_with_rubric", _should_not_be_called)
+    s = CostEvaluator().evaluate(FakeWorkspace("Projected budget: 25% of allocation"))
+    assert math.isclose(s, 0.75, rel_tol=1e-9)
+
+
+def test_cost_tbd_falls_back_to_llm(monkeypatch):
+    monkeypatch.setattr(lr, "score_with_rubric", lambda text, rubric: 0.4)
+    s = CostEvaluator().evaluate(FakeWorkspace("Costs TBD; scope under refinement."))
+    assert math.isclose(s, 0.4, rel_tol=1e-9)
+


### PR DESCRIPTION
## Summary
- add `llm_rubric` helper to call configured LLM and safely parse rubric scores
- route feasibility, novelty, compliance and cost evaluators through rubric scoring
- cost evaluator handles normalized numeric costs before falling back to LLM
- cover LLM rubric behaviour with deterministic tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fa1260810832ca00253ac3549438e