### PR TITLE
Add prompt coercion helper and harden LLM/synthesizer handling

### DIFF
--- a/agents/base_agent.py
+++ b/agents/base_agent.py
@@ -14,6 +14,7 @@ import logging
 import streamlit as st
 from dr_rd.utils.llm_client import llm_call, log_usage
 from core.llm import complete
+from dr_rd.core.prompt_utils import coerce_user_content
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +44,8 @@ class LLMRoleAgent:
 
     def act(self, system_prompt: str, user_prompt: str, **kwargs) -> str:
         """Call the model with a system and user prompt."""
+        user_prompt = coerce_user_content(user_prompt)
+        system_prompt = coerce_user_content(system_prompt)
         result = complete(system_prompt, user_prompt, model=self.model, **kwargs)
         return (result.content or "").strip()
 

--- a/agents/cto_agent.py
+++ b/agents/cto_agent.py
@@ -1,10 +1,16 @@
 from agents.base_agent import LLMRoleAgent
 
-ROLE_PROMPT = (
-    "You are the Chief Technology Officer with deep technical expertise and strategic vision. "
-    "Provide high-level architecture and technical direction."
-)
 
 class CTOAgent(LLMRoleAgent):
-    def act(self, system_prompt: str = ROLE_PROMPT, user_prompt: str = "", **kwargs) -> str:
-        return super().act(system_prompt, user_prompt, **kwargs)
+    def act(self, idea, task=None, **kwargs) -> str:
+        if isinstance(task, dict):
+            system_prompt = (
+                "You are the CTO. Assess feasibility, architecture, and risks. Return clear, structured guidance."
+            )
+            user_prompt = (
+                f"Project Idea:\n{idea}\n\n"
+                f"Task Title:\n{task.get('title','')}\n\n"
+                f"Task Description:\n{task.get('description','')}"
+            )
+            return super().act(system_prompt, user_prompt, **kwargs)
+        return super().act(idea, task or "", **kwargs)

--- a/agents/research_scientist_agent.py
+++ b/agents/research_scientist_agent.py
@@ -1,10 +1,16 @@
 from agents.base_agent import LLMRoleAgent
 
-ROLE_PROMPT = (
-    "You are a Research Scientist with deep literature awareness. "
-    "Provide specific, non-generic analysis with concrete details."
-)
 
 class ResearchScientistAgent(LLMRoleAgent):
-    def act(self, system_prompt: str = ROLE_PROMPT, user_prompt: str = "", **kwargs) -> str:
-        return super().act(system_prompt, user_prompt, **kwargs)
+    def act(self, idea, task=None, **kwargs) -> str:
+        if isinstance(task, dict):
+            system_prompt = (
+                "You are the Research Scientist. Provide specific, non-generic analysis with concrete details."
+            )
+            user_prompt = (
+                f"Project Idea:\n{idea}\n\n"
+                f"Task Title:\n{task.get('title','')}\n\n"
+                f"Task Description:\n{task.get('description','')}"
+            )
+            return super().act(system_prompt, user_prompt, **kwargs)
+        return super().act(idea, task or "", **kwargs)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1062,11 +1062,11 @@ def main():
             logger.info("Final routed task count: %d", len(routed))
             for rr, agent, t in routed:
                 try:
-                    out = _invoke_agent(
-                        agent,
-                        idea,
-                        {"title": t["title"], "description": t["description"]},
-                    )
+                    task = {
+                        "title": str(t.get("title", "")),
+                        "description": str(t.get("description", "")),
+                    }
+                    out = _invoke_agent(agent, idea, task)
                 except Exception as e:
                     logger.exception("Agent %s failed: %s", rr, e)
                     out = {"error": str(e)}

--- a/dr_rd/core/prompt_utils.py
+++ b/dr_rd/core/prompt_utils.py
@@ -1,0 +1,19 @@
+from typing import Any, Union, List
+import json
+
+
+def coerce_user_content(x: Any) -> Union[str, List[dict]]:
+    """
+    OpenAI chat messages must be str or list[dict] (for vision).
+    - str: return as-is
+    - list[dict]: assume vision content; return as-is
+    - dict/other: JSON-dump to a compact string
+    """
+    if isinstance(x, str):
+        return x
+    if isinstance(x, list) and all(isinstance(i, dict) for i in x):
+        return x
+    try:
+        return json.dumps(x, separators=(",", ":"), ensure_ascii=False)
+    except Exception:
+        return str(x)

--- a/tests/test_app_ui.py
+++ b/tests/test_app_ui.py
@@ -141,14 +141,8 @@ def test_run_domain_experts(monkeypatch):
                 ]
             },
         )(),
-        "agents.synthesizer.llm_call": lambda *a, **k: type(
-            "R",
-            (),
-            {
-                "choices": [
-                    type("C", (), {"message": type("M", (), {"content": "out"})()})
-                ]
-            },
+        "agents.synthesizer.complete": lambda *a, **k: type(
+            "R", (), {"content": "out", "raw": {}}
         )(),
     }
     reload_app(monkeypatch, st, patches)

--- a/tests/test_prompt_utils.py
+++ b/tests/test_prompt_utils.py
@@ -1,0 +1,16 @@
+from dr_rd.core.prompt_utils import coerce_user_content
+
+
+def test_string_passthrough():
+    assert coerce_user_content("x") == "x"
+
+
+def test_dict_to_json():
+    out = coerce_user_content({"a":1})
+    assert isinstance(out, str)
+    assert '"a":1' in out
+
+
+def test_list_of_dicts_allowed():
+    content = [{"type":"text","text":"hello"}]
+    assert coerce_user_content(content) == content

--- a/tests/test_synthesizer.py
+++ b/tests/test_synthesizer.py
@@ -1,26 +1,25 @@
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 import os
 import pytest
 from agents.synthesizer import compose_final_proposal
+from core.llm import ChatResult
 
 
-def make_openai_response(text: str):
-    mock_choice = Mock()
-    mock_choice.message = Mock(content=text)
-    return Mock(choices=[mock_choice])
+def make_chat_result(text: str):
+    return ChatResult(content=text, raw={"usage": {"prompt_tokens": 1, "completion_tokens": 1}})
 
 
 @patch.dict(os.environ, {"OPENAI_API_KEY": "x"})
 @patch("agents.synthesizer.make_visuals_for_project", return_value=[{"kind": "schematic", "url": "u", "caption": "S"}])
-@patch('agents.synthesizer.llm_call')
-def test_compose_final_proposal(mock_llm, _mock_vis):
+@patch("agents.synthesizer.complete")
+def test_compose_final_proposal(mock_complete, _mock_vis):
     fake_response = (
         "## Executive Summary\nOverview\n\n"
         "## Bill of Materials\n|Component|Quantity|Specs|\n|---|---|---|\n|Part|1|Spec|\n\n"
         "## Step-by-Step Instructions\n1. Do X\n\n"
         "## Simulation & Test Results\nNone"
     )
-    mock_llm.return_value = make_openai_response(fake_response)
+    mock_complete.return_value = make_chat_result(fake_response)
     answers = {
         "Mechanical Systems Lead": "design",
         "Optical Systems Engineer": "optics",


### PR DESCRIPTION
## Summary
- add `coerce_user_content` to normalize chat message content
- improve LLM wrapper validation and retry on bad model errors
- fix agents/synthesizer to build safe prompts and configurable model
- make GCP logging init idempotent and tighten task routing

## Testing
- `OPENAI_API_KEY=dummy pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4a54878a0832c848efc07bafc3cb4