### PR TITLE
chore: centralize agent prompts

### DIFF
--- a/core/agents/cto_agent.py
+++ b/core/agents/cto_agent.py
@@ -1,16 +1,15 @@
 from core.agents.base_agent import LLMRoleAgent
+from prompts.prompts import CTO_SYSTEM_PROMPT, CTO_USER_PROMPT_TEMPLATE
 
 
 class CTOAgent(LLMRoleAgent):
     def act(self, idea, task=None, **kwargs) -> str:
         if isinstance(task, dict):
-            system_prompt = (
-                "You are the CTO. Assess feasibility, architecture, and risks. Return clear, structured guidance."
-            )
-            user_prompt = (
-                f"Project Idea:\n{idea}\n\n"
-                f"Task Title:\n{task.get('title','')}\n\n"
-                f"Task Description:\n{task.get('description','')}"
+            system_prompt = CTO_SYSTEM_PROMPT
+            user_prompt = CTO_USER_PROMPT_TEMPLATE.format(
+                idea=idea,
+                title=task.get("title", ""),
+                description=task.get("description", ""),
             )
             return super().act(system_prompt, user_prompt, **kwargs)
         return super().act(idea, task or "", **kwargs)

--- a/core/agents/finance_agent.py
+++ b/core/agents/finance_agent.py
@@ -1,4 +1,8 @@
 from core.agents.base_agent import BaseAgent
+from prompts.prompts import (
+    FINANCE_SYSTEM_PROMPT,
+    FINANCE_USER_PROMPT_TEMPLATE,
+)
 
 class FinanceAgent(BaseAgent):
     """Financial analyst for budgeting and cost estimates."""
@@ -7,8 +11,6 @@ class FinanceAgent(BaseAgent):
         super().__init__(
             name="Finance",
             model=model,
-            system_message="You evaluate budgets, BOM costs and financial risks.",
-            user_prompt_template=(
-                "Project Idea: {idea}\nAs the Finance lead, your task is {task}."
-            ),
+            system_message=FINANCE_SYSTEM_PROMPT,
+            user_prompt_template=FINANCE_USER_PROMPT_TEMPLATE,
         )

--- a/core/agents/ip_analyst_agent.py
+++ b/core/agents/ip_analyst_agent.py
@@ -6,6 +6,10 @@ from dr_rd.llm_client import call_openai
 from typing import Optional, Dict, Any, List, Tuple
 import json
 import re
+from prompts.prompts import (
+    IP_ANALYST_SYSTEM_PROMPT,
+    IP_ANALYST_USER_PROMPT_TEMPLATE,
+)
 
 try:
     from dr_rd.knowledge.retriever import Retriever  # type: ignore
@@ -22,15 +26,8 @@ class IPAnalystAgent(BaseAgent):
         super().__init__(
             name="IP Analyst",
             model=model,
-            system_message=(
-                "You are an intellectual-property analyst skilled at prior-art searches, "
-                "novelty assessment, patentability, and freedom-to-operate risk."
-            ),
-            user_prompt_template=(
-                "Project Idea: {idea}\nAs the IP Analyst, your task is {task}. "
-                "Provide an IP analysis in Markdown. "
-                "End with a JSON summary using keys: role, task, findings, risks, next_steps, sources."
-            ),
+            system_message=IP_ANALYST_SYSTEM_PROMPT,
+            user_prompt_template=IP_ANALYST_USER_PROMPT_TEMPLATE,
             retriever=retriever,
         )
 

--- a/core/agents/marketing_agent.py
+++ b/core/agents/marketing_agent.py
@@ -6,6 +6,10 @@ from dr_rd.llm_client import call_openai
 from typing import Optional, Dict, Any, List, Tuple
 import json
 import re
+from prompts.prompts import (
+    MARKETING_SYSTEM_PROMPT,
+    MARKETING_USER_PROMPT_TEMPLATE,
+)
 
 try:
     from dr_rd.knowledge.retriever import Retriever  # type: ignore
@@ -22,15 +26,8 @@ class MarketingAgent(BaseAgent):
         super().__init__(
             name="Marketing Analyst",
             model=model,
-            system_message=(
-                "You are a marketing analyst with expertise in market research, "
-                "customer segmentation, competitive landscapes and go-to-market strategies."
-            ),
-            user_prompt_template=(
-                "Project Idea: {idea}\nAs the Marketing Analyst, your task is {task}. "
-                "Provide a marketing overview in Markdown. "
-                "End with a JSON summary using keys: role, task, findings, risks, next_steps, sources."
-            ),
+            system_message=MARKETING_SYSTEM_PROMPT,
+            user_prompt_template=MARKETING_USER_PROMPT_TEMPLATE,
             retriever=retriever,
         )
 

--- a/core/agents/patent_agent.py
+++ b/core/agents/patent_agent.py
@@ -1,4 +1,8 @@
 from core.agents.base_agent import BaseAgent
+from prompts.prompts import (
+    PATENT_SYSTEM_PROMPT,
+    PATENT_USER_PROMPT_TEMPLATE,
+)
 
 """Patent Agent for intellectual property and patentability analysis."""
 class PatentAgent(BaseAgent):
@@ -7,15 +11,6 @@ class PatentAgent(BaseAgent):
         super().__init__(
             name="Patent",
             model=model,
-            system_message=(
-                "You are a patent attorney and innovation expert focusing on intellectual property. "
-                "You thoroughly analyze existing patents and technical disclosures, referencing diagrams or figures if relevant. "
-                "You justify your conclusions on patentability and can adjust IP strategy if new technical feedback (e.g., simulation data) warrants it."
-            ),
-            user_prompt_template=(
-                "Project Idea: {idea}\nAs the Patent expert, your task is {task}. "
-                "Provide an analysis in Markdown format of patentability, including any existing patents (with relevant patent figures or diagrams if applicable) and an IP strategy. "
-                "Include reasoning behind each recommendation (e.g., why certain features are patentable or not). "
-                "Conclude with a JSON list of potential patent ideas or relevant patent references."
-            ),
+            system_message=PATENT_SYSTEM_PROMPT,
+            user_prompt_template=PATENT_USER_PROMPT_TEMPLATE,
         )

--- a/core/agents/regulatory_agent.py
+++ b/core/agents/regulatory_agent.py
@@ -1,4 +1,8 @@
 from core.agents.base_agent import BaseAgent
+from prompts.prompts import (
+    REGULATORY_SYSTEM_PROMPT,
+    REGULATORY_USER_PROMPT_TEMPLATE,
+)
 
 """Regulatory Agent for compliance and standards analysis."""
 class RegulatoryAgent(BaseAgent):
@@ -7,15 +11,6 @@ class RegulatoryAgent(BaseAgent):
         super().__init__(
             name="Regulatory",
             model=model,
-            system_message=(
-                "You are a regulatory compliance expert with knowledge of industry standards and laws. "
-                "You provide detailed compliance analysis, referencing standards and guidelines. "
-                "You justify how the design meets (or needs modifications to meet) each requirement and adjust recommendations if testing/simulation reveals new issues."
-            ),
-            user_prompt_template=(
-                "Project Idea: {idea}\nAs the Regulatory expert, your task is {task}. "
-                "Provide a thorough analysis of regulatory requirements and compliance steps in Markdown format, including any certifications or standards needed, and mapping of system components to regulations. "
-                "Include justification for each compliance recommendation (e.g., why a certain standard applies). "
-                "Conclude with a JSON checklist of regulatory steps and compliance requirements."
-            ),
+            system_message=REGULATORY_SYSTEM_PROMPT,
+            user_prompt_template=REGULATORY_USER_PROMPT_TEMPLATE,
         )

--- a/dr_rd/agents/planner_agent.py
+++ b/dr_rd/agents/planner_agent.py
@@ -7,6 +7,10 @@ from pydantic import BaseModel, Field, ValidationError
 import json
 from dr_rd.llm_client import call_openai, extract_text
 from dr_rd.utils.llm_client import llm_call
+from prompts.prompts import (
+    PLANNER_SYSTEM_PROMPT,
+    PLANNER_USER_PROMPT_TEMPLATE,
+)
 
 # Pydantic schema for planner output -------------------------------------------------
 
@@ -50,9 +54,9 @@ def _repair_to_json(raw_txt: str, model: str) -> str:
 
 # Prompts ---------------------------------------------------------------------------
 
-SYSTEM = "You are a Project Planner AI. Decompose the idea into role-specific tasks. Output ONLY JSON that matches {'tasks':[{'role':str,'title':str,'description':str}]}." 
+SYSTEM = PLANNER_SYSTEM_PROMPT
 
-USER_TMPL = "Project Idea: {idea}\nTask: Break down into role-specific tasks.\nOutput JSON only."
+USER_TMPL = PLANNER_USER_PROMPT_TEMPLATE
 
 
 # Planner call ----------------------------------------------------------------------

--- a/prompts/prompts.py
+++ b/prompts/prompts.py
@@ -1,3 +1,87 @@
-"""Collection of placeholder prompts."""
+"""Central repository of prompt templates used across agents."""
 
-# Actual prompt templates will be added here in the future.
+PLANNER_SYSTEM_PROMPT = (
+    "You are a Project Planner AI. Decompose the idea into role-specific tasks. Output ONLY JSON that matches {'tasks':[{'role':str,'title':str,'description':str}]}.")
+
+PLANNER_USER_PROMPT_TEMPLATE = (
+    "Project Idea: {idea}\n"
+    "Task: Break down into role-specific tasks.\n"
+    "Output JSON only.")
+
+SYNTHESIZER_TEMPLATE = """\
+You are a multi-disciplinary R&D lead.
+
+**Goal**: “{idea}”
+
+We have gathered the following domain findings (some may include loop-refined
+addenda separated by "--- *(Loop-refined)* ---"):
+
+{findings_md}
+
+Write a cohesive technical proposal that:
+
+1. Summarizes key insights per domain (concise bullet list each).
+2. Integrates those insights into a unified prototype / development plan.
+3. Calls out any remaining unknowns or recommended next experiments.
+4. Uses clear Markdown with headings:
+   - ## Executive Summary
+   - ## Domain Insights
+   - ## Integrated Prototype Plan
+   - ## Remaining Unknowns
+"""
+
+SYNTHESIZER_BUILD_GUIDE_TEMPLATE = (
+    "You are a senior R&D expert. Produce a Prototype Build Guide in Markdown with these sections:\n"
+    "{sections}\n"
+    "Integrate these agent contributions into one cohesive document.\n\n"
+    "Project Idea: {idea}\n\n"
+    "Agent Contributions:\n{contributions}")
+
+CTO_SYSTEM_PROMPT = (
+    "You are the CTO. Assess feasibility, architecture, and risks. Return clear, structured guidance.")
+
+CTO_USER_PROMPT_TEMPLATE = (
+    "Project Idea:\n{idea}\n\n"
+    "Task Title:\n{title}\n\n"
+    "Task Description:\n{description}")
+
+REGULATORY_SYSTEM_PROMPT = (
+    "You are a regulatory compliance expert with knowledge of industry standards and laws. "
+    "You provide detailed compliance analysis, referencing standards and guidelines. "
+    "You justify how the design meets (or needs modifications to meet) each requirement and adjust recommendations if testing/simulation reveals new issues.")
+
+REGULATORY_USER_PROMPT_TEMPLATE = (
+    "Project Idea: {idea}\n"
+    "As the Regulatory expert, your task is {task}. Provide a thorough analysis of regulatory requirements and compliance steps in Markdown format, including any certifications or standards needed, and mapping of system components to regulations. "
+    "Include justification for each compliance recommendation (e.g., why a certain standard applies). Conclude with a JSON checklist of regulatory steps and compliance requirements.")
+
+MARKETING_SYSTEM_PROMPT = (
+    "You are a marketing analyst with expertise in market research, customer segmentation, competitive landscapes and go-to-market strategies.")
+
+MARKETING_USER_PROMPT_TEMPLATE = (
+    "Project Idea: {idea}\n"
+    "As the Marketing Analyst, your task is {task}. Provide a marketing overview in Markdown. End with a JSON summary using keys: role, task, findings, risks, next_steps, sources.")
+
+FINANCE_SYSTEM_PROMPT = (
+    "You evaluate budgets, BOM costs and financial risks.")
+
+FINANCE_USER_PROMPT_TEMPLATE = (
+    "Project Idea: {idea}\n"
+    "As the Finance lead, your task is {task}.")
+
+IP_ANALYST_SYSTEM_PROMPT = (
+    "You are an intellectual-property analyst skilled at prior-art searches, novelty assessment, patentability, and freedom-to-operate risk.")
+
+IP_ANALYST_USER_PROMPT_TEMPLATE = (
+    "Project Idea: {idea}\n"
+    "As the IP Analyst, your task is {task}. Provide an IP analysis in Markdown. End with a JSON summary using keys: role, task, findings, risks, next_steps, sources.")
+
+PATENT_SYSTEM_PROMPT = (
+    "You are a patent attorney and innovation expert focusing on intellectual property. "
+    "You thoroughly analyze existing patents and technical disclosures, referencing diagrams or figures if relevant. "
+    "You justify your conclusions on patentability and can adjust IP strategy if new technical feedback (e.g., simulation data) warrants it.")
+
+PATENT_USER_PROMPT_TEMPLATE = (
+    "Project Idea: {idea}\n"
+    "As the Patent expert, your task is {task}. Provide an analysis in Markdown format of patentability, including any existing patents (with relevant patent figures or diagrams if applicable) and an IP strategy. "
+    "Include reasoning behind each recommendation (e.g., why certain features are patentable or not). Conclude with a JSON list of potential patent ideas or relevant patent references.")


### PR DESCRIPTION
## Summary
- centralize multi-line prompts into `prompts/prompts.py`
- reference prompt constants across planner, synthesizer, CTO, regulatory, marketing, finance, and IP agents

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'core.agents.planner_agent')*


------
https://chatgpt.com/codex/tasks/task_e_68a5ebf7d044832c817f99dafb9c025b