### PR TITLE
fix: parse tasks list in Streamlit plan view

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -843,6 +843,8 @@ def main():
             with st.spinner("📝 Planning..."):
                 tasks = generate_plan(idea)
                 update_cost()
+            if isinstance(tasks, dict):
+                tasks = tasks.get("tasks", [])
             st.session_state["plan"] = tasks
             st.session_state["plan_tasks"] = tasks
             logger.info("Planner tasks: %d", len(tasks))
@@ -887,12 +889,16 @@ def main():
 
     if "plan" in st.session_state:
         st.subheader("Project Plan (Role → Task)")
-        tasks = st.session_state["plan"]
+        raw_tasks = st.session_state["plan"]
+        tasks = raw_tasks.get("tasks", []) if isinstance(raw_tasks, dict) else raw_tasks
         if not tasks:
             getattr(st, "error", lambda *a, **k: None)("Planner returned no valid tasks. Check logs.")
         else:
             for t in tasks:
-                st.json(t)
+                st.write("role:", t.get("role", ""))
+                st.write("title:", t.get("title", ""))
+                st.write("description:", t.get("description", ""))
+                st.write("")
 
         refinement_rounds = ui_preset["refinement_rounds"]
         simulate_enabled = st.session_state.get("simulate_enabled", True)


### PR DESCRIPTION
## Summary
- handle API responses returning `{ "tasks": [...] }` when generating plans
- render each task's role, title, and description individually in the Streamlit UI

## Testing
- `pytest -q` *(fails: openai.APIConnectionError and missing patches)*

------
https://chatgpt.com/codex/tasks/task_e_68a60a118d74832cb0ea94aeac81e990