### PR TITLE
Route planner tasks without dropping roles

### DIFF
--- a/orchestrators/plan_utils.py
+++ b/orchestrators/plan_utils.py
@@ -1,0 +1,35 @@
+from typing import List, Dict, Any
+
+
+def normalize_plan_to_tasks(plan: Any) -> List[Dict]:
+    """
+    Normalize Planner output to a list of {role,title,description,tags}
+    Accepts:
+      A) dict: role -> list[{title,description}|str]
+      B) list of {role,title,description[,tags]}
+    """
+    tasks: List[Dict] = []
+    if isinstance(plan, dict):
+        for role, items in (plan or {}).items():
+            for it in (items or []):
+                if isinstance(it, str):
+                    tasks.append({"role": role, "title": it, "description": it, "tags": []})
+                else:
+                    tasks.append({
+                        "role": role,
+                        "title": it.get("title") or it.get("task") or "",
+                        "description": it.get("description") or it.get("details") or it.get("title") or "",
+                        "tags": it.get("tags", []) if isinstance(it, dict) else [],
+                    })
+    elif isinstance(plan, list):
+        for it in plan:
+            tasks.append({
+                "role": it.get("role",""),
+                "title": it.get("title") or it.get("task") or "",
+                "description": it.get("description") or it.get("details") or it.get("title") or "",
+                "tags": it.get("tags", []) if isinstance(it, dict) else [],
+            })
+    else:
+        raise ValueError("Planner returned unexpected plan type")
+    # remove empties
+    return [t for t in tasks if (t["title"] or t["description"])]

--- a/orchestrators/router.py
+++ b/orchestrators/router.py
@@ -1,0 +1,86 @@
+from typing import Dict, List, Tuple
+import re
+
+# Aliases to handle common naming mismatches from the Planner
+ROLE_ALIASES: Dict[str, str] = {
+    # broad roles you plan for in README
+    "Research Scientist": "Research",
+    "Regulatory": "Regulatory",
+    "Finance": "Finance",
+    "CTO": "CTO",
+    "Marketing Analyst": "Marketing Analyst",
+    "IP Analyst": "IP Analyst",
+}
+
+# Optional tags -> specialist roles (extend to your specialists if desired)
+TAG_TO_ROLE: Dict[str, str] = {
+    "mechanical": "Mechanical Systems Lead",
+    "optics": "Optical Systems Engineer",
+    "photonics": "Photonics Electronics Engineer",
+    "materials": "Materials Scientist",
+    "electronics": "Electronics Engineer",
+    "software": "Software/ML Engineer",
+    "thermal": "Thermal Engineer",
+    "qa": "QA/Testing Lead",
+    "regulatory": "Regulatory",
+    "finance": "Finance",
+    "marketing": "Marketing Analyst",
+    "ip": "IP Analyst",
+}
+
+# Lightweight keyword buckets for fallback routing
+KEYWORDS: Dict[str, List[str]] = {
+    "Marketing Analyst": ["market", "segment", "competition", "pricing", "revenue", "adoption", "tam", "sam", "som", "gtm"],
+    "IP Analyst": ["patent", "prior art", "claims", "novelty", "patentability", "fto", "freedom to operate"],
+    "Finance": ["budget", "cost", "capex", "opex", "bom", "unit economics", "roi", "breakeven", "payback"],
+    "Regulatory": ["regulatory", "compliance", "fda", "hipaa", "gdpr", "ce", "iso", "510(k)", "510k"],
+    "CTO": ["architecture", "system design", "tech strategy", "roadmap"],
+    # specialist hints (optional)
+    "Mechanical Systems Lead": ["mechanical", "fixture", "frame", "actuator", "gear", "stress", "strain"],
+    "Optical Systems Engineer": ["optical", "lens", "objective", "na", "interferometer", "microscope", "diffraction", "entanglement"],
+    "Materials Scientist": ["material", "coating", "substrate", "alloy", "polymer", "film"],
+    "Electronics Engineer": ["circuit", "pcb", "adc", "fpga", "driver", "amplifier", "dac"],
+    "Software/ML Engineer": ["pipeline", "inference", "training", "dataset", "api", "opencv"],
+    "Thermal Engineer": ["thermal", "heat sink", "convection", "temperature", "cooling"],
+    "QA/Testing Lead": ["test plan", "validation", "verification", "acceptance criteria"],
+    "Research": [],  # safe default
+}
+
+
+def _norm(s: str) -> str:
+    return (s or "").strip()
+
+
+def normalize_role(planned_role: str) -> str:
+    pr = _norm(planned_role)
+    return ROLE_ALIASES.get(pr, pr)
+
+
+def choose_agent_for_task(
+    planned_role: str,
+    title: str,
+    description: str,
+    tags: List[str],
+    agents: Dict[str, object],
+) -> Tuple[object, str]:
+    """
+    Returns (agent_instance, routed_role_name) without dropping any task.
+    Order: exact/alias -> tags -> keywords -> default
+    """
+    # 1) exact or alias
+    cand = normalize_role(planned_role)
+    if cand in agents:
+        return agents[cand], cand
+    # 2) tags to specialists
+    for t in (tags or []):
+        r = TAG_TO_ROLE.get(_norm(t).lower())
+        if r and r in agents:
+            return agents[r], r
+    # 3) keyword buckets (title+description)
+    text = f"{title or ''} {description or ''}".lower()
+    for role, words in KEYWORDS.items():
+        if role in agents and any(re.search(rf"\b{re.escape(w)}\b", text) for w in words):
+            return agents[role], role
+    # 4) safe default (prefer Research if present)
+    fallback = agents.get("Research") or next(iter(agents.values()))
+    return fallback, "Research"

--- a/tests/test_router_no_drop.py
+++ b/tests/test_router_no_drop.py
@@ -1,0 +1,22 @@
+from orchestrators.router import choose_agent_for_task
+
+
+class Dummy:
+    pass
+
+
+def test_unknown_role_does_not_drop(monkeypatch):
+    agents = {"Research": Dummy(), "Finance": Dummy(), "Regulatory": Dummy()}
+    # planned role not in agents, but finance keywords route it
+    agent, role = choose_agent_for_task(
+        "Finance Analyst", "Budget Planning", "ROI and BOM", ["finance"], agents
+    )
+    assert role in agents
+
+
+def test_alias_maps_to_known():
+    agents = {"Research": Dummy()}
+    agent, role = choose_agent_for_task(
+        "Research Scientist", "Investigate", "quantum entanglement", [], agents
+    )
+    assert role == "Research"


### PR DESCRIPTION
## Summary
- add central router with role aliases, tag and keyword routing
- normalize planner output into unified task list
- integrate router into Streamlit app and expose executable roles
- verify routing via new no-drop tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a38d211d98832cb537a50ea103e966