### PR TITLE
Add PyYAML dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pytest-timeout>=2.3.1
 pymupdf>=1.24.0
 numpy>=1.26
 faiss-cpu>=1.7.4; platform_system != "Windows"
+PyYAML>=6.0


### PR DESCRIPTION
## Summary
- include PyYAML in Python requirements to provide `yaml` module

## Testing
- `pytest tests/test_pdf_generator.py tests/test_price_yaml_schema.py -q`
- `pytest -q` *(partial run; interrupted after ~73s, 50 tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a104e3b778832ca52db9c8d4e295a8