### PR TITLE
Unify agent registry and add audit tooling

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -37,13 +37,13 @@ from dr_rd.utils.llm_client import llm_call, METER, set_budget_manager
 from app.ui_cost_meter import render_cost_summary, render_estimator
 from app.lite_runner import render_lite
 from app.config_loader import load_mode
-from core.agents.registry import build_agents
+from core.agents.unified_registry import build_agents_unified
+from config.agent_models import AGENT_MODEL_MAP
 from orchestrators.plan_utils import normalize_plan_to_tasks
 from orchestrators.router import choose_agent_for_task
 from core.plan_utils import normalize_tasks
 from agents.planner_agent import PlannerAgent
 from agents.synthesizer import SynthesizerAgent
-from config.agent_models import AGENT_MODEL_MAP
 
 logger = logging.getLogger(__name__)
 
@@ -94,12 +94,13 @@ def setup_logging():
 @cache_resource
 def get_agents():
     """Create and return the initialized agents using the core registry."""
-    agents = build_agents()
+    default_model = AGENT_MODEL_MAP.get("DEFAULT") if isinstance(AGENT_MODEL_MAP, dict) else None
+    agents = build_agents_unified(AGENT_MODEL_MAP if isinstance(AGENT_MODEL_MAP, dict) else {}, default_model)
     agents["Planner"] = PlannerAgent(AGENT_MODEL_MAP.get("Planner", "gpt-4o"))
     agents["Synthesizer"] = SynthesizerAgent(
         AGENT_MODEL_MAP.get("Synthesizer", "gpt-4o")
     )
-    logger.info("Registered agents: %s", sorted(agents.keys()))
+    logger.info("Registered agents (unified): %s", sorted(agents.keys()))
     return agents
 
 

--- a/core/agents/unified_registry.py
+++ b/core/agents/unified_registry.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+from typing import Dict, Tuple, Iterable
+import importlib, pkgutil, inspect, logging
+
+log = logging.getLogger("unified_registry")
+
+# Light alias map so synonyms converge
+ALIASES = {
+    "research": "Research Scientist",
+    "research scientist": "Research Scientist",
+    "regulatory & compliance lead": "Regulatory",
+    "chief technology officer": "CTO",
+    "marketing": "Marketing Analyst",
+    "ip": "IP Analyst",
+}
+
+def _canon(name: str) -> str:
+    if not name: return ""
+    key = name.strip()
+    low = key.lower()
+    return ALIASES.get(low, key)
+
+def _iter_agent_classes(pkg_mod) -> Iterable[Tuple[str, type]]:
+    """Yield (role_name, class) for classes that look like agents."""
+    base = pkg_mod.__name__
+    for _, modname, _ in pkgutil.walk_packages(pkg_mod.__path__, base + "."):
+        try:
+            m = importlib.import_module(modname)
+        except Exception:
+            continue
+        for _, obj in inspect.getmembers(m, inspect.isclass):
+            if not obj.__module__.startswith(m.__name__):
+                continue
+            # Heuristic: must have a .run(...) method
+            if not hasattr(obj, "run"):
+                continue
+            role = getattr(obj, "ROLE", None) or getattr(obj, "NAME", None) or getattr(obj, "__name__", None)
+            if isinstance(role, str) and role:
+                yield _canon(role), obj
+
+def _discover_legacy() -> Dict[str, type]:
+    found: Dict[str, type] = {}
+    for pkg_name in ("agents", "dr_rd.agents"):
+        try:
+            pkg = importlib.import_module(pkg_name)
+        except Exception:
+            continue
+        for role, cls in _iter_agent_classes(pkg):
+            # keep first occurrence; core will override later
+            found.setdefault(role, cls)
+    return found
+
+def build_agents_unified(agent_model_map: Dict[str, str], default_model: str | None = None) -> Dict[str, object]:
+    """
+    Prefer core agents; backfill with any legacy agents discovered in /agents and /dr_rd/agents.
+    Returns {role: agent_instance}.
+    """
+    # 1) Start with core registry
+    from core.agents.registry import build_agents as _build_core
+    agents = _build_core()
+
+    # 2) Backfill: if canonical keys are missing but legacy classes exist, instantiate them
+    legacy = _discover_legacy()
+    for role, cls in legacy.items():
+        if role in agents:
+            continue
+        try:
+            model = agent_model_map.get(role, default_model)
+            agents[role] = cls(model) if model is not None else cls()
+        except Exception as e:
+            log.warning("Could not instantiate legacy agent %s: %s", role, e)
+
+    # 3) Provide common alias keys to avoid planner/registry mismatch
+    if "Regulatory" not in agents and "Regulatory & Compliance Lead" in agents:
+        agents["Regulatory"] = agents["Regulatory & Compliance Lead"]
+    if "Research Scientist" not in agents and "Research" in agents:
+        agents["Research Scientist"] = agents["Research"]
+    if "CTO" not in agents and "AI R&D Coordinator" in agents:
+        agents["CTO"] = agents["AI R&D Coordinator"]
+
+    return agents

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,6 @@
+# Agents layout
+- core/agents: canonical executable agents + registry used at runtime.
+- agents: UI-only wrappers (PlannerAgent, SynthesizerAgent) and any view helpers.
+- dr_rd/agents: deprecated shim that re-exports core agents.
+
+The app builds agents via core/agents/unified_registry.build_agents_unified(...). The HRM “Pro” loop runs through orchestrators/router + orchestrators/plan_utils.

--- a/dr_rd/agents/__init__.py
+++ b/dr_rd/agents/__init__.py
@@ -1,1 +1,10 @@
-"""DR-RD agent proxies."""
+"""
+Deprecated shim. Import from core.agents.*. This package remains for backward compatibility.
+"""
+
+import warnings as _w
+_w.warn("dr_rd/agents is deprecated; use core.agents.*", DeprecationWarning, stacklevel=2)
+try:
+    from core.agents.registry import build_agents as build_agents  # re-export
+except Exception:
+    pass

--- a/scripts/audit_agents.py
+++ b/scripts/audit_agents.py
@@ -1,0 +1,19 @@
+import json, importlib, pkgutil, inspect
+paths = ["core.agents", "agents", "dr_rd.agents"]
+inventory = {}
+def collect(pkg_name):
+    try:
+        pkg = importlib.import_module(pkg_name)
+    except Exception:
+        return
+    for _, modname, _ in pkgutil.walk_packages(pkg.__path__, pkg_name + "."):
+        try:
+            m = importlib.import_module(modname)
+        except Exception:
+            continue
+        for _, obj in inspect.getmembers(m, inspect.isclass):
+            if getattr(obj, "run", None):
+                role = getattr(obj, "ROLE", None) or getattr(obj, "NAME", None) or obj.__name__
+                inventory.setdefault(pkg_name, []).append({"role": role, "class": f"{obj.__module__}.{obj.__name__}"})
+for p in paths: collect(p)
+print(json.dumps(inventory, indent=2))


### PR DESCRIPTION
## Summary
- Introduce unified agent registry that merges core and legacy agents with alias support
- Add audit script and architecture doc to clarify agent layout
- Switch app initialization to use unified registry and deprecate old dr_rd agent package

## Testing
- `python -m py_compile core/agents/unified_registry.py scripts/audit_agents.py dr_rd/agents/__init__.py app/__init__.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a399a97664832cb3af23b529626e45