### PR TITLE
Unify model selection and enforce planner schema

### DIFF
--- a/core/privacy.py
+++ b/core/privacy.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+from typing import Any, Dict, Tuple, Union
+
+try:
+    import spacy  # type: ignore
+
+    try:
+        _NLP = spacy.load("en_core_web_sm")
+    except Exception:  # pragma: no cover - model may be missing
+        _NLP = None
+except Exception:  # pragma: no cover - spaCy not installed
+    spacy = None
+    _NLP = None
+
+
+def generate_alias_map(text: str) -> OrderedDict[str, str]:
+    """Return an OrderedDict mapping detected entities to aliases."""
+    candidates: list[tuple[int, str, str]] = []
+    if _NLP:
+        doc = _NLP(text)
+        for ent in doc.ents:
+            if ent.label_ in {"PERSON", "ORG", "PRODUCT"}:
+                candidates.append((ent.start_char, ent.text, ent.label_))
+    patterns = [
+        (r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}", "EMAIL"),
+        (r"\+?\d[\d\s\-]{7,}\d", "PHONE"),
+    ]
+    for pat, ttype in patterns:
+        for m in re.finditer(pat, text):
+            candidates.append((m.start(), m.group(0), ttype))
+    if not _NLP:
+        for m in re.finditer(r"\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\b", text):
+            val = m.group(1)
+            token = val.split()[-1]
+            ttype = "ORG" if token in {"Corp", "Inc", "LLC", "Company"} else "PERSON"
+            candidates.append((m.start(), val, ttype))
+    candidates.sort(key=lambda x: x[0])
+    aliases: OrderedDict[str, str] = OrderedDict()
+    counters: Dict[str, int] = {}
+    for _, value, ttype in candidates:
+        if value in aliases:
+            continue
+        counters[ttype] = counters.get(ttype, 0) + 1
+        aliases[value] = f"[{ttype}_{counters[ttype]}]"
+    return aliases
+
+
+def _apply_aliases(obj: Any, mapping: Dict[str, str]) -> Any:
+    items = sorted(mapping.items(), key=lambda kv: len(kv[0]), reverse=True)
+    if isinstance(obj, str):
+        out = obj
+        for orig, alias in items:
+            out = out.replace(orig, alias)
+        return out
+    if isinstance(obj, list):
+        return [_apply_aliases(v, mapping) for v in obj]
+    if isinstance(obj, dict):
+        return {k: _apply_aliases(v, mapping) for k, v in obj.items()}
+    return obj
+
+
+def _gather_text(obj: Union[dict, list, str]) -> str:
+    parts: list[str] = []
+
+    def _g(o: Any) -> None:
+        if isinstance(o, str):
+            parts.append(o)
+        elif isinstance(o, dict):
+            for v in o.values():
+                _g(v)
+        elif isinstance(o, list):
+            for v in o:
+                _g(v)
+
+    _g(obj)
+    return " ".join(parts)
+
+
+def pseudonymize_for_model(
+    payload: Union[dict, str],
+) -> Tuple[Union[dict, str], OrderedDict[str, str]]:
+    text = _gather_text(payload)
+    alias_map = generate_alias_map(text)
+    pseudo = _apply_aliases(payload, alias_map)
+    return pseudo, alias_map
+
+
+def rehydrate_output(obj: Union[dict, str], alias_map: Dict[str, str]) -> Union[dict, str]:
+    reverse = {v: k for k, v in alias_map.items()}
+    return _apply_aliases(obj, reverse)
+
+
+def redact_for_logging(obj: Union[dict, str]) -> Union[dict, str]:
+    text = _gather_text(obj)
+    alias_map = generate_alias_map(text)
+    redactions = {orig: alias.replace("[", "[REDACTED:") for orig, alias in alias_map.items()}
+    return _apply_aliases(obj, redactions)
+
+
+__all__ = [
+    "generate_alias_map",
+    "pseudonymize_for_model",
+    "rehydrate_output",
+    "redact_for_logging",
+]

--- a/core/schemas.py
+++ b/core/schemas.py
@@ -22,7 +22,8 @@ class Task(BaseModel):
     id: str
     role: str
     title: str
-    description: str
+    summary: str
+    description: Optional[str] = None
     inputs: Optional[Dict[str, Any]] = None
     dependencies: List[str] = Field(default_factory=list)
     stop_rules: List[str] = Field(default_factory=list)

--- a/prompts/prompts.py
+++ b/prompts/prompts.py
@@ -1,12 +1,15 @@
 """Central repository of prompt templates used across agents."""
 
 PLANNER_SYSTEM_PROMPT = (
-    "You are a Project Planner AI. Decompose the idea into role-specific tasks. Output ONLY JSON that matches {'tasks':[{'role':str,'title':str,'description':str}]}.")
+    "You are a Project Planner AI. Decompose the idea into role-specific tasks. "
+    'Output ONLY JSON matching this schema: {"tasks":[{"id":"T01","role":"Role","title":"Task title","summary":"Short"}]}.'
+)
 
 PLANNER_USER_PROMPT_TEMPLATE = (
     "Project idea: {idea}{constraints_section}{risk_section}\n"
     "Break the project into role-specific tasks. "
-    "Output ONLY JSON matching {{\"tasks\": [...]}}.")
+    'Output ONLY JSON matching {{"tasks": [...]}}.'
+)
 
 SYNTHESIZER_TEMPLATE = """\
 You are a multi-disciplinary R&D lead.
@@ -35,53 +38,53 @@ SYNTHESIZER_BUILD_GUIDE_TEMPLATE = (
     "{sections}\n"
     "Integrate these agent contributions into one cohesive document.\n\n"
     "Project Idea: {idea}\n\n"
-    "Agent Contributions:\n{contributions}")
+    "Agent Contributions:\n{contributions}"
+)
 
-CTO_SYSTEM_PROMPT = (
-    "You are the CTO. Assess feasibility, architecture, and risks. Return clear, structured guidance.")
+CTO_SYSTEM_PROMPT = "You are the CTO. Assess feasibility, architecture, and risks. Return clear, structured guidance."
 
 CTO_USER_PROMPT_TEMPLATE = (
-    "Project Idea:\n{idea}\n\n"
-    "Task Title:\n{title}\n\n"
-    "Task Description:\n{description}")
+    "Project Idea:\n{idea}\n\n" "Task Title:\n{title}\n\n" "Task Description:\n{description}"
+)
 
 REGULATORY_SYSTEM_PROMPT = (
     "You are a regulatory compliance expert with knowledge of industry standards and laws. "
     "You provide detailed compliance analysis, referencing standards and guidelines. "
-    "You justify how the design meets (or needs modifications to meet) each requirement and adjust recommendations if testing/simulation reveals new issues.")
+    "You justify how the design meets (or needs modifications to meet) each requirement and adjust recommendations if testing/simulation reveals new issues."
+)
 
 REGULATORY_USER_PROMPT_TEMPLATE = (
     "Project Idea: {idea}\n"
     "As the Regulatory expert, your task is {task}. Provide a thorough analysis of regulatory requirements and compliance steps in Markdown format, including any certifications or standards needed, and mapping of system components to regulations. "
-    "Include justification for each compliance recommendation (e.g., why a certain standard applies). Conclude with a JSON checklist of regulatory steps and compliance requirements.")
+    "Include justification for each compliance recommendation (e.g., why a certain standard applies). Conclude with a JSON checklist of regulatory steps and compliance requirements."
+)
 
-MARKETING_SYSTEM_PROMPT = (
-    "You are a marketing analyst with expertise in market research, customer segmentation, competitive landscapes and go-to-market strategies.")
+MARKETING_SYSTEM_PROMPT = "You are a marketing analyst with expertise in market research, customer segmentation, competitive landscapes and go-to-market strategies."
 
 MARKETING_USER_PROMPT_TEMPLATE = (
     "Project Idea: {idea}\n"
-    "As the Marketing Analyst, your task is {task}. Provide a marketing overview in Markdown. End with a JSON summary using keys: role, task, findings, risks, next_steps, sources.")
+    "As the Marketing Analyst, your task is {task}. Provide a marketing overview in Markdown. End with a JSON summary using keys: role, task, findings, risks, next_steps, sources."
+)
 
-FINANCE_SYSTEM_PROMPT = (
-    "You evaluate budgets, BOM costs and financial risks.")
+FINANCE_SYSTEM_PROMPT = "You evaluate budgets, BOM costs and financial risks."
 
-FINANCE_USER_PROMPT_TEMPLATE = (
-    "Project Idea: {idea}\n"
-    "As the Finance lead, your task is {task}.")
+FINANCE_USER_PROMPT_TEMPLATE = "Project Idea: {idea}\n" "As the Finance lead, your task is {task}."
 
-IP_ANALYST_SYSTEM_PROMPT = (
-    "You are an intellectual-property analyst skilled at prior-art searches, novelty assessment, patentability, and freedom-to-operate risk.")
+IP_ANALYST_SYSTEM_PROMPT = "You are an intellectual-property analyst skilled at prior-art searches, novelty assessment, patentability, and freedom-to-operate risk."
 
 IP_ANALYST_USER_PROMPT_TEMPLATE = (
     "Project Idea: {idea}\n"
-    "As the IP Analyst, your task is {task}. Provide an IP analysis in Markdown. End with a JSON summary using keys: role, task, findings, risks, next_steps, sources.")
+    "As the IP Analyst, your task is {task}. Provide an IP analysis in Markdown. End with a JSON summary using keys: role, task, findings, risks, next_steps, sources."
+)
 
 PATENT_SYSTEM_PROMPT = (
     "You are a patent attorney and innovation expert focusing on intellectual property. "
     "You thoroughly analyze existing patents and technical disclosures, referencing diagrams or figures if relevant. "
-    "You justify your conclusions on patentability and can adjust IP strategy if new technical feedback (e.g., simulation data) warrants it.")
+    "You justify your conclusions on patentability and can adjust IP strategy if new technical feedback (e.g., simulation data) warrants it."
+)
 
 PATENT_USER_PROMPT_TEMPLATE = (
     "Project Idea: {idea}\n"
     "As the Patent expert, your task is {task}. Provide an analysis in Markdown format of patentability, including any existing patents (with relevant patent figures or diagrams if applicable) and an IP strategy. "
-    "Include reasoning behind each recommendation (e.g., why certain features are patentable or not). Conclude with a JSON list of potential patent ideas or relevant patent references.")
+    "Include reasoning behind each recommendation (e.g., why certain features are patentable or not). Conclude with a JSON list of potential patent ideas or relevant patent references."
+)

--- a/tests/test_model_selection.py
+++ b/tests/test_model_selection.py
@@ -1,0 +1,27 @@
+import pytest
+
+from core.llm import select_model
+
+
+@pytest.mark.parametrize(
+    "ui,purpose_env,global_env,expected",
+    [
+        ("ui-choice", None, None, "ui-choice"),
+        (None, "purpose-model", None, "purpose-model"),
+        (None, None, "global-model", "global-model"),
+    ],
+)
+def test_select_model_precedence(monkeypatch, ui, purpose_env, global_env, expected):
+    monkeypatch.delenv("DRRD_FORCE_MODEL", raising=False)
+    monkeypatch.delenv("DRRD_MODEL_PLANNER", raising=False)
+    monkeypatch.delenv("DRRD_OPENAI_MODEL", raising=False)
+    if purpose_env:
+        monkeypatch.setenv("DRRD_MODEL_PLANNER", purpose_env)
+    if global_env:
+        monkeypatch.setenv("DRRD_OPENAI_MODEL", global_env)
+    assert select_model("planner", ui) == expected
+
+
+def test_select_model_forced_override(monkeypatch):
+    monkeypatch.setenv("DRRD_FORCE_MODEL", "forced")
+    assert select_model("planner", "ui-choice") == "forced"

--- a/tests/test_plan_routing.py
+++ b/tests/test_plan_routing.py
@@ -1,17 +1,21 @@
-import importlib, sys
+import importlib
+import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 
 def load_app():
-    st = SimpleNamespace(session_state={}, secrets={"gcp_service_account": {}}, cache_resource=lambda f: f)
-    sys.modules['streamlit'] = st
-    sys.modules['openai'] = MagicMock()
-    if 'app' in sys.modules:
-        importlib.reload(sys.modules['app'])
+    st = SimpleNamespace(
+        session_state={}, secrets={"gcp_service_account": {}}, cache_resource=lambda f: f
+    )
+    sys.modules["streamlit"] = st
+    sys.modules["openai"] = MagicMock()
+    sys.modules["filelock"] = MagicMock()
+    if "app" in sys.modules:
+        importlib.reload(sys.modules["app"])
     else:
-        importlib.import_module('app')
-    return sys.modules['app']
+        importlib.import_module("app")
+    return sys.modules["app"]
 
 
 def test_normalize_plan_formats():
@@ -23,9 +27,9 @@ def test_normalize_plan_formats():
 
 def test_role_alias_normalization():
     app = load_app()
-    tasks = app.normalize_tasks([
-        {"role": "Regulatory & Compliance Lead", "title": "t", "description": "d"}
-    ])
+    tasks = app.normalize_tasks(
+        [{"role": "Regulatory & Compliance Lead", "title": "t", "description": "d"}]
+    )
     assert tasks[0]["role"] == "Regulatory"
 
 

--- a/tests/test_planner_schema_alignment.py
+++ b/tests/test_planner_schema_alignment.py
@@ -1,0 +1,80 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from core.llm import ChatResult
+from core import orchestrator
+from core.orchestrator import generate_plan
+
+
+def _patch_streamlit(monkeypatch):
+    monkeypatch.setattr(orchestrator, "st", SimpleNamespace(session_state={}))
+
+
+def _patch_redaction(monkeypatch):
+    monkeypatch.setattr(orchestrator, "load_redaction_policy", lambda: {})
+    monkeypatch.setattr(orchestrator, "redact_text", lambda policy, txt: txt)
+
+
+def test_rehydration_before_validation(monkeypatch):
+    _patch_streamlit(monkeypatch)
+    _patch_redaction(monkeypatch)
+    monkeypatch.setenv("DRRD_PSEUDONYMIZE_TO_MODEL", "1")
+
+    def fake_complete(system, user, *, model, response_format):
+        payload = {
+            "tasks": [
+                {
+                    "id": "T01",
+                    "role": "Role",
+                    "title": "Meet [PERSON_1] at [ORG_1]",
+                    "summary": "Email [EMAIL_1]",
+                }
+            ]
+        }
+        return ChatResult(content=json.dumps(payload), raw=payload)
+
+    monkeypatch.setattr(orchestrator, "complete", fake_complete)
+    tasks = generate_plan(
+        "Alice Smith from Acme Corp, contact alice@acme.com",
+        ui_model="x",
+    )
+    assert "Alice Smith" in tasks[0]["title"]
+    assert "Acme Corp" in tasks[0]["title"]
+    assert "alice@acme.com" in tasks[0]["description"]
+    monkeypatch.delenv("DRRD_PSEUDONYMIZE_TO_MODEL", raising=False)
+
+
+def test_missing_ids_injected(monkeypatch, caplog):
+    _patch_streamlit(monkeypatch)
+    _patch_redaction(monkeypatch)
+
+    def fake_complete(system, user, *, model, response_format):
+        payload = {
+            "tasks": [
+                {"role": "Role", "title": "Task", "summary": "One"},
+                {"id": "T09", "role": "Role2", "title": "Task2", "summary": "Two"},
+            ]
+        }
+        return ChatResult(content=json.dumps(payload), raw=payload)
+
+    monkeypatch.setattr(orchestrator, "complete", fake_complete)
+    with caplog.at_level("INFO"):
+        tasks = generate_plan("idea", ui_model="x")
+    assert len(tasks) == 2
+    assert any("injected" in r.message for r in caplog.records)
+
+
+def test_description_field_rejected(monkeypatch):
+    _patch_streamlit(monkeypatch)
+    _patch_redaction(monkeypatch)
+
+    def bad_complete(system, user, *, model, response_format):
+        payload = {"tasks": [{"id": "T01", "role": "R", "title": "T", "description": "D"}]}
+        return ChatResult(content=json.dumps(payload), raw=payload)
+
+    monkeypatch.setattr(orchestrator, "complete", bad_complete)
+    with pytest.raises(ValueError) as exc:
+        generate_plan("idea", ui_model="x")
+    assert "summary" in str(exc.value)

--- a/tests/test_planner_schema_enforcement.py
+++ b/tests/test_planner_schema_enforcement.py
@@ -1,0 +1,48 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from core.llm import ChatResult
+from core import orchestrator
+from core.orchestrator import generate_plan
+
+
+def _patch_streamlit(monkeypatch):
+    monkeypatch.setattr(orchestrator, "st", SimpleNamespace(session_state={}))
+
+
+def _patch_redaction(monkeypatch):
+    monkeypatch.setattr(orchestrator, "load_redaction_policy", lambda: {})
+    monkeypatch.setattr(orchestrator, "redact_text", lambda policy, txt: txt)
+
+
+def test_normalizer_injects_ids(monkeypatch, caplog):
+    _patch_streamlit(monkeypatch)
+    _patch_redaction(monkeypatch)
+
+    def fake_complete(system, user, *, model, response_format):
+        payload = {
+            "tasks": [{"role": "Role", "title": "Task", "summary": "Done", "description": "Desc"}]
+        }
+        return ChatResult(content=json.dumps(payload), raw=payload)
+
+    monkeypatch.setattr(orchestrator, "complete", fake_complete)
+    with caplog.at_level("INFO"):
+        tasks = generate_plan("idea", ui_model="x")
+    assert tasks and tasks[0]["role"] == "Role"
+    assert any("injected" in r.message for r in caplog.records)
+
+
+def test_schema_violation(monkeypatch):
+    _patch_streamlit(monkeypatch)
+    _patch_redaction(monkeypatch)
+
+    def bad_complete(system, user, *, model, response_format):
+        payload = {"tasks": [{"id": "T01", "role": "Role", "title": "Task"}]}
+        return ChatResult(content=json.dumps(payload), raw=payload)
+
+    monkeypatch.setattr(orchestrator, "complete", bad_complete)
+    with pytest.raises(ValueError) as exc:
+        generate_plan("idea", ui_model="x")
+    assert "missing" in str(exc.value)

--- a/tests/test_privacy.py
+++ b/tests/test_privacy.py
@@ -1,0 +1,37 @@
+from collections import OrderedDict
+
+from core.privacy import (
+    pseudonymize_for_model,
+    rehydrate_output,
+    redact_for_logging,
+)
+
+
+SAMPLE = (
+    "Alice Smith from Acme Corp emailed alice@acme.com and called +1-555-555-5555. "
+    "Bob Jones replied."
+)
+
+
+def test_redact_and_pseudonymization():
+    redacted = redact_for_logging(SAMPLE)
+    assert "[REDACTED:PERSON_1]" in redacted
+    assert "[REDACTED:ORG_1]" in redacted
+    assert "[REDACTED:EMAIL_1]" in redacted
+    assert "[REDACTED:PHONE_1]" in redacted
+
+    pseudo, alias_map = pseudonymize_for_model(SAMPLE)
+    assert alias_map == OrderedDict(
+        [
+            ("Alice Smith", "[PERSON_1]"),
+            ("Acme Corp", "[ORG_1]"),
+            ("alice@acme.com", "[EMAIL_1]"),
+            ("+1-555-555-5555", "[PHONE_1]"),
+            ("Bob Jones", "[PERSON_2]"),
+        ]
+    )
+    for token in alias_map.values():
+        assert token in pseudo
+
+    rehydrated = rehydrate_output(pseudo, alias_map)
+    assert rehydrated == SAMPLE

--- a/tests/test_schemas_minimal.py
+++ b/tests/test_schemas_minimal.py
@@ -1,4 +1,4 @@
-from core.schemas import ConceptBrief, RoleCard, ScopeNote, TaskSpec
+from core.schemas import ConceptBrief, Plan, RoleCard, ScopeNote, Task, TaskSpec
 
 
 def test_scope_note_instantiation():
@@ -38,3 +38,8 @@ def test_role_card_instantiation():
 def test_task_spec_instantiation():
     task = TaskSpec(role="R", task="Do")
     assert task.task == "Do"
+
+
+def test_plan_requires_id_and_summary():
+    plan = Plan(tasks=[Task(id="T1", role="R", title="T", summary="S")])
+    assert plan.tasks[0].id == "T1"


### PR DESCRIPTION
## Summary
- add select_model helper with UI, purpose, global, and forced override precedence
- log final model once per request and remove implicit gpt-5 fallbacks
- route UI-selected model into planner and enforce strict schema with task-ID normalizer
- introduce privacy utilities for redaction, pseudonymization, and rehydration
- redact LLM logs, optionally pseudonymize planner inputs, and require planner JSON schema with id/role/title/summary

## Testing
- `python -m black core/privacy.py core/llm.py core/llm_client.py core/orchestrator.py core/schemas.py prompts/prompts.py tests/test_privacy.py tests/test_planner_schema_alignment.py tests/test_schemas_minimal.py tests/test_planner_schema_enforcement.py`
- `python -m flake8 tests/test_privacy.py tests/test_planner_schema_alignment.py`
- `pytest tests/test_model_selection.py tests/test_planner_schema_enforcement.py tests/test_privacy.py tests/test_planner_schema_alignment.py tests/test_plan_utils_normalize.py tests/test_planner_normalize.py tests/test_plan_routing.py tests/test_schemas_minimal.py`


------
https://chatgpt.com/codex/tasks/task_e_68a76e55b9d4832c890a0f3b048d601a