### PR TITLE
audit: refine intake audit and add plan v1 artifacts

### DIFF
--- a/AUDIT_STATUS.md
+++ b/AUDIT_STATUS.md
@@ -1,0 +1,6 @@
+# Audit Status
+
+| Area | Criteria Passed | Criteria Failed | Risk | Next Action |
+|------|-----------------|-----------------|------|-------------|
+| 0 | 1 | 4 | High | Address missing intake, memory TTL, redaction, and config caps |
+| 1 | 0 | 4 | High | Add concept brief, role cards, task plan, and redaction policy |

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: audit
+audit:
+	pytest -q tests/audit

--- a/audits/2025-08-20/0-intake-scoping.md
+++ b/audits/2025-08-20/0-intake-scoping.md
@@ -1,0 +1,30 @@
+# Intake & Scoping Audit
+
+## Summary
+Initial review of project intake and scoping components shows only partial support for orchestration.
+Most intake, memory, and redaction controls are absent.
+
+## Checklist
+- [FAIL] 0.1 Streamlit intake screen capturing problem/goal, constraints, budget cap, time cap, allowed sources, redaction rules
+- [PASS] 0.2 Orchestrator module present with entrypoint function and loop control
+- [FAIL] 0.3 Memory layer with create/read/update and TTL or session keys
+- [FAIL] 0.4 Config supports redaction and budget/time caps with enforcement
+- [FAIL] 0.5 PII redaction utility with unit tests
+
+## Evidence
+- Orchestrator: `core/orchestrator.py`
+- Memory manager without TTL: `memory/memory_manager.py`
+- Budget config only: `config/modes.yaml`
+- Ad-hoc query obfuscation: `utils/search_tools.py`
+
+## Gaps
+- No intake UI collecting required fields
+- Memory lacks session scoping and expiration
+- No configurable redaction rules or time caps
+- No dedicated PII redaction utility or tests
+
+## Minimal Fix Suggestions
+- Add Streamlit intake form with required fields
+- Extend memory layer with session keys and TTL
+- Introduce config options for redaction, budget, and time caps; enforce them
+- Implement PII redaction utility with corresponding tests

--- a/audits/2025-08-20/1-plan-v1.md
+++ b/audits/2025-08-20/1-plan-v1.md
@@ -1,0 +1,29 @@
+# Plan v1 Audit
+
+## Summary
+Concept planning artifacts are largely absent. The repository lacks templates, role definitions, structured task plans, and redaction guidance.
+
+## Checklist
+- [FAIL] 1.1 Concept brief template exists
+- [FAIL] 1.2 Role cards exist for Planner/PM and other agents
+- [FAIL] 1.3 Task segmentation plan exists as structured data
+- [FAIL] 1.4 Redaction policy bound into planning prompts
+
+## Evidence
+- No `docs/concept_brief.md`
+- No `docs/roles/` directory
+- No task plan YAML or JSON under `planning/`
+- No mentions of redaction in planning prompts
+
+## Gaps
+- Missing concept brief template
+- No role cards or agent definitions
+- Planning lacks structured task segmentation
+- Redaction policy not integrated into prompts
+
+## Minimal Fix Suggestions
+- Add `docs/concept_brief.md` template
+- Create `docs/roles/` with role card markdown files
+- Introduce YAML/JSON task plan defining roles, tasks, inputs, and outputs
+- Embed redaction policy references in planning prompts
+

--- a/tests/audit/test_intake_scoping.py
+++ b/tests/audit/test_intake_scoping.py
@@ -1,0 +1,45 @@
+import os
+import importlib
+import glob
+
+
+def test_streamlit_intake_screen_exists():
+    """Fail if no Streamlit intake screen capturing required fields."""
+    candidates = ["streamlit_app.py", "app.py"] + glob.glob("pages/*.py")
+    found = False
+    for path in candidates:
+        if os.path.exists(path):
+            with open(path, "r", encoding="utf-8") as f:
+                text = f.read().lower()
+            needed = ["problem", "constraint", "budget", "time", "allowed", "redaction"]
+            if all(term in text for term in needed):
+                found = True
+                break
+    assert found, "Intake screen with required fields not found"
+
+
+def test_orchestrator_module_present():
+    orchestrator = importlib.import_module("core.orchestrator")
+    assert hasattr(orchestrator, "orchestrate"), "Orchestrator entrypoint missing"
+
+
+def test_memory_layer_has_ttl_or_session():
+    path = "memory/memory_manager.py"
+    assert os.path.exists(path), "Memory manager missing"
+    with open(path, "r", encoding="utf-8") as f:
+        text = f.read().lower()
+    assert "ttl" in text or "session" in text, "Memory layer lacks TTL or session keys"
+
+
+def test_config_supports_redaction_and_caps():
+    path = "config/modes.yaml"
+    assert os.path.exists(path), "modes.yaml missing"
+    with open(path, "r", encoding="utf-8") as f:
+        text = f.read().lower()
+    assert "redact" in text and "time" in text, "Redaction or time caps not configured"
+
+
+def test_pii_redaction_utility_has_tests():
+    util_exists = os.path.exists("utils/redaction.py")
+    test_exists = bool(glob.glob("tests/**/*redaction*.py"))
+    assert util_exists and test_exists, "PII redaction utility or tests missing"

--- a/tests/audit/test_plan_v1.py
+++ b/tests/audit/test_plan_v1.py
@@ -1,0 +1,40 @@
+import os
+import glob
+
+
+def test_concept_brief_template_exists():
+    assert os.path.exists("docs/concept_brief.md"), "Concept brief template missing"
+
+
+def test_role_cards_exist():
+    assert glob.glob("docs/roles/*.md"), "Role cards missing"
+
+
+def test_task_segmentation_plan_structure():
+    candidates = glob.glob("planning/*.yaml") + glob.glob("planning/*.yml") + glob.glob("planning/*.json")
+    assert candidates, "Task segmentation plan file missing"
+    path = candidates[0]
+    if path.endswith((".yaml", ".yml")):
+        import yaml
+        with open(path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    else:
+        import json
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    assert isinstance(data, dict) and data, "Task plan not structured as dict"
+    any_role = next(iter(data.values()))
+    assert "tasks" in any_role, "Task plan lacks role->tasks mapping"
+
+
+def test_redaction_policy_bound_in_planning_prompts():
+    prompt_files = glob.glob("prompts/*.py") + glob.glob("prompts/**/*.py", recursive=True) + glob.glob("core/agents/*planner*.py")
+    found = False
+    for path in prompt_files:
+        with open(path, "r", encoding="utf-8") as f:
+            text = f.read().lower()
+        if "redact" in text or "redaction" in text:
+            found = True
+            break
+    assert found, "Redaction policy missing from planning prompts"
+


### PR DESCRIPTION
## Summary
- address review feedback for intake & scoping audit
- document plan v1 gaps with new report and failing dry-run tests
- update audit status table

## Testing
- `make audit` (fails: 8 failed, 1 passed)


------
https://chatgpt.com/codex/tasks/task_e_68a64b2935bc832cb27c886462211d7f