### PR TITLE
Strip temperature from OpenAI Responses calls

### DIFF
--- a/dr_rd/llm_client.py
+++ b/dr_rd/llm_client.py
@@ -51,15 +51,18 @@ def call_openai(model: str, messages: List[Dict[str, Any]], **kwargs) -> Dict[st
     if "max_tokens" in params and "max_output_tokens" not in params:
         params["max_output_tokens"] = params.pop("max_tokens")
     try:
+        response_params = {k: v for k, v in params.items() if k != "temperature"}
         try:
             resp = client.responses.create(
                 model=model,
                 input=_to_responses_input(messages),
-                **params,
+                **response_params,
             )
-        except TypeError as e:
-            if "response_format" in params:
-                cleaned = {k: v for k, v in params.items() if k != "response_format"}
+        except TypeError:
+            if "response_format" in response_params:
+                cleaned = {
+                    k: v for k, v in response_params.items() if k != "response_format"
+                }
                 resp = client.responses.create(
                     model=model,
                     input=_to_responses_input(messages),

--- a/tests/test_llm_route.py
+++ b/tests/test_llm_route.py
@@ -42,3 +42,15 @@ def test_responses_route():
         res = llm.complete("You are a test.", "Say OK.", model="gpt-4.1")
     assert isinstance(res.content, str)
     fake.responses.create.assert_called_once()
+
+
+def test_responses_drops_temperature():
+    fake = MagicMock()
+    fake.responses.create.return_value = make_resp_resp()
+    with patch.object(lc, "client", fake):
+        res = llm.complete(
+            "You are a test.", "Say OK.", model="gpt-4.1", temperature=0.9
+        )
+    assert isinstance(res.content, str)
+    fake.responses.create.assert_called_once()
+    assert "temperature" not in fake.responses.create.call_args.kwargs


### PR DESCRIPTION
## Summary
- Remove `temperature` argument when using OpenAI Responses API to avoid unsupported parameter errors.
- Add regression test ensuring `temperature` is not forwarded to Responses.

## Testing
- `pytest` *(fails: AttributeError and APIConnectionError in unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a530f96f4c832cb795aaed0a57311b