### PR TITLE
Normalize PDF ToC heading levels

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -114,8 +114,13 @@ def generate_pdf(markdown_text):
         pdf.out_file.seek(0)
         doc = fitz.open(stream=pdf.out_file, filetype="pdf")
     doc.set_metadata(pdf.meta)
-    if pdf.toc_level > 0:
-        doc.set_toc(pdf.toc)
+    if pdf.toc_level > 0 and pdf.toc:
+        try:
+            min_level = min(item[0] for item in pdf.toc)
+            normalized_toc = [[item[0] - min_level + 1, *item[1:]] for item in pdf.toc]
+            doc.set_toc(normalized_toc)
+        except Exception as e:
+            logging.warning(f"Failed to set PDF ToC: {e}")
     buffer = io.BytesIO()
     if pdf.optimize:
         doc.ez_save(buffer)

--- a/tests/test_pdf_generator.py
+++ b/tests/test_pdf_generator.py
@@ -40,3 +40,14 @@ def test_generate_pdf_wraps_long_lines(tmp_path):
     assert long_value[:40] in page_text
     assert long_value[-40:] in page_text
     (tmp_path / "json_report.pdf").write_bytes(pdf_bytes)
+
+
+def test_generate_pdf_normalizes_heading_levels(tmp_path):
+    if not md_spec:
+        pytest.skip("markdown_pdf not installed")
+    md = "## Subtitle\n\nContent\n\n### Subsection"
+    pdf_bytes = generate_pdf(md)
+    doc = fitz.open(stream=pdf_bytes, filetype="pdf")
+    toc = doc.get_toc()
+    doc.close()
+    assert toc and toc[0][0] == 1


### PR DESCRIPTION
## Summary
- Normalize heading levels in PDF table of contents so the smallest heading starts at level 1
- Skip invalid or empty ToCs when generating PDFs
- Add regression test ensuring PDF generation works when the first heading is level 2

## Testing
- `pytest tests/test_pdf_generator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a751263908832ca758ebde75d93ad1