### PR TITLE
Allow model override for tests

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+max-line-length = 100
+per-file-ignores =
+    core/agents/base_agent.py:E731,E501
+    core/orchestrator.py:E501

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ profile = "black"
 
 [tool.flake8]
 max-line-length = 100
-per-file-ignores = {
-  "core/agents/base_agent.py" = ["E731", "E501"],
-  "core/orchestrator.py" = ["E501"],
-}
+
+[tool.flake8.per-file-ignores]
+"core/agents/base_agent.py" = ["E731", "E501"]
+"core/orchestrator.py" = ["E501"]

--- a/tests/test_profile_model.py
+++ b/tests/test_profile_model.py
@@ -9,3 +9,17 @@ def test_pro_profile_uses_gpt5(monkeypatch):
     assert resolve_model("Planner", "plan") == "gpt-5"
     # Synth stage
     assert resolve_model("Synthesizer", "synth") == "gpt-5"
+
+
+def test_test_profile_defaults_to_gpt4turbo(monkeypatch):
+    monkeypatch.setenv("DRRD_PROFILE", "test")
+    monkeypatch.delenv("OPENAI_MODEL", raising=False)
+    monkeypatch.delenv("DRRD_MODEL_EXEC_TEST", raising=False)
+    assert resolve_model("Research Scientist") == "gpt-4-turbo"
+
+
+def test_openai_model_override(monkeypatch):
+    monkeypatch.setenv("DRRD_PROFILE", "test")
+    monkeypatch.setenv("OPENAI_MODEL", "gpt-4o-mini")
+    monkeypatch.delenv("DRRD_MODEL_EXEC_TEST", raising=False)
+    assert resolve_model("Research Scientist") == "gpt-4o-mini"


### PR DESCRIPTION
## Summary
- allow OPENAI_MODEL or DRRD_MODEL_EXEC_TEST to override model in test profile
- add regression tests for default and override behaviour
- fix flake8 configuration and pyproject formatting

## Testing
- `pre-commit run --files core/agents/unified_registry.py tests/test_profile_model.py pyproject.toml .flake8` *(fails: bandit security issues)*
- `pytest tests/test_profile_model.py`


------
https://chatgpt.com/codex/tasks/task_e_68a73a9e1f9c832cbb62fd0a7c23da63