### PR TITLE
Align routing and persistence with orchestrator

### DIFF
--- a/memory/memory_manager.py
+++ b/memory/memory_manager.py
@@ -28,13 +28,13 @@ class MemoryManager:
         if not isinstance(self.data, list):
             self.data = []
 
-    def store_project(self, name, idea, plan, outputs, proposal, images=None):
+    def store_project(self, name, idea, plan, results, proposal, images=None):
         """Save a completed project to memory (and Firestore if available)."""
         entry = {
             "name": name,
             "idea": idea,
             "plan": plan,
-            "outputs": outputs,
+            "results": results,
             "proposal": proposal,
             "images": images or [],
         }


### PR DESCRIPTION
## Summary
- wire app to orchestrator routing helpers and log registered agents
- normalize planner output, route every task, and log final routed count
- persist idea, full plan, results, and proposal to Firestore and update memory manager

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a394a26ed4832cac1ed4199d6d6310