### PR TITLE
Remove budget enforcement during LLM calls

### DIFF
--- a/core/budget.py
+++ b/core/budget.py
@@ -3,10 +3,6 @@ from dataclasses import dataclass
 from typing import Dict, Optional
 
 
-class BudgetExhausted(Exception):
-    """Raised when the budget cannot accommodate a request."""
-
-
 @dataclass
 class Reservation:
     stage: str
@@ -78,8 +74,6 @@ class BudgetManager:
         est_prompt_tokens: int,
         est_completion_tokens: int,
     ) -> Reservation:
-        if not self.can_afford(next_stage_name, model_id, est_prompt_tokens, est_completion_tokens):
-            raise BudgetExhausted("Budget would be exceeded")
         cost = self.cost_of(model_id, est_prompt_tokens, est_completion_tokens)
         self.stage_spend[next_stage_name] = self.stage_spend.get(next_stage_name, 0.0) + cost
         self.spend += cost

--- a/tests/test_budget_enforcement.py
+++ b/tests/test_budget_enforcement.py
@@ -1,11 +1,16 @@
 import os
 from unittest.mock import Mock, patch
 
-import pytest
-
-from app.price_loader import load_prices
-from core.budget import BudgetManager, BudgetExhausted
+from pathlib import Path
+import yaml
+from core.budget import BudgetManager
 from dr_rd.utils.llm_client import llm_call, set_budget_manager
+
+
+def load_prices():
+    with open(Path("config") / "prices.yaml") as fh:
+        data = yaml.safe_load(fh) or {}
+    return data.get("models", {})
 
 
 class DummyResp:
@@ -15,7 +20,7 @@ class DummyResp:
 
 
 @patch.dict(os.environ, {"OPENAI_API_KEY": "x"})
-def test_budget_fallback():
+def test_budget_no_fallback():
     prices = {"models": load_prices()}
     bm = BudgetManager({"target_cost_usd": 0.0005, "stage_weights": {"exec": 1.0}}, prices)
     set_budget_manager(bm)
@@ -29,22 +34,22 @@ def test_budget_fallback():
             messages=[{"role": "user", "content": "hi"}],
             max_tokens_hint=100,
         )
-    assert mock_create.call_args[1]["model"] == "gpt-4o-mini"
+    assert mock_create.call_args[1]["model"] == "gpt-4o"
 
 
 @patch.dict(os.environ, {"OPENAI_API_KEY": "x"})
-def test_budget_exhausted():
+def test_budget_does_not_raise():
     prices = {"models": load_prices()}
     bm = BudgetManager({"target_cost_usd": 1e-6, "stage_weights": {"exec": 1.0}}, prices)
     set_budget_manager(bm)
     mock_create = Mock(return_value=DummyResp())
     client = Mock(chat=Mock(completions=Mock(create=mock_create)))
     with patch("dr_rd.utils.llm_client.st.session_state", {}):
-        with pytest.raises(BudgetExhausted):
-            llm_call(
-                client,
-                "gpt-3.5-turbo",
-                stage="exec",
-                messages=[{"role": "user", "content": "hi"}],
-                max_tokens_hint=100,
-            )
+        llm_call(
+            client,
+            "gpt-3.5-turbo",
+            stage="exec",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens_hint=100,
+        )
+    assert bm.spend > 0

--- a/tests/test_budget_guard.py
+++ b/tests/test_budget_guard.py
@@ -6,6 +6,7 @@ import dr_rd.utils.llm_client as lc
 def test_budget_guard(monkeypatch):
     st = make_streamlit("", {}, raise_on_stop=True)
     st.error = MagicMock()
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
     monkeypatch.setattr(lc, "set_budget_manager", lambda _: None)
     monkeypatch.setattr(lc, "BUDGET", None, raising=False)
     reload_app(monkeypatch, st, expect_exit=True)


### PR DESCRIPTION
## Summary
- Skip cost-based model fallback and truncation in `llm_call` so runs continue even if they exceed budget estimates
- Stop raising `BudgetExhausted` by simplifying `BudgetManager.reserve`
- Update budget tests to expect no fallback or exception when budget limits are surpassed

## Testing
- `pytest tests/test_budget.py tests/test_budget_enforcement.py tests/test_budget_guard.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4e5b5eed0832cbd1650af03877f0b