### PR TITLE
Centralize OpenAI routing with Responses fallback

### DIFF
--- a/agents/marketing_agent.py
+++ b/agents/marketing_agent.py
@@ -1,9 +1,9 @@
 from agents.base_agent import BaseAgent
 from config.feature_flags import RAG_ENABLED, RAG_TOPK
 from dr_rd.utils.model_router import pick_model, CallHints
-from dr_rd.utils.llm_client import llm_call, log_usage
+from dr_rd.utils.llm_client import log_usage
+from dr_rd.llm_client import call_openai
 from typing import Optional, Dict, Any, List, Tuple
-import openai
 import json
 import re
 
@@ -53,17 +53,18 @@ class MarketingAgent(BaseAgent):
                 pass
         
         sel = pick_model(CallHints(stage="exec"))
-        response = llm_call(
-            openai,
-            sel["model"],
-            stage="exec",
+        result = call_openai(
+            model=sel["model"],
             messages=[
                 {"role": "system", "content": self.system_message},
                 {"role": "user", "content": prompt},
             ],
             **sel["params"],
         )
-        usage = response.choices[0].usage if hasattr(response.choices[0], "usage") else getattr(response, "usage", None)
+        resp = result["raw"]
+        usage = getattr(resp, "usage", None)
+        if usage is None and getattr(resp, "choices", None):
+            usage = getattr(resp.choices[0], "usage", None)
         if usage:
             log_usage(
                 stage="exec",
@@ -71,7 +72,7 @@ class MarketingAgent(BaseAgent):
                 pt=getattr(usage, "prompt_tokens", 0),
                 ct=getattr(usage, "completion_tokens", 0),
             )
-        raw = response.choices[0].message.content.strip()
+        raw = (result["text"] or "").strip()
         data: Dict[str, Any]
         try:
             data = json.loads(raw)

--- a/agents/obfuscator.py
+++ b/agents/obfuscator.py
@@ -10,10 +10,9 @@ Usage:
 """
 
 from typing import Dict
-import openai
 import logging
 from dr_rd.utils.model_router import pick_model, CallHints
-from dr_rd.utils.llm_client import llm_call
+from dr_rd.llm_client import call_openai
 
 SYSTEM_PROMPT = (
     "You are an R&D anonymizer. Given a research TASK and its DOMAIN, "
@@ -27,10 +26,8 @@ def obfuscate_task(domain: str, task: str) -> str:
     """Return an obfuscated version of a single domain task."""
     sel = pick_model(CallHints(stage="exec"))
     logging.info(f"Model[exec]={sel['model']} params={sel['params']}")
-    resp = llm_call(
-        openai,
-        sel["model"],
-        stage="exec",
+    result = call_openai(
+        model=sel["model"],
         temperature=0.5,
         messages=[
             {"role": "system", "content": SYSTEM_PROMPT},
@@ -38,4 +35,4 @@ def obfuscate_task(domain: str, task: str) -> str:
         ],
         **sel["params"],
     )
-    return resp.choices[0].message.content.strip()
+    return (result["text"] or "").strip()

--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -12,20 +12,17 @@ Call:
 """
 
 from typing import Dict
-import openai
 from agents.obfuscator import obfuscate_task
 from agents.router import route
 from dr_rd.utils.model_router import pick_model, CallHints
-from dr_rd.utils.llm_client import llm_call
+from dr_rd.llm_client import call_openai
 
 
 def _needs_follow_up(domain: str, task: str, answer: str) -> str | None:
     """Return a follow-up question *or* None if answer is judged complete."""
     sel = pick_model(CallHints(stage="exec"))
-    review = llm_call(
-        openai,
-        sel["model"],
-        stage="exec",
+    result = call_openai(
+        model=sel["model"],
         temperature=0,
         messages=[
             {
@@ -48,7 +45,7 @@ def _needs_follow_up(domain: str, task: str, answer: str) -> str | None:
         ],
         **sel["params"],
     )
-    proposal = review.choices[0].message.content.strip()
+    proposal = (result["text"] or "").strip()
     return None if proposal.upper().startswith("COMPLETE") else proposal
 
 

--- a/collaboration.py
+++ b/collaboration.py
@@ -1,7 +1,6 @@
-import openai
 import logging
 from dr_rd.utils.model_router import pick_model, CallHints
-from dr_rd.utils.llm_client import llm_call
+from dr_rd.llm_client import call_openai
 
 def agent_chat(agentA, agentB, idea, outputA, outputB):
     """
@@ -19,14 +18,12 @@ def agent_chat(agentA, agentB, idea, outputA, outputB):
     )
     sel = pick_model(CallHints(stage="exec"))
     logging.info(f"Model[exec]={sel['model']} params={sel['params']}")
-    response = llm_call(
-        openai,
-        sel["model"],
-        stage="exec",
+    result = call_openai(
+        model=sel["model"],
         messages=[{"role": "user", "content": prompt}],
         **sel["params"],
     )
-    content = response.choices[0].message.content.strip()
+    content = (result["text"] or "").strip()
     # Extract updated outputs from the response content
     updated_cto = ""
     updated_rs = ""

--- a/core/agents/base_agent.py
+++ b/core/agents/base_agent.py
@@ -5,8 +5,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional
 from abc import ABC
 
-import openai
-from dr_rd.utils.llm_client import llm_call
+from dr_rd.llm_client import call_openai
 
 
 @dataclass
@@ -29,8 +28,8 @@ class Agent(ABC):
                 ),
             },
         ]
-        resp = llm_call(openai, self.model_id, stage="exec", messages=messages)
-        return resp.choices[0].message.content
+        result = call_openai(model=self.model_id, messages=messages)
+        return result["text"] or ""
 
     def act(self, idea: str, task: str, context: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Execute the agent for a given task and shared context."""

--- a/core/synthesizer.py
+++ b/core/synthesizer.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 from typing import Dict, List
 
-import openai
-from dr_rd.utils.llm_client import llm_call
+from dr_rd.llm_client import call_openai
 
 
 def synthesize(idea: str, results_by_role: Dict[str, List[dict]], model_id: str) -> str:
@@ -27,5 +26,5 @@ def synthesize(idea: str, results_by_role: Dict[str, List[dict]], model_id: str)
             ),
         },
     ]
-    resp = llm_call(openai, model_id, stage="synth", messages=messages)
-    return resp.choices[0].message.content
+    result = call_openai(model=model_id, messages=messages)
+    return result["text"] or ""

--- a/dr_rd/llm_client.py
+++ b/dr_rd/llm_client.py
@@ -1,0 +1,77 @@
+import logging
+from typing import Any, Dict, List, Optional
+
+from openai import OpenAI
+from openai import APIStatusError
+import os
+
+logger = logging.getLogger(__name__)
+
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY", "test"))
+
+
+def _to_responses_input(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    converted: List[Dict[str, Any]] = []
+    for m in messages:
+        content = m.get("content", "")
+        if isinstance(content, str):
+            parts = [{"type": "input_text", "text": content}]
+        else:
+            parts = content
+        converted.append({"role": m.get("role", "user"), "content": parts})
+    return converted
+
+
+def extract_text(resp: Any) -> Optional[str]:
+    """Return the main text content from either Responses or Chat responses."""
+    if resp is None:
+        return None
+    # Responses API
+    if hasattr(resp, "output") or hasattr(resp, "output_text"):
+        if getattr(resp, "output_text", None):
+            return getattr(resp, "output_text")
+        chunks = []
+        for item in getattr(resp, "output", []) or []:
+            if getattr(item, "type", "") == "message":
+                for c in getattr(item, "content", []) or []:
+                    if getattr(c, "type", "") == "output_text":
+                        chunks.append(getattr(c, "text", ""))
+        return "".join(chunks) if chunks else None
+    # Chat Completions
+    try:
+        choice = resp.choices[0]
+    except Exception:
+        return None
+    return getattr(getattr(choice, "message", None), "content", None) or getattr(choice, "text", None)
+
+
+def call_openai(model: str, messages: List[Dict[str, Any]], **kwargs) -> Dict[str, Any]:
+    """Call OpenAI with automatic routing between Responses and Chat APIs."""
+    params = dict(kwargs)
+    if "max_tokens" in params and "max_output_tokens" not in params:
+        params["max_output_tokens"] = params.pop("max_tokens")
+    try:
+        resp = client.responses.create(
+            model=model,
+            input=_to_responses_input(messages),
+            **params,
+        )
+        text = extract_text(resp)
+        logger.info("call_openai: used Responses API for %s", model)
+        return {"raw": resp, "text": text}
+    except APIStatusError as e:
+        if e.status_code != 404:
+            raise
+        logger.info("call_openai: falling back to Chat Completions for %s", model)
+    except Exception as e:
+        msg = str(e).lower()
+        if "404" not in msg:
+            raise
+        logger.info("call_openai: falling back to Chat Completions for %s", model)
+
+    params = dict(kwargs)
+    if "max_output_tokens" in params and "max_tokens" not in params:
+        params["max_tokens"] = params.pop("max_output_tokens")
+    resp = client.chat.completions.create(model=model, messages=messages, **params)
+    text = extract_text(resp)
+    return {"raw": resp, "text": text}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 streamlit>=1.35.0
-openai>=1.25.0
+openai>=1.51.0
 requests>=2.31.0
 google-cloud-logging
 google-cloud-firestore

--- a/tests/test_llm_route.py
+++ b/tests/test_llm_route.py
@@ -2,6 +2,7 @@ import os
 os.environ.setdefault("OPENAI_API_KEY", "test")
 from unittest.mock import patch, MagicMock
 import core.llm as llm
+import dr_rd.llm_client as lc
 
 
 def make_chat_resp():
@@ -28,7 +29,7 @@ def make_resp_resp():
 def test_chat_route():
     fake = MagicMock()
     fake.chat.completions.create.return_value = make_chat_resp()
-    with patch.object(llm, "client", fake):
+    with patch.object(lc, "client", fake):
         res = llm.complete("You are a test.", "Say OK.", model="gpt-4o-mini")
     assert isinstance(res.content, str)
     fake.chat.completions.create.assert_called_once()
@@ -37,7 +38,7 @@ def test_chat_route():
 def test_responses_route():
     fake = MagicMock()
     fake.responses.create.return_value = make_resp_resp()
-    with patch.object(llm, "client", fake):
+    with patch.object(lc, "client", fake):
         res = llm.complete("You are a test.", "Say OK.", model="gpt-4.1")
     assert isinstance(res.content, str)
     fake.responses.create.assert_called_once()

--- a/utils/refinement.py
+++ b/utils/refinement.py
@@ -1,7 +1,6 @@
-import openai
 import logging
 from dr_rd.utils.model_router import pick_model, CallHints
-from dr_rd.utils.llm_client import llm_call
+from dr_rd.llm_client import call_openai
 
 
 def refine_agent_output(agent, idea, task, prev_output, other_outputs):
@@ -23,14 +22,12 @@ def refine_agent_output(agent, idea, task, prev_output, other_outputs):
     )
     sel = pick_model(CallHints(stage="exec"))
     logging.info(f"Model[exec]={sel['model']} params={sel['params']}")
-    response = llm_call(
-        openai,
-        sel["model"],
-        stage="exec",
+    result = call_openai(
+        model=sel["model"],
         messages=[
             {"role": "system", "content": agent.system_message},
             {"role": "user", "content": user_prompt}
         ],
         **sel["params"],
     )
-    return response.choices[0].message.content.strip()
+    return (result["text"] or "").strip()

--- a/utils/search_tools.py
+++ b/utils/search_tools.py
@@ -7,8 +7,7 @@ from typing import List, Dict
 import requests
 from html import unescape
 
-from dr_rd.utils.llm_client import llm_call
-import openai
+from dr_rd.llm_client import call_openai
 
 
 def _strip_html(text: str) -> str:
@@ -54,13 +53,11 @@ def summarize_search(snippets: List[str], model: str | None = None) -> str:
         f"- {s}" for s in snippets
     )
     try:
-        resp = llm_call(
-            openai,
-            model_id,
-            stage="exec",
+        result = call_openai(
+            model=model_id,
             messages=[{"role": "user", "content": prompt}],
         )
-        return resp.choices[0].message.content.strip()
+        return (result["text"] or "").strip()
     except Exception:
         return ""
 


### PR DESCRIPTION
## Summary
- Add `dr_rd.llm_client` helper to prefer the Responses API and fall back to Chat Completions
- Refactor agents and app modules to use `call_openai` and normalized text extraction
- Bump `openai` dependency to 1.51.0

## Testing
- `pytest` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a528c52e14832cbe80ead2d22d9c7d