### PR TITLE
Avoid embedding base64 images directly in URLs

### DIFF
--- a/agents/synthesizer.py
+++ b/agents/synthesizer.py
@@ -125,15 +125,14 @@ def compose_final_proposal(idea: str, answers: Dict[str, str], include_simulatio
             bio = BytesIO(data)
             fmt = "png"
             content_type = "image/png"
+            url = None
             if bucket:
                 filename = f"{int(__import__('time').time())}-test.{fmt}"
                 try:
                     url = upload_bytes_to_gcs(bio.getvalue(), filename, content_type, bucket)
                 except Exception:
-                    url = f"data:{content_type};base64,{b64}"
-            else:
-                url = f"data:{content_type};base64,{b64}"
-            images.append({"kind": "test", "url": url, "caption": "Test Visual"})
+                    url = None
+            images.append({"kind": "test", "url": url, "data": bio.getvalue(), "caption": "Test Visual"})
         except Exception:
             pass
     else:
@@ -142,7 +141,9 @@ def compose_final_proposal(idea: str, answers: Dict[str, str], include_simulatio
     if images:
         final_document += "\n\n## 4. Schematics & Visuals\n"
         for i, img in enumerate(images, 1):
-            final_document += f"\n**Figure {i}. {img['caption']}**\n\n![]({img['url']})\n"
+            final_document += f"\n**Figure {i}. {img['caption']}**\n"
+            if img.get("url"):
+                final_document += f"\n![]({img['url']})\n"
 
     result_payload = {"document": final_document, "images": images, "test": bool(flags.get("TEST_MODE"))}
     return result_payload

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1325,8 +1325,14 @@ def main():
             if use_firestore:
                 try:
                     doc_id = get_project_id()
+                    images_to_store = []
+                    for im in st.session_state.get("images", []):
+                        item = {k: im.get(k) for k in ("kind", "caption") if im.get(k) is not None}
+                        if im.get("url"):
+                            item["url"] = im["url"]
+                        images_to_store.append(item)
                     db.collection("dr_rd_projects").document(doc_id).set(
-                        {"images": st.session_state.get("images", []), **st.session_state.get("test_marker", {})},
+                        {"images": images_to_store, **st.session_state.get("test_marker", {})},
                         merge=True,
                     )
                 except Exception as e:
@@ -1347,7 +1353,9 @@ def main():
         if imgs:
             st.subheader("Schematics & Visuals")
             for im in imgs:
-                st.image(im["url"], caption=im.get("caption", ""))
+                img_source = im.get("url") or im.get("data")
+                if img_source:
+                    st.image(img_source, caption=im.get("caption", ""))
         pdf_bytes = generate_pdf(doc_text)
         if hasattr(st, "download_button"):
             st.download_button(

--- a/dr_rd/utils/image_visuals.py
+++ b/dr_rd/utils/image_visuals.py
@@ -82,18 +82,22 @@ def make_visuals_for_project(
                 content_type = "image/jpeg"
             data = bio.getvalue()
 
+            url = None
             if bucket:
                 filename = f"{ts}-{kind}.{fmt}"
                 try:
                     url = upload_bytes_to_gcs(data, filename, content_type, bucket)
                 except Exception:
-                    url = (
-                        f"data:{content_type};base64,{base64.b64encode(data).decode()}"
-                    )
-            else:
-                url = f"data:{content_type};base64,{base64.b64encode(data).decode()}"
+                    url = None
 
-            out.append({"kind": kind, "url": url, "caption": kind.capitalize()})
+            out.append(
+                {
+                    "kind": kind,
+                    "url": url,
+                    "data": data,
+                    "caption": kind.capitalize(),
+                }
+            )
         except Exception:
             continue
 


### PR DESCRIPTION
## Summary
- Stop embedding image bytes in `url` when uploads fail and instead keep raw bytes separately
- Show generated visuals using bytes when no URL is available and avoid saving raw bytes to Firestore
- Only embed images in final proposal markdown when a real URL exists

## Testing
- `OPENAI_API_KEY=x pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4c1d0a250832c97769cd3f7e02c00