### PR TITLE
Fix agent registry circular import and normalize plan inputs

### DIFF
--- a/agents/base_agent.py
+++ b/agents/base_agent.py
@@ -10,8 +10,6 @@ from config.feature_flags import (
 )
 import logging
 import streamlit as st
-
-from core.agents.unified_registry import resolve_model
 from dr_rd.utils.llm_client import llm_call, log_usage
 
 logger = logging.getLogger(__name__)
@@ -146,6 +144,7 @@ class BaseAgent:
             )
 
         # Call OpenAI via llm_client
+        from core.agents.unified_registry import resolve_model  # local import to avoid circular
         model_id = self.model or resolve_model(self.name)
         logger.info(f"Model[exec]={model_id} params={{}}")
         response = llm_call(


### PR DESCRIPTION
## Summary
- resolve circular import between BaseAgent and unified_registry
- allow `build_agents_unified` to accept model overrides and default model
- harden plan normalization to handle malformed inputs and canonicalize roles

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3b038f174832cb01e22f17a2f65c7