### PR TITLE
Normalize planner roles and add canonical view toggle

### DIFF
--- a/core/role_normalizer.py
+++ b/core/role_normalizer.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from difflib import get_close_matches
+from collections import Counter
+from typing import Dict, List, Set
+
+# Map canonical role names to sets of specialist synonyms
+SYNONYMS: Dict[str, Set[str]] = {
+    "Mechanical Systems Lead": {
+        "Mechanical Engineer",
+        "Manufacturing Engineer",
+        "Tooling Engineer",
+        "Prototyping Technician",
+        "Automation Engineer",
+        "Controls Engineer",
+        "Operations Manager",
+        "Packaging Engineer",
+    },
+    "Regulatory": {
+        "Quality Engineer",
+        "Regulatory/Compliance Specialist",
+        "Environmental Specialist",
+        "Test Engineer",
+        "QA Manager",
+    },
+    "Planner": {
+        "Product Manager",
+        "Program Manager",
+        "Project Manager",
+        "Logistics Manager",
+    },
+    "Finance": {
+        "Cost Analyst",
+        "Supply Chain Manager",
+        "Procurement",
+        "Sourcing Manager",
+    },
+    "Marketing Analyst": {
+        "Sales Manager",
+        "Channel Manager",
+        "Brand Manager",
+        "Product Marketing",
+    },
+    "Research Scientist": {
+        "Materials Engineer",
+        "Materials Scientist",
+        "Coating Process Engineer",
+        "R&D Scientist",
+    },
+    "IP Analyst": {
+        "Patent Analyst",
+        "IP Counsel",
+        "Patent Engineer",
+    },
+    "CTO": {
+        "Chief Engineer",
+        "Technical Lead",
+        "Systems Architect",
+    },
+    "Synthesizer": set(),
+}
+
+# Precompute reverse lookup for synonyms (case-insensitive)
+_LOOKUP: Dict[str, str] = {}
+for canon, syns in SYNONYMS.items():
+    _LOOKUP[canon.lower()] = canon
+    for s in syns:
+        _LOOKUP[s.lower()] = canon
+
+
+def normalize_role(name: str, allowed_roles: Set[str]) -> str:
+    """Map a specialist role name to a canonical allowed role.
+
+    Parameters
+    ----------
+    name: The role name suggested by the planner.
+    allowed_roles: Set of canonical role names permitted by the system.
+    """
+
+    if not name:
+        return "Synthesizer"
+
+    allowed_map = {r.lower(): r for r in allowed_roles}
+    raw = name.strip()
+    low = raw.lower()
+
+    if low in allowed_map:
+        return allowed_map[low]
+
+    hit = _LOOKUP.get(low)
+    if hit and hit in allowed_roles:
+        return hit
+
+    match = get_close_matches(raw, list(allowed_roles), n=1, cutoff=0.75)
+    if match:
+        return match[0]
+
+    return "Synthesizer"
+
+
+def normalize_tasks(
+    tasks: List[Dict],
+    *,
+    allowed_roles: Set[str],
+    max_roles: int | None = None,
+) -> List[Dict]:
+    """Attach ``normalized_role`` to each task and optionally limit distinct roles."""
+
+    normalized: List[Dict] = []
+    for t in tasks:
+        role = str(t.get("role", ""))
+        norm = normalize_role(role, allowed_roles)
+        normalized.append({**t, "normalized_role": norm})
+
+    if max_roles is not None and max_roles > 0:
+        freq = Counter(t["normalized_role"] for t in normalized)
+        if len(freq) > max_roles:
+            keep = {r for r, _ in freq.most_common(max_roles)}
+            for t in normalized:
+                if t["normalized_role"] not in keep:
+                    t["normalized_role"] = "Synthesizer"
+
+    return normalized
+
+
+def group_by_role(tasks: List[Dict], *, key: str) -> Dict[str, List[Dict]]:
+    """Group tasks by ``key`` value."""
+
+    grouped: Dict[str, List[Dict]] = {}
+    for t in tasks:
+        role = t.get(key, "Synthesizer")
+        grouped.setdefault(role, []).append(t)
+    return grouped
+

--- a/tests/test_role_normalizer.py
+++ b/tests/test_role_normalizer.py
@@ -1,0 +1,70 @@
+import pytest
+
+from core.role_normalizer import (
+    SYNONYMS,
+    normalize_role,
+    normalize_tasks,
+    group_by_role,
+)
+
+ALLOWED = set(SYNONYMS.keys())
+
+
+def test_exact_match():
+    assert normalize_role("CTO", ALLOWED) == "CTO"
+
+
+def test_synonym_mapping():
+    assert (
+        normalize_role("Mechanical Engineer", ALLOWED)
+        == "Mechanical Systems Lead"
+    )
+
+
+def test_fuzzy_fallback():
+    assert (
+        normalize_role("Reserch Scientst", ALLOWED)
+        == "Research Scientist"
+    )
+
+
+def test_tail_collapse_by_frequency():
+    tasks = [
+        {"role": "CTO", "title": "t1", "description": "d"},
+        {"role": "Finance", "title": "t2", "description": "d"},
+        {"role": "Finance", "title": "t3", "description": "d"},
+    ]
+    normalized = normalize_tasks(tasks, allowed_roles=ALLOWED, max_roles=1)
+    roles = [t["normalized_role"] for t in normalized]
+    assert roles.count("Finance") == 2
+    assert roles.count("Synthesizer") == 1
+    assert "CTO" not in roles
+
+
+def test_paperclip_plan_grouping():
+    tasks = [
+        {
+            "role": "Mechanical Engineer",
+            "title": "Design extruder",
+            "description": "Build the machine",
+        },
+        {
+            "role": "Regulatory/Compliance Specialist",
+            "title": "Check safety",
+            "description": "Ensure compliance",
+        },
+        {
+            "role": "Product Manager",
+            "title": "Analyze market",
+            "description": "Assess demand",
+        },
+        {
+            "role": "Product Manager",
+            "title": "Plan launch",
+            "description": "Coordinate release",
+        },
+    ]
+    normalized = normalize_tasks(tasks, allowed_roles=ALLOWED)
+    grouped = group_by_role(normalized, key="normalized_role")
+    assert set(grouped) == {"Mechanical Systems Lead", "Regulatory", "Planner"}
+    assert len(grouped["Planner"]) == 2


### PR DESCRIPTION
## Summary
- add `core.role_normalizer` with synonym and fuzzy matching utilities
- integrate canonical role normalization into planner flow with logging
- add Streamlit role view toggle, optional role cap slider, and grouped rendering
- create tests for role normalizer behaviors

## Testing
- `pytest` *(fails: AssertionError, APIConnectionError, etc.)*
- `pytest tests/test_role_normalizer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a66b568224832c997bbcf10adaaf86