### PR TITLE
feat: add marketing and IP analysts

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ streamlit run app.py
 DR-RD now performs a three stage pipeline:
 
 1. **Planner** decomposes your idea into specialist tasks.
-2. Each task is routed to a matching agent (CTO, Research, Regulatory or Finance) which replies using a JSON contract:
+2. Each task is routed to a matching agent (CTO, Research, Regulatory, Finance, Marketing Analyst or IP Analyst) which replies using a JSON contract:
 
 ```json
-{"role": "...", "task": "...", "findings": [], "risks": [], "next_steps": []}
+{"role": "...", "task": "...", "findings": [], "risks": [], "next_steps": [], "sources": []}
 ```
 
 3. A synthesizer combines the findings into a unified plan.
@@ -56,7 +56,7 @@ Images are disabled by default for the Test and Balanced modes.
 2) Copy `.env.example` to `.env` and set `OPENAI_API_KEY`.
 3) `streamlit run app.py`
 4) (Optional) Build a RAG index: `python scripts/build_faiss_index.py`
-   Then enable `RAG_ENABLED=true` in your environment.
+   Then enable `RAG_ENABLED=true` in your environment so agents like Marketing and IP can cite supporting snippets.
 
 ### Run profiles
 

--- a/agents/ip_analyst_agent.py
+++ b/agents/ip_analyst_agent.py
@@ -1,0 +1,105 @@
+from agents.base_agent import BaseAgent
+from config.feature_flags import RAG_ENABLED, RAG_TOPK, RAG_SNIPPET_TOKENS
+from dr_rd.utils.model_router import pick_model, CallHints
+from dr_rd.utils.llm_client import llm_call, log_usage
+from typing import Optional, Dict, Any, List, Tuple
+import openai
+import json
+import re
+
+try:
+    from dr_rd.knowledge.retriever import Retriever  # type: ignore
+    from dr_rd.knowledge.faiss_store import build_default_retriever  # type: ignore
+except Exception:  # pragma: no cover
+    Retriever = None  # type: ignore
+    build_default_retriever = lambda: None  # type: ignore
+
+
+class IPAnalystAgent(BaseAgent):
+    """Agent for prior art scans, novelty checks and IP strategy."""
+
+    def __init__(self, model: str, retriever: Optional[Retriever] = None):
+        super().__init__(
+            name="IP Analyst",
+            model=model,
+            system_message=(
+                "You are an intellectual-property analyst skilled at prior-art searches, "
+                "novelty assessment, patentability, and freedom-to-operate risk."
+            ),
+            user_prompt_template=(
+                "Project Idea: {idea}\nAs the IP Analyst, your task is {task}. "
+                "Provide an IP analysis in Markdown. "
+                "End with a JSON summary using keys: role, task, findings, risks, next_steps, sources."
+            ),
+            retriever=retriever,
+        )
+
+    def act(self, idea: str, task: str, context: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        prompt = self.user_prompt_template.format(idea=idea, task=task)
+        sources: List[str] = []
+        if RAG_ENABLED and self.retriever:
+            try:
+                hits: List[Tuple[str, str]] = self.retriever.query(f"{idea}\n{task}", RAG_TOPK)
+                if hits:
+                    bundle_lines = []
+                    for i, (text, src) in enumerate(hits, 1):
+                        raw = text.replace("\n", " ")
+                        snippet = self._truncate_tokens(raw, RAG_SNIPPET_TOKENS)
+                        bundle_lines.append(f"[{i}] {snippet} ({src})")
+                        sources.append(src)
+                    bundle = "\n".join(bundle_lines)
+                    prompt += "\n\nResearch Bundle:\n" + bundle
+            except Exception:
+                pass
+        
+        sel = pick_model(CallHints(stage="exec"))
+        response = llm_call(
+            openai,
+            sel["model"],
+            stage="exec",
+            messages=[
+                {"role": "system", "content": self.system_message},
+                {"role": "user", "content": prompt},
+            ],
+            **sel["params"],
+        )
+        usage = response.choices[0].usage if hasattr(response.choices[0], "usage") else getattr(response, "usage", None)
+        if usage:
+            log_usage(
+                stage="exec",
+                model=sel["model"],
+                pt=getattr(usage, "prompt_tokens", 0),
+                ct=getattr(usage, "completion_tokens", 0),
+            )
+        raw = response.choices[0].message.content.strip()
+        data: Dict[str, Any]
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            match = re.search(r"\{[\s\S]*\}", raw)
+            if match:
+                try:
+                    data = json.loads(match.group(0))
+                except Exception:
+                    data = {
+                        "role": self.name,
+                        "task": task,
+                        "findings": [raw],
+                        "risks": [],
+                        "next_steps": [],
+                    }
+            else:
+                data = {
+                    "role": self.name,
+                    "task": task,
+                    "findings": [raw],
+                    "risks": [],
+                    "next_steps": [],
+                }
+        data.setdefault("role", self.name)
+        data.setdefault("task", task)
+        data.setdefault("findings", [])
+        data.setdefault("risks", [])
+        data.setdefault("next_steps", [])
+        data.setdefault("sources", sources)
+        return data

--- a/agents/marketing_agent.py
+++ b/agents/marketing_agent.py
@@ -1,0 +1,106 @@
+from agents.base_agent import BaseAgent
+from config.feature_flags import RAG_ENABLED, RAG_TOPK, RAG_SNIPPET_TOKENS
+from dr_rd.utils.model_router import pick_model, CallHints
+from dr_rd.utils.llm_client import llm_call, log_usage
+from typing import Optional, Dict, Any, List, Tuple
+import openai
+import json
+import re
+
+try:
+    from dr_rd.knowledge.retriever import Retriever  # type: ignore
+    from dr_rd.knowledge.faiss_store import build_default_retriever  # type: ignore
+except Exception:  # pragma: no cover
+    Retriever = None  # type: ignore
+    build_default_retriever = lambda: None  # type: ignore
+
+
+class MarketingAgent(BaseAgent):
+    """Agent performing market analysis, segmentation and competition review."""
+
+    def __init__(self, model: str, retriever: Optional[Retriever] = None):
+        super().__init__(
+            name="Marketing Analyst",
+            model=model,
+            system_message=(
+                "You are a marketing analyst with expertise in market research, "
+                "customer segmentation, competitive landscapes and go-to-market strategies."
+            ),
+            user_prompt_template=(
+                "Project Idea: {idea}\nAs the Marketing Analyst, your task is {task}. "
+                "Provide a marketing overview in Markdown. "
+                "End with a JSON summary using keys: role, task, findings, risks, next_steps, sources."
+            ),
+            retriever=retriever,
+        )
+
+    def act(self, idea: str, task: str, context: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        prompt = self.user_prompt_template.format(idea=idea, task=task)
+        sources: List[str] = []
+        # Inject RAG snippets
+        if RAG_ENABLED and self.retriever:
+            try:
+                hits: List[Tuple[str, str]] = self.retriever.query(f"{idea}\n{task}", RAG_TOPK)
+                if hits:
+                    bundle_lines = []
+                    for i, (text, src) in enumerate(hits, 1):
+                        raw = text.replace("\n", " ")
+                        snippet = self._truncate_tokens(raw, RAG_SNIPPET_TOKENS)
+                        bundle_lines.append(f"[{i}] {snippet} ({src})")
+                        sources.append(src)
+                    bundle = "\n".join(bundle_lines)
+                    prompt += "\n\nResearch Bundle:\n" + bundle
+            except Exception:
+                pass
+        
+        sel = pick_model(CallHints(stage="exec"))
+        response = llm_call(
+            openai,
+            sel["model"],
+            stage="exec",
+            messages=[
+                {"role": "system", "content": self.system_message},
+                {"role": "user", "content": prompt},
+            ],
+            **sel["params"],
+        )
+        usage = response.choices[0].usage if hasattr(response.choices[0], "usage") else getattr(response, "usage", None)
+        if usage:
+            log_usage(
+                stage="exec",
+                model=sel["model"],
+                pt=getattr(usage, "prompt_tokens", 0),
+                ct=getattr(usage, "completion_tokens", 0),
+            )
+        raw = response.choices[0].message.content.strip()
+        data: Dict[str, Any]
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            match = re.search(r"\{[\s\S]*\}", raw)
+            if match:
+                try:
+                    data = json.loads(match.group(0))
+                except Exception:
+                    data = {
+                        "role": self.name,
+                        "task": task,
+                        "findings": [raw],
+                        "risks": [],
+                        "next_steps": [],
+                    }
+            else:
+                data = {
+                    "role": self.name,
+                    "task": task,
+                    "findings": [raw],
+                    "risks": [],
+                    "next_steps": [],
+                }
+        data.setdefault("role", self.name)
+        data.setdefault("task", task)
+        data.setdefault("findings", [])
+        data.setdefault("risks", [])
+        data.setdefault("next_steps", [])
+        data.setdefault("sources", sources)
+        return data

--- a/agents/planner_agent.py
+++ b/agents/planner_agent.py
@@ -46,7 +46,9 @@ class PlannerAgent(BaseAgent):
                 "  - Prototyping & Test Lab Manager\n"
                 "  - Project Manager / Principal Investigator\n"
                 "  - Product Manager / Translational Lead\n"
-                "  - AI R&D Coordinator\n\n"
+                "  - AI R&D Coordinator\n"
+                "  - Marketing Analyst\n"
+                "  - IP Analyst\n\n"
                 "Only include roles that are relevant, and do not include any roles outside this list. "
                 "Use each role name exactly as given above as JSON keys, and provide a brief task description for each selected role."
             ),

--- a/config/agent_models.py
+++ b/config/agent_models.py
@@ -21,5 +21,7 @@ AGENT_MODEL_MAP = {
     "Project Manager / Principal Investigator": "gpt-4o-mini",
     "Product Manager / Translational Lead": "gpt-4o-mini",
     "AI R&D Coordinator": "gpt-4o-mini",
-    "Synthesizer": "gpt-4o"
+    "Synthesizer": "gpt-4o",
+    "Marketing": "gpt-4o-mini",
+    "IP": "gpt-4o-mini",
 }

--- a/core/agents/base_agent.py
+++ b/core/agents/base_agent.py
@@ -18,23 +18,23 @@ class Agent(ABC):
     model_id: str
     system_prompt: str = ""
 
-    def _call_openai(self, task: str, context: str) -> str:
+    def _call_openai(self, idea: str, task: str, context: str) -> str:
         messages = [
             {"role": "system", "content": self.system_prompt or f"You are {self.role}."},
             {
                 "role": "user",
                 "content": (
-                    f"Task: {task}\nContext: {context}\n"
-                    "Respond with JSON using keys: role, task, findings, risks, next_steps."
+                    f"Project Idea: {idea}\nTask: {task}\nContext: {context}\n"
+                    "Provide your analysis in Markdown followed by a JSON block with keys: role, task, findings, risks, next_steps, sources."
                 ),
             },
         ]
         resp = llm_call(openai, self.model_id, stage="exec", messages=messages)
         return resp.choices[0].message.content
 
-    def act(self, task: str, context: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def act(self, idea: str, task: str, context: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Execute the agent for a given task and shared context."""
-        raw = self._call_openai(task, json.dumps(context or {}))
+        raw = self._call_openai(idea, task, json.dumps(context or {}))
         try:
             data = json.loads(raw)
         except json.JSONDecodeError:
@@ -44,6 +44,7 @@ class Agent(ABC):
                 "findings": [raw],
                 "risks": [],
                 "next_steps": [],
+                "sources": [],
             }
         # Attach usage from session log if available
         usage_log = getattr(__import__("streamlit"), "session_state", {}).get("usage_log", [])

--- a/core/agents/registry.py
+++ b/core/agents/registry.py
@@ -7,6 +7,8 @@ from .cto_agent import CTOAgent
 from .scientist_agent import ResearchScientistAgent
 from .regulatory_agent import RegulatoryAgent
 from .finance_agent import FinanceAgent
+from agents.marketing_agent import MarketingAgent
+from agents.ip_analyst_agent import IPAnalystAgent
 from config.agent_models import AGENT_MODEL_MAP
 
 
@@ -29,6 +31,8 @@ def build_agents(mode: str | None = None) -> Dict[str, Agent]:
         "Research": ResearchScientistAgent(model_id=AGENT_MODEL_MAP.get("Research", default)),
         "Regulatory": RegulatoryAgent(model_id=AGENT_MODEL_MAP.get("Regulatory", default)),
         "Finance": FinanceAgent(model_id=AGENT_MODEL_MAP.get("Finance", default)),
+        "Marketing Analyst": MarketingAgent(model=AGENT_MODEL_MAP.get("Marketing", default)),
+        "IP Analyst": IPAnalystAgent(model=AGENT_MODEL_MAP.get("IP", default)),
     }
 
 
@@ -38,7 +42,48 @@ _KEYWORDS = {
     "CTO": ["architecture", "risk", "scalability"],
     "Research": ["materials", "physics", "prior art", "literature"],
     "Regulatory": ["compliance", "fda", "iso", "fcc"],
-    "Finance": ["cost", "bom", "budget"],
+    "Finance": [
+        "cost",
+        "bom",
+        "budget",
+        "bill of materials",
+        "unit economics",
+        "capex",
+        "opex",
+        "payback",
+        "breakeven",
+        "roi",
+    ],
+    "Marketing Analyst": [
+        "market",
+        "customer",
+        "user",
+        "segment",
+        "tam",
+        "sam",
+        "som",
+        "gtm",
+        "competition",
+        "competitor",
+        "competitive",
+        "pricing",
+        "price",
+        "revenue",
+        "sales",
+        "adoption",
+        "roi",
+    ],
+    "IP Analyst": [
+        "patent",
+        "prior art",
+        "intellectual property",
+        "claims",
+        "novelty",
+        "patentability",
+        "fto",
+        "freedom to operate",
+        "ip strategy",
+    ],
 }
 
 

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -26,7 +26,7 @@ def run_pipeline(
     trace: List[dict] = []
     for t in tasks:
         agent = get_agent_for_task(t.get("title", t.get("role", "")), agents)
-        result = agent.act(t.get("title", ""), context)
+        result = agent.act(idea, t.get("title", ""), context)
         results_by_role.setdefault(agent.name, []).append(result)
         summary_line = result.get("findings", [""])[0] if result.get("findings") else ""
         answers[agent.name] = summary_line

--- a/tests/test_agents_contract.py
+++ b/tests/test_agents_contract.py
@@ -5,10 +5,10 @@ def test_agent_output_contract(monkeypatch):
     agent = ResearchScientistAgent(model_id="gpt-3.5-turbo")
     sample = (
         '{"role": "Research", "task": "t", '
-        '"findings": ["f"], "risks": ["r"], "next_steps": ["n"]}'
+        '"findings": ["f"], "risks": ["r"], "next_steps": ["n"], "sources": []}'
     )
-    monkeypatch.setattr(agent, "_call_openai", lambda task, context: sample)
-    result = agent.act("t")
+    monkeypatch.setattr(agent, "_call_openai", lambda idea, task, context: sample)
+    result = agent.act("idea", "t")
     assert set(result.keys()) >= {
         "role",
         "task",

--- a/tests/test_business_agents.py
+++ b/tests/test_business_agents.py
@@ -1,0 +1,71 @@
+import json
+from unittest.mock import Mock, patch
+import json
+from unittest.mock import Mock, patch
+
+from agents.marketing_agent import MarketingAgent
+from agents.ip_analyst_agent import IPAnalystAgent
+from core.agents import registry
+
+
+def _fake_response(payload: dict):
+    choice = Mock()
+    choice.message = Mock(content=json.dumps(payload))
+    choice.usage = Mock(prompt_tokens=1, completion_tokens=1)
+    return Mock(choices=[choice])
+
+
+@patch("agents.marketing_agent.llm_call")
+def test_marketing_agent_contract(mock_call):
+    mock_call.return_value = _fake_response(
+        {
+            "role": "Marketing Analyst",
+            "task": "Assess market",
+            "findings": [],
+            "risks": [],
+            "next_steps": [],
+            "sources": [],
+        }
+    )
+    agent = MarketingAgent("gpt-4o-mini")
+    result = agent.act("idea", "study customers")
+    assert set(result.keys()) >= {
+        "role",
+        "task",
+        "findings",
+        "risks",
+        "next_steps",
+        "sources",
+    }
+
+
+@patch("agents.ip_analyst_agent.llm_call")
+def test_ip_agent_contract(mock_call):
+    mock_call.return_value = _fake_response(
+        {
+            "role": "IP Analyst",
+            "task": "Check novelty",
+            "findings": [],
+            "risks": [],
+            "next_steps": [],
+            "sources": [],
+        }
+    )
+    agent = IPAnalystAgent("gpt-4o-mini")
+    result = agent.act("idea", "scan patents")
+    assert set(result.keys()) >= {
+        "role",
+        "task",
+        "findings",
+        "risks",
+        "next_steps",
+        "sources",
+    }
+
+
+def test_router_dispatches_to_new_agents():
+    agents = registry.build_agents("test")
+    a1 = registry.get_agent_for_task("Analyze competitor pricing and market segments", agents)
+    assert a1.name == "Marketing Analyst"
+    a2 = registry.get_agent_for_task("Review patent claims for novelty", agents)
+    assert a2.name == "IP Analyst"


### PR DESCRIPTION
## Summary
- add marketing and IP agents that produce markdown+JSON with optional RAG citations
- route marketing, finance, and IP tasks to new specialists
- let planner suggest Marketing Analyst and IP Analyst roles
- document new roles, defaults, and JSON contract

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2795bcfa8832c8f462642c410bd3a