### PR TITLE
Add gpt-4-turbo test model pricing

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+TEST_MODEL_ID=gpt-4-turbo

--- a/app/config_loader.py
+++ b/app/config_loader.py
@@ -34,8 +34,13 @@ def load_mode(mode: str) -> tuple[dict, CostTracker]:
         prices = yaml.safe_load(fh) or {}
 
     if mode == "test":
-        cheap = TEST_MODEL_ID or _cheap_default(prices.get("models", {}))
-        mode_cfg["models"] = {s: cheap for s in ["plan", "exec", "synth"]}
+        models = mode_cfg.get("models")
+        if not (
+            isinstance(models, dict)
+            and all(stage in models for stage in ["plan", "exec", "synth"])
+        ):
+            cheap = TEST_MODEL_ID or _cheap_default(prices.get("models", {}))
+            mode_cfg["models"] = {s: cheap for s in ["plan", "exec", "synth"]}
 
     budget = CostTracker(mode_cfg, prices)
     return mode_cfg, budget

--- a/config/prices.yaml
+++ b/config/prices.yaml
@@ -1,3 +1,4 @@
 models:
   gpt-5:   { in_per_1k: 0.00125, out_per_1k: 0.01000 }
+  gpt-4-turbo: { in_per_1k: 0.01000, out_per_1k: 0.03000 }
   default: { in_per_1k: 0.00125, out_per_1k: 0.01000 }


### PR DESCRIPTION
## Summary
- add gpt-4-turbo to price table
- keep test mode model settings when already configured
- declare TEST_MODEL_ID=gpt-4-turbo in environment file

## Testing
- `pytest -q` *(fails: FileNotFoundError for config/defaults.yaml and missing streamlit text_area stub)*

------
https://chatgpt.com/codex/tasks/task_e_68a7619b77c0832ca55c164d07796e6b