### PR TITLE
Handle missing domain answers in refinement loop

### DIFF
--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -49,8 +49,13 @@ def _needs_follow_up(domain: str, task: str, answer: str) -> str | None:
 def refine_once(plan: Dict[str, str], answers: Dict[str, str]) -> Dict[str, str]:
     """Return answers, optionally enriched with one follow-up per domain."""
     updated = answers.copy()
-    for domain in plan:
-        follow_up = _needs_follow_up(domain, plan[domain], updated[domain])
+    for domain, task in plan.items():
+        current_answer = updated.get(domain)
+        if current_answer is None:
+            # Skip refinement if no answer was provided for this domain
+            continue
+
+        follow_up = _needs_follow_up(domain, task, current_answer)
         if not follow_up:
             continue
 


### PR DESCRIPTION
## Summary
- skip domains with missing answers during refinement

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2917b4f24832c908d014ae9b0fab3