### PR TITLE
Wire DRRD_MODE, warn on fallback, enforce budget guard, and sweep direct OpenAI calls

### DIFF
--- a/app/config_loader.py
+++ b/app/config_loader.py
@@ -15,6 +15,10 @@ def load_mode(mode: str) -> tuple[dict, BudgetManager]:
 
     with open(modes_path) as fh:
         modes = yaml.safe_load(fh) or {}
+    if mode not in modes:
+        logging.warning(
+            "Requested mode '%s' not found. Falling back to 'test'.", mode
+        )
     mode_cfg = modes.get(mode, modes.get("test", {}))
     weights = mode_cfg.get("stage_weights")
     if isinstance(weights, dict):

--- a/app/safety.py
+++ b/app/safety.py
@@ -1,0 +1,9 @@
+import streamlit as st
+from dr_rd.utils.llm_client import BUDGET
+
+
+def require_budget_or_block():
+    """Ensure a budget manager is installed or stop execution."""
+    if BUDGET is None:
+        st.error("Budget manager not installed. Fix config before running.")
+        st.stop()

--- a/tests/test_agent_output_structure.py
+++ b/tests/test_agent_output_structure.py
@@ -17,11 +17,11 @@ AGENTS = [
 ]
 
 @patch.dict(os.environ, {"OPENAI_API_KEY": "x"})
-@patch('openai.chat.completions.create')
+@patch('agents.base_agent.llm_call')
 @pytest.mark.parametrize("cls", AGENTS)
-def test_agent_output_structure(mock_create, cls):
+def test_agent_output_structure(mock_llm, cls):
     fake_md = "Result\n```json\n{\"key\": 1}\n```"
-    mock_create.return_value = make_openai_response(fake_md)
+    mock_llm.return_value = make_openai_response(fake_md)
     agent = cls("gpt-4o")
     result = agent.run("idea", "task")
     stripped = result.strip()

--- a/tests/test_app_ui.py
+++ b/tests/test_app_ui.py
@@ -1,4 +1,5 @@
 import importlib
+import os
 import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -131,7 +132,16 @@ def test_run_domain_experts(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "x")
     patches = {
         "agents.base_agent.BaseAgent.run": lambda self, idea, task, design_depth="Medium": "out",
-        "openai.chat.completions.create": lambda *a, **k: type(
+        "dr_rd.utils.llm_client.llm_call": lambda *a, **k: type(
+            "R",
+            (),
+            {
+                "choices": [
+                    type("C", (), {"message": type("M", (), {"content": "out"})()})
+                ]
+            },
+        )(),
+        "agents.synthesizer.llm_call": lambda *a, **k: type(
             "R",
             (),
             {

--- a/tests/test_budget_guard.py
+++ b/tests/test_budget_guard.py
@@ -1,0 +1,12 @@
+from unittest.mock import MagicMock
+from tests.test_app_ui import make_streamlit, reload_app
+import dr_rd.utils.llm_client as lc
+
+
+def test_budget_guard(monkeypatch):
+    st = make_streamlit("", {}, raise_on_stop=True)
+    st.error = MagicMock()
+    monkeypatch.setattr(lc, "set_budget_manager", lambda _: None)
+    monkeypatch.setattr(lc, "BUDGET", None, raising=False)
+    reload_app(monkeypatch, st, expect_exit=True)
+    st.error.assert_called_once_with("Budget manager not installed. Fix config before running.")

--- a/tests/test_mode_env.py
+++ b/tests/test_mode_env.py
@@ -1,0 +1,18 @@
+from unittest.mock import MagicMock
+from tests.test_app_ui import make_streamlit, reload_app
+
+
+def test_env_selects_fast(monkeypatch):
+    st = make_streamlit("", {}, raise_on_stop=True)
+    monkeypatch.setenv("DRRD_MODE", "fast")
+    reload_app(monkeypatch, st, expect_exit=True)
+    assert st.session_state["MODE_CFG"]["models"]["plan"] == "gpt-4o-mini"
+
+
+def test_env_invalid_warns(monkeypatch):
+    st = make_streamlit("", {}, raise_on_stop=True)
+    st.warning = MagicMock()
+    monkeypatch.setenv("DRRD_MODE", "bogus")
+    reload_app(monkeypatch, st, expect_exit=True)
+    st.warning.assert_called_once_with("Unknown mode: bogus. Falling back to test.")
+    assert st.session_state["MODE_CFG"]["models"]["plan"] == "gpt-3.5-turbo"

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -8,16 +8,16 @@ def make_openai_response(text: str):
     return Mock(choices=[mock_choice])
 
 
-@patch("agents.orchestrator.openai")
-def test_needs_follow_up_returns_none(mock_openai):
-    mock_openai.chat.completions.create.return_value = make_openai_response("COMPLETE")
+@patch("agents.orchestrator.llm_call")
+def test_needs_follow_up_returns_none(mock_llm):
+    mock_llm.return_value = make_openai_response("COMPLETE")
     result = orch._needs_follow_up("Physics", "task", "answer")
     assert result is None
 
 
-@patch("agents.orchestrator.openai")
-def test_needs_follow_up_returns_question(mock_openai):
-    mock_openai.chat.completions.create.return_value = make_openai_response(
+@patch("agents.orchestrator.llm_call")
+def test_needs_follow_up_returns_question(mock_llm):
+    mock_llm.return_value = make_openai_response(
         "Please clarify"
     )
     result = orch._needs_follow_up("Physics", "task", "answer")
@@ -26,9 +26,9 @@ def test_needs_follow_up_returns_question(mock_openai):
 
 @patch("agents.orchestrator.route")
 @patch("agents.orchestrator.obfuscate_task")
-@patch("agents.orchestrator.openai")
-def test_refine_once_no_follow_up(mock_openai, mock_obfuscate, mock_route):
-    mock_openai.chat.completions.create.return_value = make_openai_response("COMPLETE")
+@patch("agents.orchestrator.llm_call")
+def test_refine_once_no_follow_up(mock_llm, mock_obfuscate, mock_route):
+    mock_llm.return_value = make_openai_response("COMPLETE")
     plan = {"Physics": "task1"}
     answers = {"Physics": "answer1"}
     result = orch.refine_once(plan, answers)
@@ -39,9 +39,9 @@ def test_refine_once_no_follow_up(mock_openai, mock_obfuscate, mock_route):
 
 @patch("agents.orchestrator.route", return_value="extra info")
 @patch("agents.orchestrator.obfuscate_task", return_value="obf")
-@patch("agents.orchestrator.openai")
-def test_refine_once_with_follow_up(mock_openai, mock_obfuscate, mock_route):
-    mock_openai.chat.completions.create.return_value = make_openai_response(
+@patch("agents.orchestrator.llm_call")
+def test_refine_once_with_follow_up(mock_llm, mock_obfuscate, mock_route):
+    mock_llm.return_value = make_openai_response(
         "More details?"
     )
     plan = {"Chemistry": "task2"}

--- a/tests/test_planner_agent.py
+++ b/tests/test_planner_agent.py
@@ -10,35 +10,35 @@ def make_openai_response(text: str):
 
 
 @patch.dict(os.environ, {"OPENAI_API_KEY": "x"})
-@patch('agents.planner_agent.openai.chat.completions.create')
-def test_planner_agent_returns_dict_without_response_format(mock_create):
+@patch('agents.planner_agent.llm_call')
+def test_planner_agent_returns_dict_without_response_format(mock_llm):
     """Legacy models should not receive the response_format parameter."""
-    mock_create.return_value = make_openai_response('{"X": "Y"}')
+    mock_llm.return_value = make_openai_response('{"X": "Y"}')
     agent = PlannerAgent("gpt-4")
     result = agent.run('idea', 'task')
 
     assert result == {"X": "Y"}
     # Ensure response_format was not supplied for unsupported models
-    _, kwargs = mock_create.call_args
+    _, kwargs = mock_llm.call_args
     assert "response_format" not in kwargs
 
 
 @patch.dict(os.environ, {"OPENAI_API_KEY": "x"})
-@patch('agents.planner_agent.openai.chat.completions.create')
-def test_planner_agent_uses_response_format_for_new_models(mock_create):
-    mock_create.return_value = make_openai_response('{"X": "Y"}')
+@patch('agents.planner_agent.llm_call')
+def test_planner_agent_uses_response_format_for_new_models(mock_llm):
+    mock_llm.return_value = make_openai_response('{"X": "Y"}')
     agent = PlannerAgent("gpt-4o-mini")
     agent.run('idea', 'task')
 
-    _, kwargs = mock_create.call_args
+    _, kwargs = mock_llm.call_args
     assert kwargs.get("response_format") == {"type": "json_object"}
 
 
 @patch.dict(os.environ, {"OPENAI_API_KEY": "x"})
-@patch('agents.planner_agent.openai.chat.completions.create')
-def test_planner_agent_handles_truncated_json(mock_create):
+@patch('agents.planner_agent.llm_call')
+def test_planner_agent_handles_truncated_json(mock_llm):
     text = '{ "A": "B", "C": "D", "E": "F'
-    mock_create.return_value = make_openai_response(text)
+    mock_llm.return_value = make_openai_response(text)
     agent = PlannerAgent("gpt-4o")
     result = agent.run('idea', 'task')
 

--- a/tests/test_planner_output.py
+++ b/tests/test_planner_output.py
@@ -16,9 +16,9 @@ ALLOWED_ROLES = set(AGENT_MODEL_MAP.keys()) - {"Planner", "Synthesizer"}
 
 
 @patch.dict(os.environ, {"OPENAI_API_KEY": "x"})
-@patch('agents.planner_agent.openai.chat.completions.create')
-def test_planner_output_validity(mock_create):
-    mock_create.return_value = make_openai_response('{"Mechanical Systems Lead": "Design the frame"}')
+@patch('agents.planner_agent.llm_call')
+def test_planner_output_validity(mock_llm):
+    mock_llm.return_value = make_openai_response('{"Mechanical Systems Lead": "Design the frame"}')
     agent = PlannerAgent("gpt-4o")
     result = agent.run("a quantum entangled laser alignment tool with an FPGA controller", "Develop a plan")
 

--- a/tests/test_planner_remediation.py
+++ b/tests/test_planner_remediation.py
@@ -12,9 +12,9 @@ def make_openai_response(text: str):
 
 
 @patch.dict(os.environ, {"OPENAI_API_KEY": "x"})
-@patch('agents.planner_agent.openai.chat.completions.create')
-def test_planner_adds_remediation_task(mock_create):
-    mock_create.return_value = make_openai_response('{"updated_tasks": []}')
+@patch('agents.planner_agent.llm_call')
+def test_planner_adds_remediation_task(mock_llm):
+    mock_llm.return_value = make_openai_response('{"updated_tasks": []}')
     agent = PlannerAgent("gpt-4o-mini")
     workspace = {"tasks": [], "scorecard": {"overall": EVALUATOR_MIN_OVERALL - 0.1, "metrics": {}}}
     tasks = agent.revise_plan(workspace)

--- a/tests/test_rag_prompt.py
+++ b/tests/test_rag_prompt.py
@@ -15,9 +15,9 @@ def make_openai_response(text: str):
 
 
 @patch.dict(os.environ, {"OPENAI_API_KEY": "x"})
-@patch("openai.chat.completions.create")
-def test_rag_included_when_enabled(mock_create, monkeypatch):
-    mock_create.return_value = make_openai_response("ok")
+@patch("dr_rd.utils.llm_client.llm_call")
+def test_rag_included_when_enabled(mock_llm, monkeypatch):
+    mock_llm.return_value = make_openai_response("ok")
     monkeypatch.setenv("RAG_ENABLED", "true")
     monkeypatch.setenv("RAG_TOPK", "2")
     import config.feature_flags as ff
@@ -26,16 +26,16 @@ def test_rag_included_when_enabled(mock_create, monkeypatch):
     importlib.reload(ba)
     agent = ba.BaseAgent("Test", "gpt-4o", "sys", "Task: {task}", retriever=StubRetriever())
     agent.run("idea", "do something")
-    prompt = mock_create.call_args.kwargs["messages"][1]["content"]
+    prompt = mock_llm.call_args.kwargs["messages"][1]["content"]
     assert "# RAG Knowledge" in prompt
     assert "alpha data" in prompt
     assert "(alpha.txt)" in prompt
 
 
 @patch.dict(os.environ, {"OPENAI_API_KEY": "x"})
-@patch("openai.chat.completions.create")
-def test_rag_skipped_when_disabled(mock_create, monkeypatch):
-    mock_create.return_value = make_openai_response("ok")
+@patch("dr_rd.utils.llm_client.llm_call")
+def test_rag_skipped_when_disabled(mock_llm, monkeypatch):
+    mock_llm.return_value = make_openai_response("ok")
     monkeypatch.setenv("RAG_ENABLED", "false")
     import config.feature_flags as ff
     importlib.reload(ff)
@@ -43,14 +43,14 @@ def test_rag_skipped_when_disabled(mock_create, monkeypatch):
     importlib.reload(ba)
     agent = ba.BaseAgent("Test", "gpt-4o", "sys", "Task: {task}", retriever=StubRetriever())
     agent.run("idea", "do something")
-    prompt = mock_create.call_args.kwargs["messages"][1]["content"]
+    prompt = mock_llm.call_args.kwargs["messages"][1]["content"]
     assert "# RAG Knowledge" not in prompt
 
 
 @patch.dict(os.environ, {"OPENAI_API_KEY": "x"})
-@patch("openai.chat.completions.create")
-def test_rag_snippet_token_truncation(mock_create, monkeypatch):
-    mock_create.return_value = make_openai_response("ok")
+@patch("dr_rd.utils.llm_client.llm_call")
+def test_rag_snippet_token_truncation(mock_llm, monkeypatch):
+    mock_llm.return_value = make_openai_response("ok")
     monkeypatch.setenv("RAG_ENABLED", "true")
     monkeypatch.setenv("RAG_TOPK", "1")
     monkeypatch.setenv("RAG_SNIPPET_TOKENS", "3")
@@ -65,6 +65,6 @@ def test_rag_snippet_token_truncation(mock_create, monkeypatch):
     importlib.reload(ba)
     agent = ba.BaseAgent("Test", "gpt-4o", "sys", "Task: {task}", retriever=LongRetriever())
     agent.run("idea", "do something")
-    prompt = mock_create.call_args.kwargs["messages"][1]["content"]
+    prompt = mock_llm.call_args.kwargs["messages"][1]["content"]
     assert "one two three" in prompt
     assert "four" not in prompt

--- a/tests/test_synthesizer.py
+++ b/tests/test_synthesizer.py
@@ -12,15 +12,15 @@ def make_openai_response(text: str):
 
 @patch.dict(os.environ, {"OPENAI_API_KEY": "x"})
 @patch("agents.synthesizer.make_visuals_for_project", return_value=[{"kind": "schematic", "url": "u", "caption": "S"}])
-@patch('agents.synthesizer.openai.chat.completions.create')
-def test_compose_final_proposal(mock_create, _mock_vis):
+@patch('agents.synthesizer.llm_call')
+def test_compose_final_proposal(mock_llm, _mock_vis):
     fake_response = (
         "## Executive Summary\nOverview\n\n"
         "## Bill of Materials\n|Component|Quantity|Specs|\n|---|---|---|\n|Part|1|Spec|\n\n"
         "## Step-by-Step Instructions\n1. Do X\n\n"
         "## Simulation & Test Results\nNone"
     )
-    mock_create.return_value = make_openai_response(fake_response)
+    mock_llm.return_value = make_openai_response(fake_response)
     answers = {
         "Mechanical Systems Lead": "design",
         "Optical Systems Engineer": "optics",


### PR DESCRIPTION
## Summary
- Preselect run mode via `DRRD_MODE` and warn on unknown values
- Warn and fallback when a requested mode is missing from YAML
- Enforce presence of a budget manager and replace remaining direct OpenAI calls with `llm_call`
- Add tests for environment-mode selection and budget guard

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3c0534d68832cb7f37c7e63a4b2e0