### PR TITLE
Fix MemoryManager import for Streamlit app

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,6 +6,7 @@ import logging
 from core.roles import normalize_role
 import streamlit as st
 from memory import audit_logger  # import the audit logger
+from memory.memory_manager import MemoryManager
 from collaboration import agent_chat
 from utils.refinement import refine_agent_output
 from agents.simulation_agent import SimulationAgent


### PR DESCRIPTION
## Summary
- Import `MemoryManager` in app initialization to avoid NameError

## Testing
- `pytest` *(fails: Connection error, missing attributes)*

------
https://chatgpt.com/codex/tasks/task_e_68a52d53c638832cb401910c12d3a46c