### PR TITLE
feat: add live web search fallback using SerpAPI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@ OPENAI_API_KEY=sk-...
 EVALUATORS_ENABLED=false
 REFLECTION_ENABLED=false
 RAG_ENABLED=false
+ENABLE_LIVE_SEARCH=false
+SERPAPI_KEY=
 
 # Optional: override prices file
 # PRICES_PATH=./config/prices.yaml
@@ -12,4 +14,3 @@ RAG_ENABLED=false
 # Optional: Google Cloud
 GCS_BUCKET=
 GOOGLE_CLOUD_PROJECT=
-SERPAPI_KEY=

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Images are disabled by default for the Test and Balanced modes.
 4) (Optional) Build a RAG index: `python scripts/build_faiss_index.py`
    Then enable `RAG_ENABLED=true` in your environment so agents like Marketing and IP can cite supporting snippets.
 
+### Live Web Search (optional)
+
+Set `ENABLE_LIVE_SEARCH=true` and provide a `SERPAPI_KEY` to allow the Research Scientist, IP Analyst, and Regulatory agents to query the live web when local RAG hits are missing or too short. When web results are used, these agents add a `sources` array with short titles or URLs to their JSON output.
+
 ### Run profiles
 
 - **Lite**: deterministic single-pass pipeline with a hard budget cap. Good for demos and CI smoke tests.

--- a/agents/planner_agent.py
+++ b/agents/planner_agent.py
@@ -60,7 +60,7 @@ class PlannerAgent(BaseAgent):
         import json
 
         prompt = self.user_prompt_template.format(idea=idea, task=task)
-        prompt = self._augment_prompt(prompt, f"{idea}\n{task}")
+        prompt = self._augment_prompt(prompt, idea, task)
 
         kwargs = {
             "messages": [

--- a/config/feature_flags.py
+++ b/config/feature_flags.py
@@ -18,6 +18,7 @@ SIM_OPTIMIZER_MAX_EVALS: int = int(os.getenv("SIM_OPTIMIZER_MAX_EVALS", "50"))
 RAG_ENABLED = _flag("RAG_ENABLED")
 RAG_TOPK: int = int(os.getenv("RAG_TOPK", "5"))
 RAG_SNIPPET_TOKENS: int = int(os.getenv("RAG_SNIPPET_TOKENS", "200"))
+ENABLE_LIVE_SEARCH = _flag("ENABLE_LIVE_SEARCH")
 DISABLE_IMAGES_BY_DEFAULT = {"test": True, "balanced": True, "deep": False}
 
 # Default evaluator weights and threshold. ``EVALUATOR_WEIGHTS`` can be
@@ -57,6 +58,7 @@ def get_env_defaults() -> dict:
         "RAG_ENABLED": RAG_ENABLED,
         "RAG_TOPK": RAG_TOPK,
         "RAG_SNIPPET_TOKENS": RAG_SNIPPET_TOKENS,
+        "ENABLE_LIVE_SEARCH": ENABLE_LIVE_SEARCH,
         "SIM_OPTIMIZER_ENABLED": SIM_OPTIMIZER_ENABLED,
         "SIM_OPTIMIZER_STRATEGY": SIM_OPTIMIZER_STRATEGY,
         "SIM_OPTIMIZER_MAX_EVALS": SIM_OPTIMIZER_MAX_EVALS,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+from dr_rd.utils.llm_client import set_budget_manager
+
+
+@pytest.fixture(autouse=True)
+def _reset_budget():
+    yield
+    set_budget_manager(None)

--- a/tests/test_live_search.py
+++ b/tests/test_live_search.py
@@ -1,0 +1,96 @@
+import types
+import importlib
+
+import config.feature_flags as ff
+import agents.base_agent as ba
+import agents.ip_analyst_agent as ip_agent
+
+
+class DummyResp:
+    def __init__(self, content: str):
+        self.choices = [types.SimpleNamespace(message=types.SimpleNamespace(content=content), usage=None)]
+
+
+def test_live_search_triggered(monkeypatch):
+    monkeypatch.setenv("ENABLE_LIVE_SEARCH", "true")
+    importlib.reload(ff)
+    importlib.reload(ba)
+    importlib.reload(ip_agent)
+
+    def fake_search(q, k=5):
+        return [{"snippet": "alpha beta", "title": "T1", "link": "u1"}]
+
+    monkeypatch.setattr("utils.search_tools.search_google", fake_search)
+    monkeypatch.setattr("utils.search_tools.llm_call", lambda *a, **k: DummyResp("summary"))
+
+    captured = {}
+
+    def fake_agent_llm(client, model, stage, messages, **params):
+        captured["prompt"] = messages[1]["content"]
+        return DummyResp('{"role":"IP Analyst","task":"x","findings":[],"risks":[],"next_steps":[]}')
+
+    monkeypatch.setattr(ip_agent, "llm_call", fake_agent_llm)
+    agent = ip_agent.IPAnalystAgent(model="gpt-4o-mini", retriever=None)
+    out = agent.act("idea", "task")
+    assert "# Web Search Results" in captured["prompt"]
+    assert out["sources"] == ["T1"]
+
+
+def test_no_live_search_with_rag(monkeypatch):
+    monkeypatch.setenv("ENABLE_LIVE_SEARCH", "true")
+    monkeypatch.setenv("RAG_ENABLED", "true")
+    importlib.reload(ff)
+    importlib.reload(ba)
+    importlib.reload(ip_agent)
+    called = {"search": False}
+
+    def fake_search(q, k=5):
+        called["search"] = True
+        return []
+
+    monkeypatch.setattr("utils.search_tools.search_google", fake_search)
+    monkeypatch.setattr("utils.search_tools.llm_call", lambda *a, **k: DummyResp("summary"))
+
+    captured = {}
+
+    def fake_agent_llm(client, model, stage, messages, **params):
+        captured["prompt"] = messages[1]["content"]
+        return DummyResp('{"role":"IP Analyst","task":"x","findings":[],"risks":[],"next_steps":[]}')
+
+    monkeypatch.setattr(ip_agent, "llm_call", fake_agent_llm)
+
+    class DummyRetriever:
+        def query(self, q, k):
+            return [("word " * 60, "Doc1")]
+
+    agent = ip_agent.IPAnalystAgent(model="gpt-4o-mini", retriever=DummyRetriever())
+    agent.act("idea", "task")
+    assert "# Web Search Results" not in captured.get("prompt", "")
+    assert called["search"] is False
+
+
+def test_live_search_disabled(monkeypatch):
+    monkeypatch.setenv("ENABLE_LIVE_SEARCH", "false")
+    importlib.reload(ff)
+    importlib.reload(ba)
+    importlib.reload(ip_agent)
+    called = {"search": False}
+
+    def fake_search(q, k=5):
+        called["search"] = True
+        return []
+
+    monkeypatch.setattr("utils.search_tools.search_google", fake_search)
+    monkeypatch.setattr("utils.search_tools.llm_call", lambda *a, **k: DummyResp("summary"))
+
+    captured = {}
+
+    def fake_agent_llm(client, model, stage, messages, **params):
+        captured["prompt"] = messages[1]["content"]
+        return DummyResp('{"role":"IP Analyst","task":"x","findings":[],"risks":[],"next_steps":[]}')
+
+    monkeypatch.setattr(ip_agent, "llm_call", fake_agent_llm)
+    agent = ip_agent.IPAnalystAgent(model="gpt-4o-mini", retriever=None)
+    agent.act("idea", "task")
+    assert "# Web Search Results" not in captured.get("prompt", "")
+    assert called["search"] is False

--- a/tests/test_rag_prompt.py
+++ b/tests/test_rag_prompt.py
@@ -27,7 +27,7 @@ def test_rag_included_when_enabled(mock_create, monkeypatch):
     agent = ba.BaseAgent("Test", "gpt-4o", "sys", "Task: {task}", retriever=StubRetriever())
     agent.run("idea", "do something")
     prompt = mock_create.call_args.kwargs["messages"][1]["content"]
-    assert "Research Bundle" in prompt
+    assert "# RAG Knowledge" in prompt
     assert "alpha data" in prompt
     assert "(alpha.txt)" in prompt
 
@@ -44,7 +44,7 @@ def test_rag_skipped_when_disabled(mock_create, monkeypatch):
     agent = ba.BaseAgent("Test", "gpt-4o", "sys", "Task: {task}", retriever=StubRetriever())
     agent.run("idea", "do something")
     prompt = mock_create.call_args.kwargs["messages"][1]["content"]
-    assert "Research Bundle" not in prompt
+    assert "# RAG Knowledge" not in prompt
 
 
 @patch.dict(os.environ, {"OPENAI_API_KEY": "x"})

--- a/utils/search_tools.py
+++ b/utils/search_tools.py
@@ -1,0 +1,74 @@
+import os
+import re
+import os
+import re
+from typing import List, Dict
+
+import requests
+from html import unescape
+
+from dr_rd.utils.llm_client import llm_call
+import openai
+
+
+def _strip_html(text: str) -> str:
+    clean = re.sub(r"<[^>]+>", "", text or "")
+    return unescape(clean)
+
+
+def search_google(query: str, k: int = 5) -> List[Dict]:
+    """Query SerpAPI for Google results.
+
+    Returns a list of dicts with snippet, link and title fields. On any
+    failure or if the API key is missing, an empty list is returned.
+    """
+    key = os.getenv("SERPAPI_KEY")
+    if not key:
+        return []
+    try:
+        params = {"engine": "google", "q": query, "api_key": key}
+        resp = requests.get("https://serpapi.com/search.json", params=params, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        out: List[Dict] = []
+        for item in data.get("organic_results", [])[:k]:
+            snippet = _strip_html(item.get("snippet") or item.get("summary") or "")
+            out.append(
+                {
+                    "snippet": snippet,
+                    "link": item.get("link", ""),
+                    "title": item.get("title", ""),
+                }
+            )
+        return out
+    except Exception:
+        return []
+
+
+def summarize_search(snippets: List[str], model: str | None = None) -> str:
+    """Summarize snippets into a concise paragraph using the repo's LLM helper."""
+    if not snippets:
+        return ""
+    model_id = model or "gpt-4o-mini"
+    prompt = "Summarize the following search snippets in a single concise paragraph:\n" + "\n".join(
+        f"- {s}" for s in snippets
+    )
+    try:
+        resp = llm_call(
+            openai,
+            model_id,
+            stage="exec",
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return resp.choices[0].message.content.strip()
+    except Exception:
+        return ""
+
+
+def obfuscate_query(role: str, idea: str, task: str) -> str:
+    """Lightly redact identifying details from the query."""
+    text = f"{role}: {idea}. {task}"
+    text = re.sub(r'".*?"', "[REDACTED]", text)
+    text = re.sub(r"\b[A-Z][a-zA-Z0-9]+\b", "[REDACTED]", text)
+    text = re.sub(r"\d+", "[REDACTED]", text)
+    return text


### PR DESCRIPTION
## Summary
- add SerpAPI search utilities with summary and obfuscation helpers
- let research, IP, and regulatory agents fall back to live web search and include sources
- label prompts with `# RAG Knowledge` and `# Web Search Results`
- document ENABLE_LIVE_SEARCH and SERPAPI_KEY usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a28a10e334832cba0f95ba5ae16692