### PR TITLE
fix: restore iterative HRM loop with robust agent routing

### DIFF
--- a/app/lite_runner.py
+++ b/app/lite_runner.py
@@ -26,7 +26,7 @@ def render_lite() -> None:
 
     idea = st.text_area("Project Idea", key="lite_idea")
     modes = _available_modes()
-    idx = max(0, modes.index("test") if "test" in modes else 0)
+    idx = max(0, modes.index("balanced") if "balanced" in modes else 0)
     mode = st.selectbox("Mode", modes, index=idx, key="lite_mode")
 
     if st.button("Run", key="lite_run"):

--- a/config/modes.yaml
+++ b/config/modes.yaml
@@ -8,17 +8,17 @@ fast:
   target_cost_usd: 0.75
   models: { plan: gpt-4o-mini, exec: gpt-4o-mini, synth: gpt-4o-mini }
   k_search: 3
-  max_loops: 1
+  max_loops: 2
   stage_weights: { plan: 0.25, exec: 0.45, synth: 0.30 }
 balanced:
   target_cost_usd: 1.00
   models: { plan: gpt-4o, exec: gpt-4o-mini, synth: gpt-4o }
   k_search: 4
-  max_loops: 2
+  max_loops: 3
   stage_weights: { plan: 0.25, exec: 0.45, synth: 0.30 }
 deep:
   target_cost_usd: 2.50
   models: { plan: gpt-4o, exec: gpt-4o, synth: gpt-5 }
   k_search: 6
-  max_loops: 3
+  max_loops: 5
   stage_weights: { plan: 0.20, exec: 0.50, synth: 0.30 }

--- a/core/agents/registry.py
+++ b/core/agents/registry.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict
+from typing import Dict, Tuple
 from .base_agent import Agent
 
 from .cto_agent import CTOAgent
@@ -10,6 +10,14 @@ from .finance_agent import FinanceAgent
 from agents.marketing_agent import MarketingAgent
 from agents.ip_analyst_agent import IPAnalystAgent
 from config.agent_models import AGENT_MODEL_MAP
+
+DEFAULT_EXEC_MODEL = AGENT_MODEL_MAP.get("Research", "gpt-3.5-turbo")
+AGENT_MODEL_MAP.setdefault(
+    "Marketing Analyst", AGENT_MODEL_MAP.get("Research", DEFAULT_EXEC_MODEL)
+)
+AGENT_MODEL_MAP.setdefault(
+    "IP Analyst", AGENT_MODEL_MAP.get("Research", DEFAULT_EXEC_MODEL)
+)
 
 
 def build_agents(mode: str | None = None) -> Dict[str, Agent]:
@@ -25,35 +33,20 @@ def build_agents(mode: str | None = None) -> Dict[str, Agent]:
     currently ignored.
     """
 
-    default = AGENT_MODEL_MAP.get("Research", "gpt-3.5-turbo")
+    default = AGENT_MODEL_MAP.get("Research", DEFAULT_EXEC_MODEL)
     return {
         "CTO": CTOAgent(model_id=AGENT_MODEL_MAP.get("CTO", default)),
         "Research": ResearchScientistAgent(model_id=AGENT_MODEL_MAP.get("Research", default)),
         "Regulatory": RegulatoryAgent(model_id=AGENT_MODEL_MAP.get("Regulatory", default)),
         "Finance": FinanceAgent(model_id=AGENT_MODEL_MAP.get("Finance", default)),
-        "Marketing Analyst": MarketingAgent(model=AGENT_MODEL_MAP.get("Marketing", default)),
-        "IP Analyst": IPAnalystAgent(model=AGENT_MODEL_MAP.get("IP", default)),
+        "Marketing Analyst": MarketingAgent(model=AGENT_MODEL_MAP.get("Marketing Analyst", default)),
+        "IP Analyst": IPAnalystAgent(model=AGENT_MODEL_MAP.get("IP Analyst", default)),
     }
 
 
 AGENTS = build_agents()
 
-_KEYWORDS = {
-    "CTO": ["architecture", "risk", "scalability"],
-    "Research": ["materials", "physics", "prior art", "literature"],
-    "Regulatory": ["compliance", "fda", "iso", "fcc"],
-    "Finance": [
-        "cost",
-        "bom",
-        "budget",
-        "bill of materials",
-        "unit economics",
-        "capex",
-        "opex",
-        "payback",
-        "breakeven",
-        "roi",
-    ],
+KEYWORDS = {
     "Marketing Analyst": [
         "market",
         "customer",
@@ -84,17 +77,43 @@ _KEYWORDS = {
         "freedom to operate",
         "ip strategy",
     ],
+    "Finance": [
+        "budget",
+        "cost",
+        "bom",
+        "bill of materials",
+        "capex",
+        "opex",
+        "unit economics",
+        "breakeven",
+        "payback",
+        "roi",
+    ],
+    "Regulatory": ["regulatory", "compliance", "fda", "ce", "iso", "510(k)", "hipaa", "gdpr"],
+    "CTO": ["architecture", "system design", "tech strategy", "roadmap"],
+    "Research": [],
 }
 
 
+def choose_agent_for_task(
+    planned_role: str | None, title: str, agents: Dict[str, Agent]
+) -> Tuple[Agent, str]:
+    # 1) Exact role match
+    if planned_role and planned_role in agents:
+        return agents[planned_role], planned_role
+    # 2) Keyword fallback
+    t = (title or "").lower()
+    for role_key, words in KEYWORDS.items():
+        if role_key in agents and any(w in t for w in words):
+            return agents[role_key], role_key
+    # 3) Safe default
+    fallback = agents.get("Research") or next(iter(agents.values()))
+    return fallback, "Research"
+
+
 def get_agent_for_task(task: str, agents: Dict[str, Agent] | None = None) -> Agent:
-    agents = agents or AGENTS
-    text = (task or "").lower()
-    for name, words in _KEYWORDS.items():
-        for w in words:
-            if w in text:
-                return agents[name]
-    return agents["Research"]
+    agent, _ = choose_agent_for_task(None, task, agents or AGENTS)
+    return agent
 
 # --- Added: mode-aware model loader that also installs the BudgetManager ---
 def load_mode_models(mode: str | None = None) -> dict:

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -2,54 +2,67 @@ from __future__ import annotations
 
 from typing import Dict, List, Tuple
 
+import logging
 import streamlit as st
 from agents.planner_agent import PlannerAgent
-from agents.orchestrator import refine_once
-from core.agents.registry import build_agents, get_agent_for_task, load_mode_models
+from core.agents.registry import build_agents, choose_agent_for_task, load_mode_models
 from core.synthesizer import synthesize
+
+logger = logging.getLogger(__name__)
 
 
 def run_pipeline(
-    idea: str, mode: str = "test"
+    idea: str, mode: str = "test",
 ) -> Tuple[str, Dict[str, List[dict]], List[dict]]:
-    """Run planner → specialists → synthesis pipeline."""
+    """Run iterative planner → specialists → synthesis pipeline."""
     models = load_mode_models(mode)
     planner_model = models.get("Planner", models.get("default", "gpt-3.5-turbo"))
     planner = PlannerAgent(planner_model)
-    plan = planner.run(idea, "Decompose the project into specialist tasks")
-    tasks = [{"title": task, "role": role} for role, task in plan.items()]
-
     agents = build_agents(mode)
-    answers: Dict[str, str] = {}
+
+    max_loops = int(st.session_state.get("MODE_CFG", {}).get("max_loops", 5))
+    cycle = 0
+    task_queue: List[dict] = []
     results_by_role: Dict[str, List[dict]] = {}
-    context: Dict[str, List[str]] = {"idea": idea, "summaries": []}
     trace: List[dict] = []
-    for t in tasks:
-        agent = get_agent_for_task(t.get("title", t.get("role", "")), agents)
-        result = agent.act(idea, t.get("title", ""), context)
-        results_by_role.setdefault(agent.name, []).append(result)
-        summary_line = result.get("findings", [""])[0] if result.get("findings") else ""
-        answers[agent.name] = summary_line
-        context["summaries"].append(summary_line)
-        usage = result.get("usage", {})
-        tokens = usage.get("total_tokens") or (
-            usage.get("prompt_tokens", 0) + usage.get("completion_tokens", 0)
+    context: Dict[str, List[str]] = {"idea": idea, "summaries": []}
+
+    plan = planner.run(idea, "Decompose the project into specialist tasks")
+    task_queue.extend({"role": r, "title": t} for r, t in plan.items())
+
+    while True:
+        if not task_queue:
+            followups = planner.revise_plan({"idea": idea, "results": results_by_role})
+            if not followups:
+                break
+            task_queue.extend({"role": t.get("role"), "title": t.get("task")} for t in followups)
+        cycle += 1
+        batch = list(task_queue)
+        task_queue.clear()
+        for task in batch:
+            agent, routed_role = choose_agent_for_task(
+                task.get("role"), task.get("title", ""), agents
+            )
+            logger.info(
+                "Dispatch '%s' planned_role=%s -> routed_role=%s",
+                task.get("title"),
+                task.get("role"),
+                routed_role,
+            )
+            result = agent.act(idea, task.get("title", ""), context)
+            results_by_role.setdefault(routed_role, []).append(result)
+            summary_line = result.get("findings", [""])[0] if result.get("findings") else ""
+            context["summaries"].append(summary_line)
+            usage = result.get("usage", {})
+            tokens = usage.get("total_tokens") or (
+                usage.get("prompt_tokens", 0) + usage.get("completion_tokens", 0)
+            )
+            trace.append({"agent": routed_role, "tokens": tokens, "finding": summary_line})
+        logger.info(
+            "Cycle %s — executed %s tasks; queue=%s", cycle, len(batch), len(task_queue)
         )
-        trace.append({"agent": agent.name, "tokens": tokens, "finding": summary_line})
+        if cycle >= max_loops and not task_queue:
+            break
 
-    def _answers_to_results(ans: Dict[str, str]) -> Dict[str, List[dict]]:
-        return {role: [{"findings": [txt]}] for role, txt in ans.items()}
-
-    answers_by_role = _answers_to_results(answers)
-    final = synthesize(
-        idea, answers_by_role, model_id=models.get("synth", planner_model)
-    )
-    loops = int(st.session_state.get("MODE_CFG", {}).get("max_loops", 1))
-    for _ in range(max(0, loops - 1)):
-        answers = refine_once(plan, answers)
-        answers_by_role = _answers_to_results(answers)
-        final = synthesize(
-            idea, answers_by_role, model_id=models.get("synth", planner_model)
-        )
-
-    return final, answers_by_role, trace
+    final = synthesize(idea, results_by_role, model_id=models.get("synth", planner_model))
+    return final, results_by_role, trace

--- a/tests/test_business_agents.py
+++ b/tests/test_business_agents.py
@@ -65,7 +65,11 @@ def test_ip_agent_contract(mock_call):
 
 def test_router_dispatches_to_new_agents():
     agents = registry.build_agents("test")
-    a1 = registry.get_agent_for_task("Analyze competitor pricing and market segments", agents)
-    assert a1.name == "Marketing Analyst"
-    a2 = registry.get_agent_for_task("Review patent claims for novelty", agents)
-    assert a2.name == "IP Analyst"
+    a1, role1 = registry.choose_agent_for_task(
+        None, "Analyze competitor pricing and market segments", agents
+    )
+    assert a1.name == "Marketing Analyst" and role1 == "Marketing Analyst"
+    a2, role2 = registry.choose_agent_for_task(
+        None, "Review patent claims for novelty", agents
+    )
+    assert a2.name == "IP Analyst" and role2 == "IP Analyst"

--- a/tests/test_orchestrator_loop.py
+++ b/tests/test_orchestrator_loop.py
@@ -1,0 +1,48 @@
+from unittest.mock import patch, Mock
+
+import core.orchestrator as orch
+
+
+def test_orchestrator_iterative_loop_executes_all_roles():
+    class DummyPlanner:
+        def __init__(self, *args, **kwargs):
+            self.called = False
+
+        def run(self, idea, prompt):
+            return {
+                "Marketing Analyst": "analyze market",
+                "IP Analyst": "search patents",
+                "Finance": "calc budget",
+                "Research": "general research",
+            }
+
+        def revise_plan(self, state):
+            if not self.called:
+                self.called = True
+                return [{"role": "Research", "task": "extra"}]
+            return []
+
+    class StubAgent:
+        def __init__(self, name):
+            self.name = name
+
+        def act(self, idea, task, context):
+            return {"findings": [f"{self.name}:{task}"], "usage": {"total_tokens": 1}}
+
+    def fake_build_agents(mode):
+        return {
+            "Marketing Analyst": StubAgent("Marketing Analyst"),
+            "IP Analyst": StubAgent("IP Analyst"),
+            "Finance": StubAgent("Finance"),
+            "Research": StubAgent("Research"),
+        }
+
+    with patch.object(orch, "PlannerAgent", DummyPlanner), \
+         patch.object(orch, "build_agents", fake_build_agents), \
+         patch.object(orch, "synthesize", return_value="final"), \
+         patch.object(orch, "load_mode_models", return_value={"Planner": "x", "synth": "x", "default": "x"}):
+        final, results, trace = orch.run_pipeline("idea", mode="test")
+
+    assert set(results.keys()) >= {"Marketing Analyst", "IP Analyst", "Finance", "Research"}
+    assert len(results["Research"]) == 2  # initial + follow-up
+    assert len(trace) == 5  # 4 initial tasks + 1 follow-up

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -3,29 +3,45 @@ from core.agents import registry
 
 def test_agent_mapping_cto():
     agents = registry.build_agents("test")
-    agent = registry.get_agent_for_task("Evaluate system architecture and risk", agents)
-    assert agent.name == "CTO"
+    agent, role = registry.choose_agent_for_task(
+        None, "Evaluate system architecture and risk", agents
+    )
+    assert agent.name == "CTO" and role == "CTO"
 
 
 def test_agent_mapping_research():
     agents = registry.build_agents("test")
-    agent = registry.get_agent_for_task("Survey materials and physics literature", agents)
-    assert agent.name == "Research"
+    agent, role = registry.choose_agent_for_task(
+        None, "Survey materials and physics literature", agents
+    )
+    assert agent.name == "Research" and role == "Research"
 
 
 def test_agent_mapping_regulatory():
     agents = registry.build_agents("test")
-    agent = registry.get_agent_for_task("Check FDA compliance and ISO standards", agents)
-    assert agent.name == "Regulatory"
+    agent, role = registry.choose_agent_for_task(
+        None, "Check FDA compliance and ISO standards", agents
+    )
+    assert agent.name == "Regulatory" and role == "Regulatory"
 
 
-def test_agent_mapping_finance():
+def test_agent_mapping_finance_keyword():
     agents = registry.build_agents("test")
-    agent = registry.get_agent_for_task("Estimate BOM cost and budget", agents)
-    assert agent.name == "Finance"
+    agent, role = registry.choose_agent_for_task(
+        None, "Estimate BOM cost and budget", agents
+    )
+    assert agent.name == "Finance" and role == "Finance"
+
+
+def test_agent_exact_role_over_keyword():
+    agents = registry.build_agents("test")
+    agent, role = registry.choose_agent_for_task(
+        "Finance", "Analyze competitor pricing and market segments", agents
+    )
+    assert agent.name == "Finance" and role == "Finance"
 
 
 def test_agent_mapping_default():
     agents = registry.build_agents("test")
-    agent = registry.get_agent_for_task("Unrecognized task", agents)
-    assert agent.name == "Research"
+    agent, role = registry.choose_agent_for_task(None, "Unrecognized task", agents)
+    assert agent.name == "Research" and role == "Research"


### PR DESCRIPTION
## Summary
- add Marketing Analyst & IP Analyst to agent registry and keyword router
- restore iterative planner-execute loop with exact-role dispatch and logs
- raise default max_loops and default UI to balanced mode

## Testing
- `pytest tests/test_registry.py tests/test_business_agents.py tests/test_orchestrator_loop.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a29b9a8000832c930e3faacf5bae52