### PR TITLE
feat: centralize agent registry and wrappers

### DIFF
--- a/core/agents/planner_agent.py
+++ b/core/agents/planner_agent.py
@@ -1,0 +1,34 @@
+"""PlannerAgent wrapper exposing a minimal LLM-style interface."""
+
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+from dr_rd.agents.planner_agent import (
+    PlannerAgent as _PlannerAgent,
+    llm_call,
+    run_planner,
+)
+
+
+class PlannerAgent(_PlannerAgent):
+    """Subclass of the legacy planner with an ``act`` method.
+
+    The underlying planner operates via :func:`run_planner`.  This wrapper adds
+    an ``act`` method so the agent can be used interchangeably with
+    :class:`core.agents.base_agent.LLMRoleAgent` in tests and orchestration code.
+    """
+
+    def __init__(self, model: str = "gpt-5", repair_model: Optional[str] = "gpt-5"):
+        super().__init__(model, repair_model)
+        self.name = "Planner"
+
+    def act(self, system_prompt: str, user_prompt: str, **kwargs) -> str:
+        """Run the planner and return its JSON output as a string."""
+
+        data = self.run(user_prompt, "", roles=None)
+        return json.dumps(data)
+
+
+__all__ = ["PlannerAgent", "llm_call", "run_planner"]

--- a/core/agents_registry.py
+++ b/core/agents_registry.py
@@ -4,20 +4,23 @@ from core.agents.hrm_agent import HRMAgent
 from core.agents.planner_agent import PlannerAgent
 from core.agents.reflection_agent import ReflectionAgent
 from core.agents.chief_scientist_agent import ChiefScientistAgent
-from core.agents.cto_agent import CTOAgent
-from core.agents.research_scientist_agent import ResearchScientistAgent
 from core.agents.materials_engineer_agent import MaterialsEngineerAgent
 from core.agents.regulatory_specialist_agent import RegulatorySpecialistAgent
+from core.agents.registry import get_agent_class
 
 MODEL = os.getenv("OPENAI_MODEL", "gpt-5").strip()
 
 agents_dict = {
     "HRM": HRMAgent("HRM", MODEL),
-    "Planner": PlannerAgent("Planner", MODEL),
+    "Planner": PlannerAgent(MODEL),
     "Reflection": ReflectionAgent("Reflection", MODEL),
     "ChiefScientist": ChiefScientistAgent("ChiefScientist", MODEL),
-    "CTO": CTOAgent("CTO", MODEL),
-    "ResearchScientist": ResearchScientistAgent("ResearchScientist", MODEL),
     "MaterialsEngineer": MaterialsEngineerAgent("MaterialsEngineer", MODEL),
     "RegulatorySpecialist": RegulatorySpecialistAgent("RegulatorySpecialist", MODEL),
 }
+
+# Standard business roles via the central registry
+for role, key in [("CTO", "CTO"), ("Research Scientist", "ResearchScientist")]:
+    cls = get_agent_class(role)
+    if cls:
+        agents_dict[key] = cls(MODEL)

--- a/tests/test_agents_contract.py
+++ b/tests/test_agents_contract.py
@@ -1,14 +1,21 @@
+import json
+
 from core.agents.research_scientist_agent import ResearchScientistAgent
+from core.agents import base_agent
+
+
+def _res(text):
+    return type("R", (), {"content": text})()
 
 
 def test_agent_output_contract(monkeypatch):
     agent = ResearchScientistAgent("gpt-5")
     sample = (
-        '{"role": "Research", "task": "t", '
+        '{"role": "Research Scientist", "task": "t", '
         '"findings": ["f"], "risks": ["r"], "next_steps": ["n"], "sources": []}'
     )
-    monkeypatch.setattr(agent, "_call_openai", lambda idea, task, context: sample)
-    result = agent.act("idea", "t")
+    monkeypatch.setattr(base_agent, "complete", lambda s, u, **k: _res(sample))
+    result = json.loads(agent.act("idea", "t"))
     assert set(result.keys()) >= {
         "role",
         "task",

--- a/tests/test_business_agents.py
+++ b/tests/test_business_agents.py
@@ -9,13 +9,12 @@ from core.agents import registry
 
 
 def _fake_response(payload: dict):
-    choice = Mock()
-    choice.message = Mock(content=json.dumps(payload))
-    choice.usage = Mock(prompt_tokens=1, completion_tokens=1)
-    return Mock(choices=[choice])
+    raw = Mock()
+    raw.usage = Mock(prompt_tokens=1, completion_tokens=1)
+    return {"raw": raw, "text": json.dumps(payload)}
 
 
-@patch("core.agents.marketing_agent.llm_call")
+@patch("core.agents.marketing_agent.call_openai")
 def test_marketing_agent_contract(mock_call):
     mock_call.return_value = _fake_response(
         {
@@ -39,7 +38,7 @@ def test_marketing_agent_contract(mock_call):
     }
 
 
-@patch("core.agents.ip_analyst_agent.llm_call")
+@patch("core.agents.ip_analyst_agent.call_openai")
 def test_ip_agent_contract(mock_call):
     mock_call.return_value = _fake_response(
         {

--- a/tests/test_orchestrator_loop.py
+++ b/tests/test_orchestrator_loop.py
@@ -13,13 +13,13 @@ def test_orchestrator_iterative_loop_executes_all_roles():
                 {"role": "Marketing Analyst", "title": "analyze market", "description": "analyze market"},
                 {"role": "IP Analyst", "title": "search patents", "description": "search patents"},
                 {"role": "Finance", "title": "calc budget", "description": "calc budget"},
-                {"role": "Research", "title": "general research", "description": "general research"},
+                {"role": "Research Scientist", "title": "general research", "description": "general research"},
             ]
 
         def revise_plan(self, state):
             if not self.called:
                 self.called = True
-                return [{"role": "Research", "task": "extra"}]
+                return [{"role": "Research Scientist", "task": "extra"}]
             return []
 
     class StubAgent:
@@ -34,7 +34,7 @@ def test_orchestrator_iterative_loop_executes_all_roles():
             "Marketing Analyst": StubAgent("Marketing Analyst"),
             "IP Analyst": StubAgent("IP Analyst"),
             "Finance": StubAgent("Finance"),
-            "Research": StubAgent("Research"),
+            "Research Scientist": StubAgent("Research Scientist"),
         }
 
     with patch.object(orch, "PlannerAgent", DummyPlanner), \
@@ -43,6 +43,6 @@ def test_orchestrator_iterative_loop_executes_all_roles():
          patch.object(orch, "load_mode_models", return_value={"Planner": "x", "synth": "x", "default": "x"}):
         final, results, trace = orch.run_pipeline("idea", mode="test")
 
-    assert set(results.keys()) >= {"Marketing Analyst", "IP Analyst", "Finance", "Research"}
-    assert len(results["Research"]) == 2  # initial + follow-up
+    assert set(results.keys()) >= {"Marketing Analyst", "IP Analyst", "Finance", "Research Scientist"}
+    assert len(results["Research Scientist"]) == 2  # initial + follow-up
     assert len(trace) == 5  # 4 initial tasks + 1 follow-up

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -14,7 +14,7 @@ def test_agent_mapping_research():
     role, agent = registry.choose_agent_for_task(
         None, "Survey materials and physics literature", agents
     )
-    assert agent.name == "Research" and role == "Research"
+    assert agent.name == "Research Scientist" and role == "Research Scientist"
 
 
 def test_agent_mapping_regulatory():
@@ -44,4 +44,4 @@ def test_agent_exact_role_over_keyword():
 def test_agent_mapping_default():
     agents = registry.build_agents("test")
     role, agent = registry.choose_agent_for_task(None, "Unrecognized task", agents)
-    assert agent.name == "Research" and role == "Research"
+    assert agent.name == "Research Scientist" and role == "Research Scientist"

--- a/tests/test_router_no_drop.py
+++ b/tests/test_router_no_drop.py
@@ -6,7 +6,7 @@ class Dummy:
 
 
 def test_unknown_role_does_not_drop(monkeypatch):
-    agents = {"Research": Dummy(), "Finance": Dummy(), "Regulatory": Dummy()}
+    agents = {"Research Scientist": Dummy(), "Finance": Dummy(), "Regulatory": Dummy()}
     # planned role not in agents, but finance keywords route it
     agent, role = choose_agent_for_task(
         "Finance Analyst", "Budget Planning", "ROI and BOM", ["finance"], agents


### PR DESCRIPTION
## Summary
- add `AGENT_REGISTRY` and helper to lookup agent classes
- wire unified and legacy registries to use the central registry
- expose planner agent wrapper with `act` method for compatibility

## Testing
- `pytest tests/test_business_agents.py tests/test_formats.py tests/test_orchestrator_loop.py tests/test_registry.py tests/test_router_no_drop.py tests/test_agents_contract.py`
- `pytest` *(fails: tests/test_orchestrator.py, tests/test_pdf_generator.py, tests/test_qa_agent_unit.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a5edfae904832c930be927928bfeeb