### PR TITLE
feat: unify agent registry and planning

### DIFF
--- a/agents/planner_agent.py
+++ b/agents/planner_agent.py
@@ -24,7 +24,7 @@ SYSTEM = (
     "- Return 8–12 tasks total.\n"
     "- Include AT LEAST one task for EACH of the six roles.\n"
     "- Roles MUST be exactly one of those six.\n"
-    "- Titles are short imperatives; descriptions are concise and specific.\n"
+    "- Titles are short imperatives; descriptions concise and specific.\n"
     "- No prose. No backticks. JSON array only."
 )
 

--- a/app/init.py
+++ b/app/init.py
@@ -1,0 +1,62 @@
+import logging
+from core.agents.unified_registry import build_agents_unified, ensure_canonical_agent_keys, choose_agent_for_task
+from core.plan_utils import normalize_plan_to_tasks, normalize_tasks
+from core.roles import canonical_roles
+
+logger = logging.getLogger(__name__)
+
+
+def get_agents():
+    agents = build_agents_unified()
+    agents = ensure_canonical_agent_keys(agents)
+    logger.info("Registered agents (unified): %s", sorted(agents.keys()))
+    return agents
+
+FALLBACK_ORDER = ["Research Scientist","Research","AI R&D Coordinator","Mechanical Systems Lead"]
+
+def _pick_default_agent(agents: dict):
+    for k in FALLBACK_ORDER:
+        if k in agents:
+            return k, agents[k]
+    k = next(iter(agents.keys()))
+    return k, agents[k]
+
+
+def route_tasks(tasks_any, agents):
+    agents = ensure_canonical_agent_keys(agents)
+    tasks = normalize_tasks(normalize_plan_to_tasks(tasks_any))
+    routed = []
+    for t in tasks:
+        role = t["role"]; title = t["title"]; desc = t["description"]
+        try:
+            rr, agent = choose_agent_for_task(role, title, desc, agents)
+        except TypeError:
+            agent, rr = choose_agent_for_task(role, title, agents)
+        if not agent:
+            low = (title + " " + desc).lower()
+            agent = agents.get("Marketing Analyst") if "market" in low else None
+            rr = "Marketing Analyst" if agent else role
+        if not agent:
+            rr, agent = _pick_default_agent(agents)
+        routed.append((rr, agent, t))
+    return routed
+
+
+def classic_execute(tasks, idea, agents):
+    outputs = {}
+    routed = route_tasks(tasks, agents)
+    logger.info("Planner routing: %s", [{"from": t["role"], "to": rr} for rr, _, t in routed])
+    logger.info("Final routed task count: %d", len(routed))
+
+    for rr, agent, t in routed:
+        try:
+            out = agent.run(idea, {"role": rr, "title": t["title"], "description": t["description"]})
+        except Exception as e:
+            logger.exception("Agent %s failed: %s", rr, e)
+            out = {"error": str(e)}
+        outputs.setdefault(rr, []).append({
+            "title": t["title"],
+            "description": t["description"],
+            "output": out,
+        })
+    return outputs

--- a/core/agents/cto.py
+++ b/core/agents/cto.py
@@ -1,0 +1,1 @@
+from agents.cto_agent import CTOAgent  # re-export for canonical path

--- a/core/agents/finance.py
+++ b/core/agents/finance.py
@@ -1,0 +1,14 @@
+from agents.base_agent import BaseAgent
+
+class FinanceAgent(BaseAgent):
+    """Financial analyst for budgeting and cost estimates."""
+
+    def __init__(self, model: str):
+        super().__init__(
+            name="Finance",
+            model=model,
+            system_message="You evaluate budgets, BOM costs and financial risks.",
+            user_prompt_template=(
+                "Project Idea: {idea}\nAs the Finance lead, your task is {task}."
+            ),
+        )

--- a/core/agents/ip_analyst.py
+++ b/core/agents/ip_analyst.py
@@ -1,0 +1,1 @@
+from agents.ip_analyst_agent import IPAnalystAgent  # re-export

--- a/core/agents/marketing.py
+++ b/core/agents/marketing.py
@@ -1,0 +1,1 @@
+from agents.marketing_agent import MarketingAgent  # re-export

--- a/core/agents/regulatory.py
+++ b/core/agents/regulatory.py
@@ -1,0 +1,1 @@
+from agents.regulatory_agent import RegulatoryAgent  # re-export

--- a/core/agents/research_scientist.py
+++ b/core/agents/research_scientist.py
@@ -1,0 +1,1 @@
+from agents.research_scientist_agent import ResearchScientistAgent  # re-export

--- a/core/roles.py
+++ b/core/roles.py
@@ -1,0 +1,31 @@
+from typing import Optional, Set
+
+CANONICAL = {
+    "cto": "CTO",
+    "chief technology officer": "CTO",
+
+    "research scientist": "Research Scientist",
+    "research": "Research Scientist",
+
+    "regulatory": "Regulatory",
+    "regulatory & compliance lead": "Regulatory",
+    "compliance": "Regulatory",
+    "legal": "Regulatory",
+
+    "finance": "Finance",
+
+    "marketing analyst": "Marketing Analyst",
+    "marketing": "Marketing Analyst",
+
+    "ip analyst": "IP Analyst",
+    "intellectual property": "IP Analyst",
+    "ip": "IP Analyst",
+}
+
+def normalize_role(name: Optional[str]) -> Optional[str]:
+    if not name:
+        return None
+    return CANONICAL.get(name.strip().lower())
+
+def canonical_roles() -> Set[str]:
+    return {"CTO","Research Scientist","Regulatory","Finance","Marketing Analyst","IP Analyst"}


### PR DESCRIPTION
## Summary
- add canonical roles and plan normalization utilities
- centralize agent registry and model selection
- update base agent to log chosen model and support dict tasks
- tighten planner output format and add routing helpers

## Testing
- `pytest` *(fails: tests cannot collect due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a3addf08bc832caf260360915050fe