### PR TITLE
Intake & Scoping hardening (constraints, risk, redaction)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -476,7 +476,12 @@ def run_manual_pipeline(
             try:
                 doc_id = get_project_id()
                 db.collection("rd_projects").document(doc_id).set(
-                    {"results": st.session_state["answers"], **st.session_state.get("test_marker", {})},
+                    {
+                        "results": st.session_state["answers"],
+                        "constraints": st.session_state.get("constraints", ""),
+                        "risk_posture": st.session_state.get("risk_posture", "Medium"),
+                        **st.session_state.get("test_marker", {}),
+                    },
                     merge=True,
                 )
             except Exception as e:
@@ -528,7 +533,12 @@ def run_manual_pipeline(
             try:
                 doc_id = get_project_id()
                 db.collection("rd_projects").document(doc_id).set(
-                    {"results": st.session_state["answers"], **st.session_state.get("test_marker", {})},
+                    {
+                        "results": st.session_state["answers"],
+                        "constraints": st.session_state.get("constraints", ""),
+                        "risk_posture": st.session_state.get("risk_posture", "Medium"),
+                        **st.session_state.get("test_marker", {}),
+                    },
                     merge=True,
                 )
             except Exception as e:
@@ -718,6 +728,12 @@ def main():
                     if doc.exists:
                         data = doc.to_dict() or {}
                         st.session_state["idea"] = data.get("idea", "")
+                        st.session_state["constraints"] = data.get(
+                            "constraints", ""
+                        )
+                        st.session_state["risk_posture"] = data.get(
+                            "risk_posture", "Medium"
+                        )
                         plan_data = data.get("plan", [])
                         st.session_state["plan_tasks"] = plan_data
                         st.session_state["plan"] = [
@@ -744,6 +760,12 @@ def main():
                 for entry in memory_manager.data:
                     if entry.get("name") == selected_project:
                         st.session_state["idea"] = entry.get("idea", "")
+                        st.session_state["constraints"] = entry.get(
+                            "constraints", ""
+                        )
+                        st.session_state["risk_posture"] = entry.get(
+                            "risk_posture", "Medium"
+                        )
                         plan_data = entry.get("plan", [])
                         st.session_state["plan_tasks"] = plan_data
                         st.session_state["plan"] = [
@@ -775,6 +797,8 @@ def main():
                 "project_name",
                 "project_id",
                 "project_saved",
+                "constraints",
+                "risk_posture",
             ]:
                 st.session_state.pop(key, None)
         st.session_state["last_selected_project"] = selected_project
@@ -786,6 +810,17 @@ def main():
     )
     idea = st.text_input(
         "🧠 Enter your project idea:", value=st.session_state.get("idea", "")
+    )
+    constraints = st.text_area(
+        "Constraints (optional)",
+        key="constraints",
+        placeholder="Limits, compliance, vendors to avoid, deadlines…",
+    )
+    risk_posture = st.selectbox(
+        "Risk posture",
+        ["Low", "Medium", "High"],
+        index=1,
+        key="risk_posture",
     )
     idea_input = idea
     submitted_idea_text = idea
@@ -834,7 +869,11 @@ def main():
                 logging.error(f"Init project failed: {e}")
         try:
             with st.spinner("📝 Planning..."):
-                tasks = generate_plan(idea)
+                tasks = generate_plan(
+                    idea,
+                    st.session_state.get("constraints"),
+                    st.session_state.get("risk_posture"),
+                )
                 update_cost()
             if isinstance(tasks, dict):
                 tasks = tasks.get("tasks", [])
@@ -864,6 +903,8 @@ def main():
                         {
                             "name": st.session_state.get("project_name", ""),
                             "idea": submitted_idea_text or idea_input or "",
+                            "constraints": st.session_state.get("constraints", ""),
+                            "risk_posture": st.session_state.get("risk_posture", "Medium"),
                             "plan": tasks,
                             **st.session_state.get("test_marker", {}),
                         },
@@ -951,7 +992,12 @@ def main():
                         try:
                             doc_id = get_project_id()
                             db.collection("rd_projects").document(doc_id).set(
-                                {"results": results, **st.session_state.get("test_marker", {})},
+                                {
+                                    "results": results,
+                                    "constraints": st.session_state.get("constraints", ""),
+                                    "risk_posture": st.session_state.get("risk_posture", "Medium"),
+                                    **st.session_state.get("test_marker", {}),
+                                },
                                 merge=True,
                             )
                         except Exception as e:
@@ -1123,6 +1169,8 @@ def main():
                         st.session_state["answers"],
                         final_report_text,
                         [],
+                        constraints=st.session_state.get("constraints", ""),
+                        risk_posture=st.session_state.get("risk_posture", "Medium"),
                     )
                 except Exception as e:  # pylint: disable=broad-except
                     getattr(
@@ -1135,7 +1183,12 @@ def main():
                 try:
                     doc_id = get_project_id()
                     db.collection("rd_projects").document(doc_id).set(
-                        {"proposal": final_report_text, **st.session_state.get("test_marker", {})},
+                        {
+                            "proposal": final_report_text,
+                            "constraints": st.session_state.get("constraints", ""),
+                            "risk_posture": st.session_state.get("risk_posture", "Medium"),
+                            **st.session_state.get("test_marker", {}),
+                        },
                         merge=True,
                     )
                 except Exception as e:
@@ -1301,7 +1354,12 @@ def main():
         if use_firestore:
             try:
                 db.collection("rd_projects").document(doc_id).set(
-                    {"chat": new_chat, **st.session_state.get("test_marker", {})},
+                    {
+                        "chat": new_chat,
+                        "constraints": st.session_state.get("constraints", ""),
+                        "risk_posture": st.session_state.get("risk_posture", "Medium"),
+                        **st.session_state.get("test_marker", {}),
+                    },
                     merge=True,
                 )
             except Exception as e:

--- a/core/agents/base_agent.py
+++ b/core/agents/base_agent.py
@@ -124,14 +124,9 @@ class BaseAgent:
         ):
             return
         try:
-            from utils.search_tools import (
-                search_google,
-                summarize_search,
-                obfuscate_query,
-            )
+            from utils.search_tools import search_google, summarize_search
 
-            query = obfuscate_query(self.name, idea, task)
-            results = search_google(query, k=5)
+            results = search_google(self.name, idea, task, k=5)
             if not results:
                 return
             summary = summarize_search([r.get("snippet", "") for r in results])

--- a/core/agents/planner_agent.py
+++ b/core/agents/planner_agent.py
@@ -61,12 +61,25 @@ USER_TMPL = PLANNER_USER_PROMPT_TEMPLATE
 # Planner call ----------------------------------------------------------------------
 
 
-def run_planner(idea: str, model: str, utility_model: Optional[str] = None):
+def run_planner(
+    idea: str,
+    model: str,
+    utility_model: Optional[str] = None,
+    constraints: str | None = None,
+    risk_posture: str | None = None,
+):
     """Run the planner model and ensure a valid :class:`Plan` is returned."""
 
+    constraints_section = f"\nConstraints: {constraints}" if constraints else ""
+    risk_section = f"\nRisk posture: {risk_posture}" if risk_posture else ""
+    user_prompt = USER_TMPL.format(
+        idea=idea,
+        constraints_section=constraints_section,
+        risk_section=risk_section,
+    )
     messages = [
         {"role": "system", "content": SYSTEM},
-        {"role": "user", "content": USER_TMPL.format(idea=idea)},
+        {"role": "user", "content": user_prompt},
     ]
 
     params = {
@@ -123,8 +136,22 @@ class PlannerAgent:
         self.system_message = SYSTEM
         self.name = "Planner"
 
-    def run(self, idea: str, task: str, difficulty: str = "normal", roles: List[str] | None = None):
-        data, _meta = run_planner(idea, self.model, self.repair_model)
+    def run(
+        self,
+        idea: str,
+        task: str,
+        difficulty: str = "normal",
+        roles: List[str] | None = None,
+        constraints: str | None = None,
+        risk_posture: str | None = None,
+    ):
+        data, _meta = run_planner(
+            idea,
+            self.model,
+            self.repair_model,
+            constraints=constraints,
+            risk_posture=risk_posture,
+        )
         return data
 
     def revise_plan(self, workspace: dict) -> List[dict]:

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -42,9 +42,19 @@ def _invoke_agent(agent, idea: str, task: Dict[str, str]) -> str:
     raise AttributeError(f"{agent.__class__.__name__} has no callable interface")
 
 
-def generate_plan(idea: str) -> List[Dict[str, str]]:
+def generate_plan(
+    idea: str,
+    constraints: str | None = None,
+    risk_posture: str | None = None,
+) -> List[Dict[str, str]]:
     """Use the Planner to create and normalize a task list."""
-    user_prompt = PLANNER_USER_PROMPT_TEMPLATE.format(idea=idea)
+    constraints_section = f"\nConstraints: {constraints}" if constraints else ""
+    risk_section = f"\nRisk posture: {risk_posture}" if risk_posture else ""
+    user_prompt = PLANNER_USER_PROMPT_TEMPLATE.format(
+        idea=idea,
+        constraints_section=constraints_section,
+        risk_section=risk_section,
+    )
     result = complete(PLANNER_SYSTEM_PROMPT, user_prompt)
     raw = result.content or ""
     tasks = normalize_tasks(normalize_plan_to_tasks(raw))

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -13,3 +13,11 @@ The system operates in two modes:
 - **test** – routes every stage to a cheap model for dry runs.
 
 Token usage is logged via a CostTracker. Costs are tracked for telemetry only; caps are not enforced.
+
+## Sanitization
+
+External queries follow a strict order: **redact → route → log → network**. Queries are obfuscated before any logging or network transmission.
+
+## Intake Fields
+
+The intake UI accepts optional **Constraints** and a **Risk posture** selection (Low/Medium/High). These values are threaded into planning prompts and persisted with each project.

--- a/memory/audit_logger.py
+++ b/memory/audit_logger.py
@@ -2,6 +2,13 @@ import json
 import os
 from datetime import datetime
 
+from utils.search_tools import obfuscate_query
+
+try:  # pragma: no cover - streamlit not always present
+    import streamlit as st
+except Exception:  # pragma: no cover
+    st = None
+
 # Ensure the audit log directory exists
 AUDIT_DIR = "memory/audit_log"
 os.makedirs(AUDIT_DIR, exist_ok=True)
@@ -12,6 +19,11 @@ def log_step(project_id: str, role: str, step_type: str, content: str, success: 
     Append a log entry for the given project_id. Each entry includes timestamp, role, step_type, content, and success.
     The log is stored in memory/audit_log/{project_id}.json as a list of entries.
     """
+    idea = ""
+    if st is not None:
+        idea = st.session_state.get("idea", "")
+    content = obfuscate_query(role, idea, content)
+
     log_entry = {
         "timestamp": datetime.utcnow().isoformat(),
         "role": role,

--- a/memory/memory_manager.py
+++ b/memory/memory_manager.py
@@ -31,6 +31,9 @@ class MemoryManager:
             self.data = []
         if not isinstance(self.data, list):
             self.data = []
+        for entry in self.data:
+            entry.setdefault("constraints", "")
+            entry.setdefault("risk_posture", "Medium")
 
         cfg = load_config()
         ttl_cfg = cfg.get("memory", {}).get("ttl_seconds", 86400)
@@ -80,7 +83,18 @@ class MemoryManager:
         return removed
 
     # Legacy project persistence helpers
-    def store_project(self, name, idea, plan, results, proposal, images=None):
+    def store_project(
+        self,
+        name,
+        idea,
+        plan,
+        results,
+        proposal,
+        images=None,
+        *,
+        constraints: str | None = None,
+        risk_posture: str | None = None,
+    ):
         entry = {
             "name": name,
             "idea": idea,
@@ -88,6 +102,8 @@ class MemoryManager:
             "results": results,
             "proposal": proposal,
             "images": images or [],
+            "constraints": constraints or "",
+            "risk_posture": risk_posture or "Medium",
         }
         try:  # pragma: no cover - optional Firestore
             if name:

--- a/prompts/prompts.py
+++ b/prompts/prompts.py
@@ -4,9 +4,9 @@ PLANNER_SYSTEM_PROMPT = (
     "You are a Project Planner AI. Decompose the idea into role-specific tasks. Output ONLY JSON that matches {'tasks':[{'role':str,'title':str,'description':str}]}.")
 
 PLANNER_USER_PROMPT_TEMPLATE = (
-    "Project Idea: {idea}\n"
-    "Task: Break down into role-specific tasks.\n"
-    "Output JSON only.")
+    "Project idea: {idea}{constraints_section}{risk_section}\n"
+    "Break the project into role-specific tasks. "
+    "Output ONLY JSON matching {{\"tasks\": [...]}}.")
 
 SYNTHESIZER_TEMPLATE = """\
 You are a multi-disciplinary R&D lead.

--- a/tests/test_intake_scoping.py
+++ b/tests/test_intake_scoping.py
@@ -1,0 +1,63 @@
+import json
+
+from memory.memory_manager import MemoryManager
+from utils.search_tools import obfuscate_query
+from core.agents import planner_agent
+
+
+def test_redaction_masks_pii_and_idea_tokens():
+    idea = "Design SuperBattery 3000 for ACME Motors; ceo@acme.com"
+    q = "best suppliers for Superbattery 3000 at https://example.com"
+    red = obfuscate_query("Researcher", idea, q)
+    assert "[REDACTED_EMAIL]" in red
+    assert "[REDACTED_URL]" in red
+    assert "SuperBattery" not in red
+    assert "3000" not in red
+
+
+def test_planner_prompt_includes_constraints_and_risk(monkeypatch):
+    captured = {}
+
+    def fake_llm_call(_logger, model, stage, messages, **kwargs):
+        captured["messages"] = messages
+        # Minimal object with JSON content
+        class Resp:
+            choices = [
+                type(
+                    "obj",
+                    (),
+                    {
+                        "message": type("obj2", (), {"content": json.dumps({"tasks": []})})(),
+                        "finish_reason": "stop",
+                        "usage": type("U", (), {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0})(),
+                    },
+                )
+            ]
+
+        return Resp()
+
+    monkeypatch.setattr(planner_agent, "llm_call", fake_llm_call)
+    agent = planner_agent.PlannerAgent()
+    agent.run("Build battery", "", constraints="No cobalt", risk_posture="Low")
+    user_msg = [m for m in captured["messages"] if m["role"] == "user"][0]["content"]
+    assert "Constraints: No cobalt" in user_msg
+    assert "Risk posture: Low" in user_msg
+
+
+def test_memory_persists_new_fields(tmp_path):
+    file = tmp_path / "mem.json"
+    mm = MemoryManager(file_path=str(file))
+    mm.store_project(
+        "Test",
+        "Idea",
+        [],
+        {},
+        "Proposal",
+        constraints="C",
+        risk_posture="High",
+    )
+    with open(file, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    assert data[-1]["constraints"] == "C"
+    assert data[-1]["risk_posture"] == "High"
+


### PR DESCRIPTION
## Summary
- add constraints and risk posture fields to intake and persist in memory/Firestore
- propagate new fields into planner prompts and plan generation
- strengthen query redaction and enforce redact→route→log→network
- document sanitization order and new intake fields

## Testing
- `pytest tests/test_intake_scoping.py tests/test_live_search.py tests/test_orchestrator.py`


------
https://chatgpt.com/codex/tasks/task_e_68a67c748464832c9b143b2bd2ce7ad5