### PR TITLE
Unify entry points: Lite + Pro profiles under `app.py`, budget caps in both

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,14 @@ Images are disabled by default for the Test and Balanced modes.
 3) `streamlit run app.py`
 4) (Optional) Build a RAG index: `python scripts/build_faiss_index.py`
    Then enable `RAG_ENABLED=true` in your environment.
+
+### Run profiles
+
+- **Lite**: deterministic single-pass pipeline with a hard budget cap. Good for demos and CI smoke tests.
+- **Pro**: full HRM engine with planning, evaluators, optional RAG, simulations, and persistence.
+
+Select the profile in the sidebar. To default to Lite when launching programmatically:
+
+```bash
+DRRD_DEFAULT_PROFILE=Lite streamlit run app.py
+```

--- a/app/lite_runner.py
+++ b/app/lite_runner.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+import yaml
+import streamlit as st
+
+from app.config_loader import load_mode
+from dr_rd.utils.llm_client import set_budget_manager
+from core.orchestrator import run_pipeline
+
+
+def _available_modes() -> list[str]:
+    # Read from the same config used by load_mode()
+    try:
+        from app.config_loader import CONFIG_DIR  # type: ignore
+        with open(Path(CONFIG_DIR) / "modes.yaml", "r") as fh:
+            d = yaml.safe_load(fh) or {}
+        # Preserve a stable ordering
+        order = ["test", "fast", "balanced", "deep"]
+        return [m for m in order if m in d] or list(d.keys())
+    except Exception:
+        return ["test", "balanced", "deep"]
+
+def render_lite() -> None:
+    st.header("DR‑RD Lite")
+
+    idea = st.text_area("Project Idea", key="lite_idea")
+    modes = _available_modes()
+    idx = max(0, modes.index("test") if "test" in modes else 0)
+    mode = st.selectbox("Mode", modes, index=idx, key="lite_mode")
+
+    if st.button("Run", key="lite_run"):
+        if not idea:
+            st.warning("Please provide an idea")
+            st.stop()
+
+        # Hard spend cap via BudgetManager
+        mode_cfg, budget = load_mode(mode)
+        set_budget_manager(budget)
+
+        # Prevent accidental duplicate execution on repeated clicks
+        run_key = (mode, (idea or "").strip())
+        if st.session_state.get("LITE_LAST_RUN") == run_key:
+            st.stop()
+        st.session_state["LITE_LAST_RUN"] = run_key
+
+        final, _, trace = run_pipeline(idea, mode=mode)
+
+        st.subheader("Synthesis")
+        st.write(final)
+
+        with st.expander("Agent Trace", expanded=False):
+            for item in (trace or []):
+                agent = item.get("agent", "?")
+                tokens = item.get("tokens", "?")
+                finding = item.get("finding", "")
+                st.write(f"{agent} ({tokens} tokens): {finding}")

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,38 +1,7 @@
-"""Simple Streamlit interface for running DR-RD multi-agent pipeline."""
-
-from app.config_loader import load_mode
-from dr_rd.utils.llm_client import set_budget_manager
-import uuid, streamlit as st
-from core.orchestrator import run_pipeline
-
-
-def main():
-    st.title("DR-RD Multi-Agent Runner")
-    idea = st.text_area("Project Idea")
-    mode = st.selectbox("Mode", ["test", "balanced", "deep"], index=0)
-    if st.button("Run"):
-        if not idea:
-            st.warning("Please provide an idea")
-        else:
-            mode_cfg, budget = load_mode(mode)
-            set_budget_manager(budget)
-            st.session_state["MODE"] = mode
-            st.session_state["MODE_CFG"] = mode_cfg
-
-            run_key = (mode, (idea or "").strip())
-            if st.session_state.get("LAST_RUN") == run_key:
-                st.stop()
-            st.session_state["LAST_RUN"] = run_key
-
-            final, _, trace = run_pipeline(idea, mode=mode)
-            st.subheader("Synthesis")
-            st.write(final)
-            with st.expander("Agent Trace"):
-                for item in trace:
-                    st.write(
-                        f"{item['agent']} ({item['tokens']} tokens): {item['finding']}"
-                    )
-
+"""Deprecated stub: use `streamlit run app.py`. This routes to Lite profile."""
+import os
+from app import main
 
 if __name__ == "__main__":  # pragma: no cover
+    os.environ.setdefault("DRRD_DEFAULT_PROFILE", "Lite")
     main()

--- a/tests/test_lite_runner_smoke.py
+++ b/tests/test_lite_runner_smoke.py
@@ -1,0 +1,3 @@
+def test_lite_import():
+    import app.lite_runner as lr
+    assert callable(lr.render_lite)


### PR DESCRIPTION
## Summary
- add Lite pipeline runner and profile selector
- enforce budget caps for Pro runs, route Lite for stub entry
- document profiles, add smoke test

## Testing
- `pytest tests/test_app_ui.py::test_empty_idea_shows_info tests/test_app_ui.py::test_generate_plan_updates_state tests/test_app_ui.py::test_run_domain_experts tests/test_app_ui.py::test_compile_final_proposal tests/test_lite_runner_smoke.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0f5e61cfc832ca3ebd011e0f946c3