### PR TITLE
fix planner agent import and llm stub

### DIFF
--- a/agents/planner_agent.py
+++ b/agents/planner_agent.py
@@ -1,22 +1,5 @@
-"""Compatibility wrapper re-exporting the planner agent from :mod:`dr_rd`."""
-
-from dr_rd.agents.planner_agent import (
-    Task,
-    Plan,
-    SYSTEM,
-    USER_TMPL,
-    llm_call,
-    run_planner,
-    PlannerAgent,
-)
-
-__all__ = [
-    "Task",
-    "Plan",
-    "SYSTEM",
-    "USER_TMPL",
-    "llm_call",
-    "run_planner",
-    "PlannerAgent",
-]
-
+"""Compatibility shim that aliases to :mod:`dr_rd.agents.planner_agent`."""
+import importlib
+import sys
+_impl = importlib.import_module("dr_rd.agents.planner_agent")
+sys.modules[__name__] = _impl


### PR DESCRIPTION
## Summary
- use llm_call from utils in planner agent and handle mock responses
- replace agents/planner_agent wrapper with module alias for patching compatibility

## Testing
- `pytest tests/test_planner_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a52b88e720832c967dfcfe9d2bb9f3