### PR TITLE
feat: add deep mode image toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ Set the mode via the `DRRD_MODE` environment variable. By default the app runs i
 | Mode | Plan model | Exec model | Synth model | max_loops | Notes |
 |------|------------|------------|-------------|-----------|-------|
 | Test | 3.5-turbo | 3.5-turbo | 3.5-turbo | 1 | images disabled |
-| Deep | 4o | 4o | gpt-5 | 5 | images enabled |
+| Deep | 4o | 4o | gpt-5 | 5 | images optional |
 
-Images are disabled by default for the Test mode.
+Images are disabled by default for the Test mode. Deep mode lets users toggle images on or off.
 
 ## Quick Start
 1) `pip install -r requirements.txt`

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -814,6 +814,14 @@ def main():
             + f"Refinement rounds={ui_preset['refinement_rounds']} • "
             + f"Simulations={'on' if ui_preset['simulate_enabled'] else 'off'}"
         )
+    if selected_mode == "deep":
+        image_toggle_fn = getattr(sidebar, "toggle", getattr(sidebar, "checkbox", lambda *a, **k: False))
+        default_images_on = not ff.DISABLE_IMAGES_BY_DEFAULT.get(selected_mode, True)
+        st.session_state["disable_images"] = not image_toggle_fn(
+            "Generate images",
+            value=default_images_on,
+            help="Include schematic and appearance visuals in the final proposal.",
+        )
     project_names = []
     project_doc_ids = {}
     if db:

--- a/dr_rd/utils/image_visuals.py
+++ b/dr_rd/utils/image_visuals.py
@@ -53,7 +53,7 @@ def make_visuals_for_project(
     """Generate schematic and render images for a project."""
 
     mode = st.session_state.get("MODE", "deep")
-    if DISABLE_IMAGES_BY_DEFAULT.get(mode, True):
+    if st.session_state.get("disable_images", DISABLE_IMAGES_BY_DEFAULT.get(mode, True)):
         return []
 
     brief = idea or ""


### PR DESCRIPTION
## Summary
- let deep mode users choose whether to generate images
- respect session image toggle when composing visuals
- document optional images in Deep mode

## Testing
- `OPENAI_API_KEY=dummy pytest` *(fails: tests/test_mode_caps.py::test_fallback_and_summarize, tests/test_mode_env.py::test_env_selects_deep)*

------
https://chatgpt.com/codex/tasks/task_e_68a50040242c832cb0c2cec518a936de