### PR TITLE
Ensure synthesizer and research agents use correct models

### DIFF
--- a/config/agent_models.py
+++ b/config/agent_models.py
@@ -4,6 +4,7 @@ AGENT_MODEL_MAP = {
     "Planner": "gpt-4o",
     "CTO": "gpt-4o",
     "Research": "gpt-4o",
+    "Research Scientist": "gpt-4o",
     "Mechanical Systems Lead": "gpt-4o",
     "Materials & Process Engineer": "gpt-4o",
     "Chemical & Surface Science Specialist": "gpt-4o",

--- a/core/agents/registry.py
+++ b/core/agents/registry.py
@@ -138,7 +138,8 @@ def load_mode_models(mode: str | None = None) -> dict:
     from app.config_loader import load_mode
     from dr_rd.utils.llm_client import set_budget_manager
 
-    mode = mode or "test"
+    # Default to deep reasoning profile when no mode is specified
+    mode = mode or "deep"
     mode_cfg, budget = load_mode(mode)
 
     # Share mode config with callers that read st.session_state

--- a/core/agents/unified_registry.py
+++ b/core/agents/unified_registry.py
@@ -23,19 +23,25 @@ logger = logging.getLogger("unified_registry")
 def resolve_model(role: str, purpose: str = "exec") -> str:
     """
     purpose: 'exec' | 'plan' | 'synth'
-    Uses environment overrides to decide model. Defaults ensure Deep/Pro
-    runs use non-mini models.
+    Uses environment overrides to decide model. Defaults:
+    - profile "test" -> gpt-5
+    - profile "pro" -> o3-deep-research
+    - profile "deep" or unset -> o3-deep-research
+    - anything else -> gpt-4o-mini
     """
-    profile = os.getenv("DRRD_PROFILE", "Pro").lower()
-    # env overrides
+    profile = os.getenv("DRRD_PROFILE", "deep").lower()
     if purpose == "plan":
-        return os.getenv("DRRD_MODEL_PLAN", "gpt-4o")
+        default_model = "gpt-5" if profile == "test" else "o3-deep-research"
+        return os.getenv("DRRD_MODEL_PLAN", default_model)
     if purpose == "synth":
-        return os.getenv("DRRD_MODEL_SYNTH", "gpt-4o")
-    # exec:
-    if profile in ("pro", "deep"):
-        return os.getenv("DRRD_MODEL_EXEC_PRO", "gpt-4o")
-    # efficient / default
+        default_model = "gpt-5" if profile == "test" else "o3-deep-research"
+        return os.getenv("DRRD_MODEL_SYNTH", default_model)
+    if profile == "test":
+        return os.getenv("DRRD_MODEL_EXEC_TEST", "gpt-5")
+    if profile == "pro":
+        return os.getenv("DRRD_MODEL_EXEC_PRO", "o3-deep-research")
+    if profile == "deep":
+        return os.getenv("DRRD_MODEL_EXEC_DEEP", "o3-deep-research")
     return os.getenv("DRRD_MODEL_EXEC_EFFICIENT", "gpt-4o-mini")
 
 def build_agents_unified(

--- a/tests/test_profile_model.py
+++ b/tests/test_profile_model.py
@@ -1,0 +1,11 @@
+from core.agents.unified_registry import resolve_model
+
+
+def test_pro_profile_uses_o3(monkeypatch):
+    monkeypatch.setenv("DRRD_PROFILE", "pro")
+    # Exec defaults
+    assert resolve_model("Research Scientist") == "o3-deep-research"
+    # Plan stage
+    assert resolve_model("Planner", "plan") == "o3-deep-research"
+    # Synth stage
+    assert resolve_model("Synthesizer", "synth") == "o3-deep-research"


### PR DESCRIPTION
## Summary
- standardize model name to `o3-deep-research`
- route both deep and pro profiles to `o3-deep-research`
- verify pro profile model resolution with tests

## Testing
- `OPENAI_API_KEY=dummy pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a510610244832ca92edbf521ce6472