### PR TITLE
Unify planning dispatch with core registry and robust routing

### DIFF
--- a/agents/planner_agent.py
+++ b/agents/planner_agent.py
@@ -2,7 +2,7 @@ from agents.base_agent import BaseAgent
 import logging, os
 import openai
 from dr_rd.utils.model_router import pick_model, CallHints
-from dr_rd.utils.llm_client import log_usage
+from dr_rd.utils.llm_client import log_usage, llm_call
 from typing import Optional
 import streamlit as st
 
@@ -17,14 +17,9 @@ except Exception:  # pragma: no cover
 log = logging.getLogger(__name__)
 
 PLAN_INSTRUCTIONS = """
-You are the Creation Planner. Output ONLY valid JSON. No prose, no backticks.
-Acceptable formats (emit exactly ONE of these):
-A) {"CTO":[{"title":"...","description":"..."}, ...], "Research Scientist":[...], ...}
-B) [{"role":"CTO","title":"...","description":"..."}, ...]
-Rules:
-- Use only roles that exist in this system (e.g., CTO, Research Scientist, Regulatory, Finance, Marketing Analyst, IP Analyst, etc.).
-- Titles must be short imperatives; descriptions concise and specific.
-- Do not include commentary, markdown, or code fences. JSON only.
+You are the Creation Planner. Output ONLY valid JSON as a single array:
+[{"role":"<one of: CTO, Research Scientist, Regulatory, Finance, Marketing Analyst, IP Analyst>","title":"...","description":"..."}]
+Rules: roles MUST be exactly one of those six; titles are short imperatives; descriptions are concise and specific. No prose. No backticks.
 """
 
 

--- a/app/ui_cost_meter.py
+++ b/app/ui_cost_meter.py
@@ -24,7 +24,7 @@ def render_estimator(mode: str, idea_text: str, price_per_1k: float = 0.005):
         else:
             metric(label, f"${est_cost:.2f}")
 
-def render_cost_summary(mode: str, plan: dict | None):
+def render_cost_summary(mode: str, plan: dict | list | None):
     log = st.session_state.get("usage_log", [])
     actual = 0.0
     stage_counts = {}
@@ -34,7 +34,12 @@ def render_cost_summary(mode: str, plan: dict | None):
 
     preset = UI_PRESETS.get(mode, UI_PRESETS["balanced"])
     refinement_rounds = preset.get("refinement_rounds", 1)
-    roles = len(plan.keys()) if plan else 0
+    if isinstance(plan, dict):
+        roles = len(plan.keys())
+    elif isinstance(plan, list):
+        roles = len({t.get("role") for t in plan})
+    else:
+        roles = 0
     expected_calls = {
         "plan": 1,
         "exec": roles * refinement_rounds,

--- a/config/agent_models.py
+++ b/config/agent_models.py
@@ -2,6 +2,8 @@
 
 AGENT_MODEL_MAP = {
     "Planner": "gpt-4o",
+    "CTO": "gpt-4o",
+    "Research": "gpt-4o",
     "Mechanical Systems Lead": "gpt-4o",
     "Materials & Process Engineer": "gpt-4o",
     "Chemical & Surface Science Specialist": "gpt-4o",
@@ -17,11 +19,15 @@ AGENT_MODEL_MAP = {
     "Systems Integration & Validation Engineer": "gpt-4o",
     "Data Scientist / Analytics Engineer": "gpt-4o",
     "Regulatory & Compliance Lead": "gpt-4o-mini",
+    "Regulatory": "gpt-4o-mini",
+    "Finance": "gpt-4o-mini",
     "Prototyping & Test Lab Manager": "gpt-4o-mini",
     "Project Manager / Principal Investigator": "gpt-4o-mini",
     "Product Manager / Translational Lead": "gpt-4o-mini",
     "AI R&D Coordinator": "gpt-4o-mini",
     "Synthesizer": "gpt-4o",
+    "Marketing Analyst": "gpt-4o-mini",
+    "IP Analyst": "gpt-4o-mini",
     "Marketing": "gpt-4o-mini",
     "IP": "gpt-4o-mini",
 }

--- a/tests/test_orchestrator_loop.py
+++ b/tests/test_orchestrator_loop.py
@@ -9,12 +9,12 @@ def test_orchestrator_iterative_loop_executes_all_roles():
             self.called = False
 
         def run(self, idea, prompt):
-            return {
-                "Marketing Analyst": "analyze market",
-                "IP Analyst": "search patents",
-                "Finance": "calc budget",
-                "Research": "general research",
-            }
+            return [
+                {"role": "Marketing Analyst", "title": "analyze market", "description": "analyze market"},
+                {"role": "IP Analyst", "title": "search patents", "description": "search patents"},
+                {"role": "Finance", "title": "calc budget", "description": "calc budget"},
+                {"role": "Research", "title": "general research", "description": "general research"},
+            ]
 
         def revise_plan(self, state):
             if not self.called:

--- a/tests/test_plan_routing.py
+++ b/tests/test_plan_routing.py
@@ -1,0 +1,36 @@
+import importlib, sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+def load_app():
+    st = SimpleNamespace(session_state={}, secrets={"gcp_service_account": {}}, cache_resource=lambda f: f)
+    sys.modules['streamlit'] = st
+    sys.modules['openai'] = MagicMock()
+    if 'app' in sys.modules:
+        importlib.reload(sys.modules['app'])
+    else:
+        importlib.import_module('app')
+    return sys.modules['app']
+
+
+def test_normalize_plan_formats():
+    app = load_app()
+    plan_a = {"CTO": [{"title": "A", "description": "B"}]}
+    plan_b = [{"role": "CTO", "title": "A", "description": "B"}]
+    assert app.normalize_plan_to_tasks(plan_a) == app.normalize_plan_to_tasks(plan_b)
+
+
+def test_role_alias_normalization():
+    app = load_app()
+    assert app.normalize_role("Regulatory & Compliance Lead") == "Regulatory"
+
+
+def test_unknown_role_routes_to_default():
+    app = load_app()
+    agents = app.get_agents()
+    tasks = [{"role": "Wizard", "title": "Budget study", "description": "cost analysis"}]
+    routed, dropped = app.route_tasks(tasks, agents)
+    assert not dropped
+    rr, agent, _ = routed[0]
+    assert rr in agents

--- a/tests/test_planner_agent.py
+++ b/tests/test_planner_agent.py
@@ -10,7 +10,7 @@ def make_openai_response(text: str):
 
 
 @patch.dict(os.environ, {"OPENAI_API_KEY": "x"})
-@patch('openai.chat.completions.create')
+@patch('agents.planner_agent.openai.chat.completions.create')
 def test_planner_agent_returns_dict_without_response_format(mock_create):
     """Legacy models should not receive the response_format parameter."""
     mock_create.return_value = make_openai_response('{"X": "Y"}')
@@ -24,7 +24,7 @@ def test_planner_agent_returns_dict_without_response_format(mock_create):
 
 
 @patch.dict(os.environ, {"OPENAI_API_KEY": "x"})
-@patch('openai.chat.completions.create')
+@patch('agents.planner_agent.openai.chat.completions.create')
 def test_planner_agent_uses_response_format_for_new_models(mock_create):
     mock_create.return_value = make_openai_response('{"X": "Y"}')
     agent = PlannerAgent("gpt-4o-mini")
@@ -35,7 +35,7 @@ def test_planner_agent_uses_response_format_for_new_models(mock_create):
 
 
 @patch.dict(os.environ, {"OPENAI_API_KEY": "x"})
-@patch('openai.chat.completions.create')
+@patch('agents.planner_agent.openai.chat.completions.create')
 def test_planner_agent_handles_truncated_json(mock_create):
     text = '{ "A": "B", "C": "D", "E": "F'
     mock_create.return_value = make_openai_response(text)

--- a/tests/test_planner_output.py
+++ b/tests/test_planner_output.py
@@ -16,7 +16,7 @@ ALLOWED_ROLES = set(AGENT_MODEL_MAP.keys()) - {"Planner", "Synthesizer"}
 
 
 @patch.dict(os.environ, {"OPENAI_API_KEY": "x"})
-@patch('openai.chat.completions.create')
+@patch('agents.planner_agent.openai.chat.completions.create')
 def test_planner_output_validity(mock_create):
     mock_create.return_value = make_openai_response('{"Mechanical Systems Lead": "Design the frame"}')
     agent = PlannerAgent("gpt-4o")

--- a/tests/test_planner_remediation.py
+++ b/tests/test_planner_remediation.py
@@ -12,7 +12,7 @@ def make_openai_response(text: str):
 
 
 @patch.dict(os.environ, {"OPENAI_API_KEY": "x"})
-@patch('openai.chat.completions.create')
+@patch('agents.planner_agent.openai.chat.completions.create')
 def test_planner_adds_remediation_task(mock_create):
     mock_create.return_value = make_openai_response('{"updated_tasks": []}')
     agent = PlannerAgent("gpt-4o-mini")

--- a/tests/test_reflection_role_tweak.py
+++ b/tests/test_reflection_role_tweak.py
@@ -50,7 +50,7 @@ def test_role_tweak_applied(monkeypatch):
             self.count = 0
 
         def run(self, idea, prompt):
-            return {"Engineer": "do stuff"}
+            return [{"role": "Engineer", "title": "do stuff", "description": "do stuff"}]
 
         def revise_plan(self, state):
             self.count += 1

--- a/tests/test_synthesizer.py
+++ b/tests/test_synthesizer.py
@@ -12,7 +12,7 @@ def make_openai_response(text: str):
 
 @patch.dict(os.environ, {"OPENAI_API_KEY": "x"})
 @patch("agents.synthesizer.make_visuals_for_project", return_value=[{"kind": "schematic", "url": "u", "caption": "S"}])
-@patch('openai.chat.completions.create')
+@patch('agents.synthesizer.openai.chat.completions.create')
 def test_compose_final_proposal(mock_create, _mock_vis):
     fake_response = (
         "## Executive Summary\nOverview\n\n"


### PR DESCRIPTION
## Summary
- Switch UI to core `build_agents` registry and introduce planner output normalization, role aliasing, and fallback routing
- Tighten planner prompt to supported roles only and persist submitted idea in Firestore
- Extend agent model mapping and adjust cost summary for list-based plans; add tests for plan formats, role aliases, and routing defaults

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a36eb66ef4832c9f70211a85916f35