### PR TITLE
feat(planning): central schemas + deterministic segmenter (non‑breaking)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Model selections and **budget caps** for different modes live in `config/modes.y
 Each mode specifies a `target_cost_usd`, default models for the planning/execution/synthesis stages,
 and limits such as `k_search` and `max_loops`.
 
+Schemas live in `core/schemas.py`; segmentation utility in `planning/segmenter.py`.
+
 Token pricing lives in `config/prices.yaml` (override via `PRICES_PATH`).
 
 Set the mode via the `DRRD_MODE` environment variable. By default the app runs in Deep mode, but a developer-only Test mode can be enabled from the sidebar. The Streamlit interface includes an **Agent Trace** expander showing which agent handled each task, token counts and a brief finding.

--- a/core/schemas.py
+++ b/core/schemas.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel
+
+
+class ScopeNote(BaseModel):
+    idea: str
+    constraints: list[str]
+    time_budget_hours: Optional[float] = None
+    cost_budget_usd: Optional[float] = None
+    risk_posture: Literal["low", "medium", "high"]
+    redaction_rules: list[str]
+
+
+class ConceptBrief(BaseModel):
+    problem: str
+    value: str
+    users: list[str]
+    success_metrics: list[str]
+    risks: list[str]
+    cost_range: str
+
+
+class RoleCard(BaseModel):
+    role: str
+    responsibilities: list[str]
+    inputs: list[str]
+    outputs: list[str]
+
+
+class TaskSpec(BaseModel):
+    role: str
+    task: str
+    inputs: Optional[dict[str, Any]] = None
+    stop_rules: Optional[list[str]] = None
+
+
+__all__ = [
+    "ScopeNote",
+    "ConceptBrief",
+    "RoleCard",
+    "TaskSpec",
+]

--- a/planning/segmenter.py
+++ b/planning/segmenter.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from utils.redaction import load_policy, redact_text
+
+from core.schemas import ConceptBrief, TaskSpec
+
+RESPONSIBILITY_TO_ROLE = {
+    "research": "Research",
+    "regulatory": "Regulatory",
+    "finance": "Finance",
+    "marketing": "Marketing Analyst",
+    "cto": "CTO",
+}
+
+_POLICY = load_policy(Path(__file__).resolve().parents[1] / "config" / "redaction.yaml")
+
+
+def segment_concept_brief(brief: ConceptBrief) -> List[TaskSpec]:
+    tasks: List[TaskSpec] = []
+    if not brief.success_metrics:
+        return tasks
+    for metric in brief.success_metrics:
+        for responsibility, role in RESPONSIBILITY_TO_ROLE.items():
+            task_text = f"{responsibility.title()} perspective on '{metric}' for {brief.problem}"
+            task_text = redact_text(task_text, policy=_POLICY)
+            tasks.append(TaskSpec(role=role, task=task_text))
+    return tasks

--- a/tests/test_schemas_minimal.py
+++ b/tests/test_schemas_minimal.py
@@ -1,0 +1,40 @@
+from core.schemas import ConceptBrief, RoleCard, ScopeNote, TaskSpec
+
+
+def test_scope_note_instantiation():
+    note = ScopeNote(
+        idea="Idea",
+        constraints=["C1"],
+        time_budget_hours=1.0,
+        cost_budget_usd=10.0,
+        risk_posture="low",
+        redaction_rules=["email"],
+    )
+    assert note.idea == "Idea"
+
+
+def test_concept_brief_instantiation():
+    brief = ConceptBrief(
+        problem="P",
+        value="V",
+        users=["user"],
+        success_metrics=["metric"],
+        risks=["risk"],
+        cost_range="0-1",
+    )
+    assert brief.value == "V"
+
+
+def test_role_card_instantiation():
+    card = RoleCard(
+        role="R",
+        responsibilities=["do"],
+        inputs=["in"],
+        outputs=["out"],
+    )
+    assert card.role == "R"
+
+
+def test_task_spec_instantiation():
+    task = TaskSpec(role="R", task="Do")
+    assert task.task == "Do"

--- a/tests/test_segmenter.py
+++ b/tests/test_segmenter.py
@@ -1,0 +1,42 @@
+from core.schemas import ConceptBrief
+from planning.segmenter import segment_concept_brief
+
+
+def test_segmenter_happy_path():
+    brief = ConceptBrief(
+        problem="Leakage of data",
+        value="Secure system",
+        users=["dev"],
+        success_metrics=["Increase revenue"],
+        risks=["none"],
+        cost_range="0-1",
+    )
+    tasks = segment_concept_brief(brief)
+    assert len(tasks) == 5
+    assert all(task.role for task in tasks)
+
+
+def test_segmenter_empty_fields():
+    brief = ConceptBrief(
+        problem="none",
+        value="none",
+        users=[],
+        success_metrics=[],
+        risks=[],
+        cost_range="0-0",
+    )
+    tasks = segment_concept_brief(brief)
+    assert tasks == []
+
+
+def test_segmenter_applies_redaction():
+    brief = ConceptBrief(
+        problem="problem",
+        value="value",
+        users=["u"],
+        success_metrics=["Contact test@example.com"],
+        risks=[],
+        cost_range="0-1",
+    )
+    tasks = segment_concept_brief(brief)
+    assert any("[REDACTED:EMAIL]" in t.task for t in tasks)


### PR DESCRIPTION
## Summary
- centralize planning-related Pydantic models in `core/schemas.py`
- add deterministic concept brief segmenter with built-in redaction
- document schema and segmenter locations in README
- cover new utilities with unit tests

## Testing
- `pytest` *(fails: missing documentation, Streamlit stubs, and external API connection errors; new tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_68a68bdb2454832cab580c848f25d3c0