### PR TITLE
feat: robust planner parsing and prompt fixes

### DIFF
--- a/agents/planner_agent.py
+++ b/agents/planner_agent.py
@@ -17,14 +17,15 @@ except Exception:  # pragma: no cover
 log = logging.getLogger(__name__)
 
 SYSTEM_PROMPT = (
-  "You are the Creation Planner. Output ONLY valid JSON as a single array.\n"
-  "[{\"role\":\"<one of: CTO, Research Scientist, Regulatory, Finance, Marketing Analyst, IP Analyst>\",""title\":\"...\",\"description\":\"...\"}]\n"
-  "Rules:\n"
-  "- Return 8–12 tasks total.\n"
-  "- Include AT LEAST one task for EACH of the six roles.\n"
-  "- Roles MUST be exactly one of those six.\n"
-  "- Titles are short imperatives; descriptions are concise and specific.\n"
-  "- No prose. No backticks. JSON array only."
+    "You are the Creation Planner. Output ONLY valid JSON as a single array.\n"
+    "[{\"role\":\"<one of: CTO, Research Scientist, Regulatory, Finance, Marketing Analyst, IP Analyst>\","\
+    "\"title\":\"...\",\"description\":\"...\"}]\n"
+    "Rules:\n"
+    "- Return 8–12 tasks total.\n"
+    "- Include AT LEAST one task for EACH of the six roles.\n"
+    "- Roles MUST be exactly one of those six.\n"
+    "- Titles are short imperatives; descriptions are concise and specific.\n"
+    "- No prose. No backticks. JSON array only."
 )
 
 

--- a/orchestrators/plan_utils.py
+++ b/orchestrators/plan_utils.py
@@ -1,35 +1,112 @@
-from typing import List, Dict, Any
+from typing import Any, Dict, List
+import json
+
+_CANON = {"CTO", "Research Scientist", "Regulatory", "Finance", "Marketing Analyst", "IP Analyst"}
+_ALIAS = {
+    "chief technology officer": "CTO",
+    "research": "Research Scientist",
+    "research scientist": "Research Scientist",
+    "regulatory & compliance lead": "Regulatory",
+    "compliance": "Regulatory",
+    "legal": "Regulatory",
+    "marketing": "Marketing Analyst",
+    "ip": "IP Analyst",
+    "ip analyst": "IP Analyst",
+    "intellectual property": "IP Analyst",
+}
 
 
-def normalize_plan_to_tasks(plan: Any) -> List[Dict]:
-    """
-    Normalize Planner output to a list of {role,title,description,tags}
-    Accepts:
-      A) dict: role -> list[{title,description}|str]
-      B) list of {role,title,description[,tags]}
-    """
-    tasks: List[Dict] = []
-    if isinstance(plan, dict):
-        for role, items in (plan or {}).items():
-            for it in (items or []):
-                if isinstance(it, str):
-                    tasks.append({"role": role, "title": it, "description": it, "tags": []})
-                else:
-                    tasks.append({
-                        "role": role,
-                        "title": it.get("title") or it.get("task") or "",
-                        "description": it.get("description") or it.get("details") or it.get("title") or "",
-                        "tags": it.get("tags", []) if isinstance(it, dict) else [],
-                    })
-    elif isinstance(plan, list):
-        for it in plan:
-            tasks.append({
-                "role": it.get("role",""),
-                "title": it.get("title") or it.get("task") or "",
-                "description": it.get("description") or it.get("details") or it.get("title") or "",
-                "tags": it.get("tags", []) if isinstance(it, dict) else [],
-            })
-    else:
-        raise ValueError("Planner returned unexpected plan type")
-    # remove empties
-    return [t for t in tasks if (t["title"] or t["description"])]
+def _canon_role(name: str) -> str | None:
+    if not name:
+        return None
+    n = name.strip()
+    k = n.lower()
+    r = _ALIAS.get(k, n)
+    return r if r in _CANON else None
+
+
+def _is_task(d: Any) -> bool:
+    return isinstance(d, dict) and all(
+        isinstance(d.get(k, ""), str) and d.get(k, "").strip() for k in ("role", "title", "description")
+    )
+
+
+def _coerce(raw: Any) -> Any:
+    if isinstance(raw, (dict, list)):
+        return raw
+    if isinstance(raw, str):
+        try:
+            return json.loads(raw)
+        except Exception:
+            try:
+                s = raw[raw.index("{") : raw.rindex("}") + 1]
+                return json.loads(s)
+            except Exception:
+                return []
+    return []
+
+
+def normalize_plan_to_tasks(raw: Any, backfill: bool = True, dedupe: bool = True) -> List[Dict[str, str]]:
+    obj = _coerce(raw)
+    tasks: List[Dict[str, str]] = []
+
+    # Case B: already a list of tasks
+    if isinstance(obj, list):
+        for it in obj:
+            if _is_task(it):
+                role = _canon_role(it["role"])
+                if role:
+                    tasks.append(
+                        {"role": role, "title": it["title"].strip(), "description": it["description"].strip()}
+                    )
+        return _post(tasks, backfill, dedupe)
+
+    # Single-object task -> wrap
+    if _is_task(obj):
+        role = _canon_role(obj["role"])
+        if role:
+            tasks.append(
+                {"role": role, "title": obj["title"].strip(), "description": obj["description"].strip()}
+            )
+        return _post(tasks, backfill, dedupe)
+
+    # Case A: {"Role":[{title,description},...], ...}
+    if isinstance(obj, dict):
+        for role_key, items in obj.items():
+            role = _canon_role(str(role_key))
+            if not role:
+                continue
+            if not isinstance(items, list):  # critical guard: do not iterate strings
+                continue
+            for it in items:
+                if isinstance(it, dict):
+                    t = (it.get("title") or "").strip()
+                    d = (it.get("description") or "").strip()
+                    if t and d:
+                        tasks.append({"role": role, "title": t, "description": d})
+    return _post(tasks, backfill, dedupe)
+
+
+def _post(tasks: List[Dict[str, str]], backfill: bool, dedupe: bool) -> List[Dict[str, str]]:
+    if dedupe:
+        seen = set()
+        uniq = []
+        for t in tasks:
+            k = (t["role"], t["title"])
+            if k in seen:
+                continue
+            seen.add(k)
+            uniq.append(t)
+        tasks = uniq
+    if backfill:
+        present = {t["role"] for t in tasks}
+        for miss in sorted(_CANON - present):
+            tasks.append(
+                {
+                    "role": miss,
+                    "title": f"Define initial {miss} workplan",
+                    "description": f"Draft first actionable tasks for {miss} to advance the project.",
+                }
+            )
+    return tasks
+

--- a/tests/test_plan_utils_normalize.py
+++ b/tests/test_plan_utils_normalize.py
@@ -1,0 +1,30 @@
+from orchestrators.plan_utils import normalize_plan_to_tasks
+
+
+def test_single_object_wraps():
+    raw = {"role": "CTO", "title": "Plan", "description": "Design"}
+    tasks = normalize_plan_to_tasks(raw, backfill=False, dedupe=False)
+    assert len(tasks) == 1
+    assert tasks[0]["role"] == "CTO"
+
+
+def test_dict_a_ignores_strings():
+    raw = {
+        "CTO": [{"title": "Do", "description": "Thing"}],
+        "Finance": "ignored",
+    }
+    tasks = normalize_plan_to_tasks(raw, backfill=False, dedupe=False)
+    assert len(tasks) == 1
+    assert tasks[0]["role"] == "CTO"
+
+
+def test_array_b_canonicalizes_and_dedupes():
+    raw = [
+        {"role": "chief technology officer", "title": "a", "description": "b"},
+        {"role": "CTO", "title": "a", "description": "b"},
+        {"role": "marketing", "title": "m", "description": "d"},
+    ]
+    tasks = normalize_plan_to_tasks(raw, backfill=False, dedupe=True)
+    assert len(tasks) == 2
+    roles = {t["role"] for t in tasks}
+    assert roles == {"CTO", "Marketing Analyst"}

--- a/utils/plan_normalizer.py
+++ b/utils/plan_normalizer.py
@@ -11,10 +11,12 @@ def _normalize_plan_to_tasks(plan) -> List[Dict[str, str]]:
     tasks: List[Dict[str, str]] = []
     if isinstance(plan, dict):
         for role, items in plan.items():
+            if not isinstance(items, list):
+                continue
             for it in items or []:
                 if isinstance(it, str):
                     tasks.append({"role": role, "title": it, "description": it})
-                else:
+                elif isinstance(it, dict):
                     tasks.append(
                         {
                             "role": role,


### PR DESCRIPTION
## Summary
- fix planner system prompt to emit valid JSON
- harden plan normalization with role aliases, dedupe, and backfill
- use normalized tasks in UI with logging and default model fallback

## Testing
- `pytest tests/test_plan_utils_normalize.py tests/test_plan_routing.py -q`
- `pytest tests/test_planner_normalize.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a39e61ae88832c9cac4277a72eb8bf