### PR TITLE
Use gpt-4-turbo for test mode

### DIFF
--- a/config/modes.yaml
+++ b/config/modes.yaml
@@ -1,7 +1,7 @@
 test:
   target_cost_usd: 2.50
   enforce_caps: false
-  models: { plan: gpt-5, exec: gpt-5, synth: gpt-5 }
+  models: { plan: gpt-4-turbo, exec: gpt-4-turbo, synth: gpt-4-turbo }
   k_search: 6
   max_loops: 5
   stage_weights: { plan: 0.20, exec: 0.50, synth: 0.30 }


### PR DESCRIPTION
## Summary
- switch test mode models to gpt-4-turbo
- keep deep mode on gpt-5

## Testing
- `pytest` (fails: Connection errors and attribute errors)

------
https://chatgpt.com/codex/tasks/task_e_68a694d742e0832ca370c1b4efe9b7b2