### PR TITLE
Orchestrator overhaul: dynamic agents, iteration loop, role-persona system prompts, final synthesis

### DIFF
--- a/agents/base_agent.py
+++ b/agents/base_agent.py
@@ -11,8 +11,21 @@ from config.feature_flags import (
 import logging
 import streamlit as st
 from dr_rd.utils.llm_client import llm_call, log_usage
+from core.llm import make_chat
 
 logger = logging.getLogger(__name__)
+
+
+class LLMRoleAgent:
+    """Minimal LLM-backed agent used by the new orchestrator."""
+
+    def __init__(self, name: str, model: str):
+        self.name = name
+        self.model = model
+
+    def act(self, system_prompt: str, user_prompt: str) -> str:
+        """Call the model with a system and user prompt."""
+        return make_chat(self.model, system_prompt, user_prompt)
 
 try:  # avoid import errors when knowledge package is absent
     from dr_rd.knowledge.retriever import Retriever

--- a/agents/chief_scientist_agent.py
+++ b/agents/chief_scientist_agent.py
@@ -1,0 +1,6 @@
+from agents.base_agent import LLMRoleAgent
+
+
+class ChiefScientistAgent(LLMRoleAgent):
+    def __init__(self, model: str):
+        super().__init__("ChiefScientist", model)

--- a/agents/cto_agent.py
+++ b/agents/cto_agent.py
@@ -1,4 +1,4 @@
-from agents.base_agent import BaseAgent
+from agents.base_agent import BaseAgent, LLMRoleAgent
 
 """CTO Agent for technical strategy and overview."""
 class CTOAgent(BaseAgent):
@@ -21,3 +21,8 @@ class CTOAgent(BaseAgent):
                 "Conclude with a JSON list of key technical decisions and resource requirements."
             ),
         )
+
+
+class SimpleCTOAgent(LLMRoleAgent):
+    def __init__(self, model: str):
+        super().__init__("CTO", model)

--- a/agents/hrm_agent.py
+++ b/agents/hrm_agent.py
@@ -1,0 +1,6 @@
+from agents.base_agent import LLMRoleAgent
+
+
+class HRMAgent(LLMRoleAgent):
+    def __init__(self, model: str):
+        super().__init__("HRM", model)

--- a/agents/materials_engineer_agent.py
+++ b/agents/materials_engineer_agent.py
@@ -1,0 +1,6 @@
+from agents.base_agent import LLMRoleAgent
+
+
+class MaterialsEngineerAgent(LLMRoleAgent):
+    def __init__(self, model: str):
+        super().__init__("MaterialsEngineer", model)

--- a/agents/planner_agent.py
+++ b/agents/planner_agent.py
@@ -1,4 +1,4 @@
-from agents.base_agent import BaseAgent
+from agents.base_agent import BaseAgent, LLMRoleAgent
 import logging
 import openai
 from dr_rd.utils.model_router import pick_model, CallHints
@@ -157,3 +157,10 @@ class PlannerAgent(BaseAgent):
                 remediation.append({"role": "AI R&D Coordinator", "task": "Address evaluation weaknesses"})
         out.extend(remediation)
         return out
+
+
+class LLMPlannerAgent(LLMRoleAgent):
+    """Lightweight planner used by the new orchestrator."""
+
+    def __init__(self, model: str):
+        super().__init__("Planner", model)

--- a/agents/reflection_agent.py
+++ b/agents/reflection_agent.py
@@ -1,0 +1,6 @@
+from agents.base_agent import LLMRoleAgent
+
+
+class ReflectionAgent(LLMRoleAgent):
+    def __init__(self, model: str):
+        super().__init__("Reflection", model)

--- a/agents/regulatory_specialist_agent.py
+++ b/agents/regulatory_specialist_agent.py
@@ -1,0 +1,6 @@
+from agents.base_agent import LLMRoleAgent
+
+
+class RegulatorySpecialistAgent(LLMRoleAgent):
+    def __init__(self, model: str):
+        super().__init__("RegulatorySpecialist", model)

--- a/agents/research_scientist_agent.py
+++ b/agents/research_scientist_agent.py
@@ -1,21 +1,6 @@
-from agents.base_agent import BaseAgent
+from agents.base_agent import LLMRoleAgent
 
-"""Research Scientist Agent for in-depth analysis and experimentation plans."""
-class ResearchScientistAgent(BaseAgent):
-    """Agent that conducts research analysis and proposes experiments for the idea."""
-    def __init__(self, model):
-        super().__init__(
-            name="Research Scientist",
-            model=model,
-            system_message=(
-                "You are a research scientist with expertise in experimental design and literature review. "
-                "You provide in-depth analysis and propose rigorous experiments (with schematics or flow diagrams as needed). "
-                "You justify each experimental approach with scientific reasoning and are ready to refine plans based on simulation or test feedback."
-            ),
-            user_prompt_template=(
-                "Project Idea: {idea}\nAs the Research Scientist, your task is {task}. "
-                "Provide an in-depth analysis in Markdown format, including relevant background research, potential experiments (with experimental setup diagrams if applicable), and expected results. "
-                "Include reasoning for why each experiment or study is needed and how it will validate key aspects of the idea. "
-                "Conclude with a JSON summary of proposed experiments and key findings."
-            ),
-        )
+
+class ResearchScientistAgent(LLMRoleAgent):
+    def __init__(self, model: str):
+        super().__init__("ResearchScientist", model)

--- a/core/agents_registry.py
+++ b/core/agents_registry.py
@@ -1,0 +1,21 @@
+from agents.hrm_agent import HRMAgent
+from agents.planner_agent import LLMPlannerAgent
+from agents.reflection_agent import ReflectionAgent
+from agents.chief_scientist_agent import ChiefScientistAgent
+from agents.cto_agent import SimpleCTOAgent
+from agents.research_scientist_agent import ResearchScientistAgent
+from agents.materials_engineer_agent import MaterialsEngineerAgent
+from agents.regulatory_specialist_agent import RegulatorySpecialistAgent
+
+DEFAULT_MODEL = "gpt-4o-mini"
+
+agents_dict = {
+    "HRM": HRMAgent(DEFAULT_MODEL),
+    "Planner": LLMPlannerAgent(DEFAULT_MODEL),
+    "Reflection": ReflectionAgent(DEFAULT_MODEL),
+    "ChiefScientist": ChiefScientistAgent(DEFAULT_MODEL),
+    "CTO": SimpleCTOAgent(DEFAULT_MODEL),
+    "ResearchScientist": ResearchScientistAgent(DEFAULT_MODEL),
+    "MaterialsEngineer": MaterialsEngineerAgent(DEFAULT_MODEL),
+    "RegulatorySpecialist": RegulatorySpecialistAgent(DEFAULT_MODEL),
+}

--- a/core/llm.py
+++ b/core/llm.py
@@ -1,0 +1,15 @@
+import os
+from openai import OpenAI
+
+
+def make_chat(model: str, system_prompt: str, user_prompt: str) -> str:
+    """Send a single-turn chat completion request and return the content."""
+    client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+    resp = client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+    )
+    return resp.choices[0].message.content

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -1,15 +1,239 @@
-from __future__ import annotations
-
-from typing import Dict, List, Tuple
-
+import json
+import re
 import logging
+from typing import Dict, List, Tuple, Any
+
 import streamlit as st
 from agents.planner_agent import PlannerAgent
 from core.agents.registry import build_agents, choose_agent_for_task, load_mode_models
 from core.synthesizer import synthesize
 from core.plan_utils import normalize_plan_to_tasks, normalize_tasks
+from core.agents_registry import agents_dict
 
-logger = logging.getLogger(__name__)
+
+def orchestrate(user_idea: str) -> str:
+    """Orchestrate the multi-agent R&D process for a given idea.
+
+    This function expects a global ``agents_dict`` mapping role names to
+    agent instances. Each agent must implement ``act(system_prompt, user_prompt)``.
+    The function will coordinate the HR manager, planner, specialists, a
+    reflection step, and finally the chief scientist who synthesizes results
+    into a final plan.
+    """
+
+    global agents_dict
+
+    print(f"[User] Idea submitted: {user_idea}")
+
+    role_personas: Dict[str, str] = {
+        "HRM": (
+            "You are an HR Manager specializing in R&D projects. "
+            "Identify the expert roles needed for the following idea."
+        ),
+        "Planner": (
+            "You are a Project Planner AI. Decompose the given idea "
+            "into specific tasks, noting the domain or role needed for each task."
+        ),
+        "Reflection": (
+            "You are a Reflection agent analyzing the team's outputs. "
+            "Determine if any additional follow-up tasks are required based on the results so far."
+        ),
+        "ChiefScientist": (
+            "You are the Chief Scientist overseeing this project. "
+            "Integrate all contributions into a comprehensive final R&D plan."
+        ),
+        "CTO": (
+            "You are the Chief Technology Officer (CTO) for this project, focusing on technical strategy and feasibility. "
+            "Address architecture, potential technical risks, and ensure coherence across domains in the plan."
+        ),
+        "ResearchScientist": (
+            "You are a Research Scientist with expertise in the project's field. "
+            "Research the state-of-the-art and summarize key findings, relevant studies, and gaps related to the idea."
+        ),
+        "MaterialsEngineer": (
+            "You are a Materials Engineer specialized in material selection and engineering feasibility. "
+            "Evaluate material and engineering aspects of the idea and suggest solutions to any challenges."
+        ),
+        "RegulatorySpecialist": (
+            "You are a Regulatory Compliance Specialist. "
+            "Review the idea for any regulatory or safety requirements and highlight compliance issues to address."
+        ),
+    }
+
+    hrm_output = agents_dict["HRM"].act(role_personas["HRM"], user_idea)
+
+    roles_needed: List[str] = []
+    if isinstance(hrm_output, str):
+        try:
+            roles_needed = json.loads(hrm_output)
+            if isinstance(roles_needed, dict):
+                roles_needed = roles_needed.get("roles", list(roles_needed.values())[0] if roles_needed else [])
+        except json.JSONDecodeError:
+            parts = re.split(r"[\n,;]+", hrm_output)
+            roles_needed = [role.strip() for role in parts if role.strip()]
+    elif isinstance(hrm_output, (list, tuple)):
+        roles_needed = list(hrm_output)
+    else:
+        try:
+            roles_needed = list(hrm_output)
+        except Exception:
+            roles_needed = [str(hrm_output)]
+    print(f"[HRM] Roles needed: {roles_needed}")
+
+    planner_output = agents_dict["Planner"].act(role_personas["Planner"], user_idea)
+
+    tasks: List[Dict[str, Any]] = []
+    if isinstance(planner_output, str):
+        try:
+            plan_data = json.loads(planner_output)
+        except json.JSONDecodeError:
+            plan_data = {}
+        if isinstance(plan_data, dict):
+            tasks = plan_data.get("tasks", plan_data.get("Tasks", []))
+        elif isinstance(plan_data, list):
+            tasks = plan_data
+    elif isinstance(planner_output, dict):
+        tasks = planner_output.get("tasks") or planner_output.get("Tasks", []) or []
+    elif isinstance(planner_output, list):
+        tasks = planner_output
+
+    normalized_tasks: List[Dict[str, Any]] = []
+    for t in tasks:
+        if isinstance(t, str):
+            normalized_tasks.append({"task": t})
+        elif isinstance(t, dict):
+            task_desc = t.get("task") or t.get("Task") or ""
+            domain = t.get("domain") or t.get("Domain") or None
+            normalized_tasks.append({"task": task_desc, "domain": domain})
+    tasks = normalized_tasks
+    print(f"[Planner] Tasks identified: {tasks}")
+
+    if not tasks:
+        print("[Planner] No tasks were generated. Proceeding to final plan synthesis directly.")
+        direct_input = f"Roles: {roles_needed}. Idea: {user_idea}. Provide a comprehensive R&D plan."
+        final_plan = agents_dict["ChiefScientist"].act(role_personas["ChiefScientist"], direct_input)
+        print("[ChiefScientist] Final plan (direct synthesis) ready.")
+        return final_plan
+
+    def assign_role(task: Dict[str, Any]) -> str:
+        domain = task.get("domain")
+        task_desc = task.get("task", "")
+        if domain:
+            dom_lower = str(domain).lower()
+            for role_name in agents_dict.keys():
+                if dom_lower in role_name.lower():
+                    return role_name
+            if "material" in dom_lower:
+                return "MaterialsEngineer"
+            if "regulator" in dom_lower or "compliance" in dom_lower:
+                return "RegulatorySpecialist"
+            if "science" in dom_lower or "research" in dom_lower:
+                return "ResearchScientist"
+            if "tech" in dom_lower or "engineer" in dom_lower:
+                return "CTO"
+        desc_lower = task_desc.lower()
+        if any(word in desc_lower for word in ["material", "materials"]):
+            return "MaterialsEngineer" if "MaterialsEngineer" in agents_dict else "MaterialsScientist"
+        if any(word in desc_lower for word in ["regulatory", "regulation", "compliance"]):
+            return "RegulatorySpecialist"
+        if any(word in desc_lower for word in ["research", "analysis", "study"]):
+            return "ResearchScientist"
+        if any(word in desc_lower for word in ["technical", "architecture", "system design"]):
+            return "CTO"
+        if roles_needed:
+            return roles_needed[0]
+        return "ResearchScientist"
+
+    all_outputs: Dict[str, List[Dict[str, Any]]] = {}
+    for task in tasks:
+        task_desc = task.get("task", "")
+        role_assigned = assign_role(task)
+        agent = agents_dict.get(role_assigned)
+        if agent is None:
+            print(f"[Warning] No agent found for role {role_assigned}, skipping task: {task_desc}")
+            continue
+        system_prompt = role_personas.get(role_assigned, f"You are a {role_assigned} expert.")
+        user_prompt = task_desc
+        result = agent.act(system_prompt, user_prompt)
+        all_outputs.setdefault(role_assigned, []).append({"task": task_desc, "result": result})
+        print(f"[{role_assigned}] Completed task: '{task_desc}' -> Result captured.")
+
+    reflection_summary = ""
+    for role, outputs in all_outputs.items():
+        for entry in outputs:
+            reflection_summary += f"\n- {role} on '{entry['task']}': {entry['result']}"
+    reflection_user_prompt = (
+        "The team of agents have completed their tasks with the following results:"
+        f"{reflection_summary}\nGiven these results, determine if any additional follow-up tasks are needed to address remaining gaps or questions. "
+        "If yes, list the new tasks (as a JSON list of task descriptions or task dicts with domains if applicable); if not, respond with 'no further tasks'."
+    )
+    reflection_output = agents_dict["Reflection"].act(role_personas["Reflection"], reflection_user_prompt)
+
+    follow_up_tasks: List[Any] = []
+    if reflection_output:
+        if isinstance(reflection_output, str):
+            if "no further tasks" in reflection_output.lower():
+                follow_up_tasks = []
+            else:
+                try:
+                    follow_up_tasks = json.loads(reflection_output)
+                    if isinstance(follow_up_tasks, dict) and "tasks" in follow_up_tasks:
+                        follow_up_tasks = follow_up_tasks["tasks"]
+                    if isinstance(follow_up_tasks, dict):
+                        follow_up_tasks = list(follow_up_tasks.values())
+                except json.JSONDecodeError:
+                    lines = [
+                        line.strip("- ").strip()
+                        for line in reflection_output.splitlines() if line.strip()
+                    ]
+                    if any("no further tasks" in line.lower() for line in lines):
+                        follow_up_tasks = []
+                    else:
+                        for line in lines:
+                            if line:
+                                try:
+                                    task_obj = json.loads(line)
+                                    if isinstance(task_obj, str):
+                                        follow_up_tasks.append({"task": task_obj})
+                                    elif isinstance(task_obj, dict):
+                                        follow_up_tasks.append(task_obj)
+                                except json.JSONDecodeError:
+                                    follow_up_tasks.append({"task": line})
+        elif isinstance(reflection_output, list):
+            follow_up_tasks = reflection_output
+        elif isinstance(reflection_output, dict):
+            follow_up_tasks = reflection_output.get("tasks") or list(reflection_output.values())
+
+    if follow_up_tasks:
+        print(f"[Reflection] Follow-up tasks suggested: {follow_up_tasks}")
+        for ftask in follow_up_tasks:
+            if isinstance(ftask, str):
+                ftask = {"task": ftask}
+            ftask_desc = ftask.get("task", "")
+            role_assigned = assign_role(ftask)
+            agent = agents_dict.get(role_assigned)
+            if agent is None:
+                print(f"[Warning] No agent for follow-up role {role_assigned}, skipping task: {ftask_desc}")
+                continue
+            system_prompt = role_personas.get(role_assigned, f"You are a {role_assigned} expert.")
+            user_prompt = ftask_desc
+            result = agent.act(system_prompt, user_prompt)
+            all_outputs.setdefault(role_assigned, []).append({"task": ftask_desc, "result": result})
+            print(f"[{role_assigned}] Completed follow-up task: '{ftask_desc}' -> Result captured.")
+    else:
+        print("[Reflection] No follow-up tasks needed.")
+
+    synthesis_summary = ""
+    for role, outputs in all_outputs.items():
+        for entry in outputs:
+            synthesis_summary += f"\n{role} ({entry['task']}): {entry['result']}"
+    chief_user_prompt = (
+        "All specialist tasks are complete. Here are the results:"
+        f"{synthesis_summary}\nAs the Chief Scientist, please synthesize these contributions into a final comprehensive R&D plan."
+    )
+    final_plan = agents_dict["ChiefScientist"].act(role_personas["ChiefScientist"], chief_user_prompt)
+    print("[ChiefScientist] Final R&D plan synthesized.")
+    return final_plan
 
 
 def run_pipeline(
@@ -29,6 +253,7 @@ def run_pipeline(
     context: Dict[str, List[str]] = {"idea": idea, "summaries": []}
 
     plan = planner.run(idea, "Decompose the project into specialist tasks")
+    logger = logging.getLogger(__name__)
     logger.info(
         "Planner raw (first 400 chars): %s",
         str(getattr(planner, "last_raw", plan))[:400],

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1,0 +1,55 @@
+import json
+from unittest.mock import patch
+
+from agents.hrm_agent import HRMAgent
+from agents.planner_agent import LLMPlannerAgent
+from agents.reflection_agent import ReflectionAgent
+from core.orchestrator import orchestrate
+
+
+@patch("agents.base_agent.make_chat", return_value='{"roles":["CTO"]}')
+def test_hrm_returns_roles_json(mock_chat):
+    agent = HRMAgent("gpt-4o-mini")
+    out = agent.act("sys", "idea")
+    data = json.loads(out)
+    assert isinstance(data.get("roles"), list)
+
+
+@patch("agents.base_agent.make_chat", return_value='{"tasks":[{"task":"T","domain":"D"}]}')
+def test_planner_returns_tasks_json(mock_chat):
+    agent = LLMPlannerAgent("gpt-4o-mini")
+    out = agent.act("sys", "idea")
+    data = json.loads(out)
+    assert isinstance(data.get("tasks"), list)
+    assert "task" in data["tasks"][0]
+    assert set(data["tasks"][0].keys()) <= {"task", "domain"}
+
+
+@patch("agents.base_agent.make_chat", return_value='["follow up"]')
+def test_reflection_returns_list(mock_chat):
+    agent = ReflectionAgent("gpt-4o-mini")
+    out = agent.act("sys", "summary")
+    data = json.loads(out)
+    assert isinstance(data, list)
+
+
+@patch("agents.base_agent.make_chat", return_value='no further tasks')
+def test_reflection_returns_no_tasks(mock_chat):
+    agent = ReflectionAgent("gpt-4o-mini")
+    out = agent.act("sys", "summary")
+    assert out.strip().lower() == "no further tasks"
+
+
+@patch(
+    "agents.base_agent.make_chat",
+    side_effect=[
+        '{"roles":["ResearchScientist"]}',
+        '{"tasks":[{"task":"do research","domain":"research"}]}',
+        "result",
+        "no further tasks",
+        "final plan",
+    ],
+)
+def test_orchestrate_smoke(mock_chat):
+    result = orchestrate("Microscope that uses quantum entanglement")
+    assert isinstance(result, str) and result


### PR DESCRIPTION
## Summary
- add OpenAI chat helper and lightweight `LLMRoleAgent` to unify agent calls
- implement HRM, planner, reflection, and specialist agents plus registry for orchestrator
- replace orchestrator with persona-driven workflow and include compatibility `run_pipeline`
- validate agent output formats and orchestrator flow with new tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a409b0ea30832c983e2289a6343a4a