### PR TITLE
Unify model selection and router synonyms

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -909,11 +909,12 @@ def main():
                 logging.error(f"Init project failed: {e}")
         try:
             with st.spinner("📝 Planning..."):
+                ui_model = st.session_state.get("model")
                 tasks = generate_plan(
                     idea,
                     st.session_state.get("constraints"),
                     st.session_state.get("risk_posture"),
-                    st.session_state.get("model"),
+                    ui_model,
                 )
                 update_cost()
             if isinstance(tasks, dict):
@@ -1029,6 +1030,7 @@ def main():
             with st.spinner("🤖 Running domain experts..."):
                 try:
                     tasks = st.session_state.get("plan", [])
+                    ui_model = st.session_state.get("model")
                     results = execute_plan(
                         idea,
                         tasks,
@@ -1036,6 +1038,7 @@ def main():
                         save_decision_log=st.session_state.get("save_decision_log", False),
                         save_evidence=st.session_state.get("save_evidence_coverage", False),
                         project_name=st.session_state.get("project_name"),
+                        ui_model=ui_model,
                     )
                     st.session_state["answers"] = results
                     if use_firestore:

--- a/core/agents/hrm_role_agent.py
+++ b/core/agents/hrm_role_agent.py
@@ -23,13 +23,13 @@ Output strictly as JSON: {{"roles": [...]}}
 
 class HRMRoleAgent(BaseAgent):
     def __init__(self, **kwargs):
-        model = kwargs.pop("model", os.getenv("DRRD_PLAN_MODEL", "gpt-5"))
+        model = kwargs.pop("model", os.getenv("DRRD_PLAN_MODEL", "gpt-4.1-mini"))
         super().__init__(name="HRM Role Agent", model=model, system_message="", user_prompt_template="", **kwargs)
 
     def discover_roles(self, idea: str) -> list[str]:
         user_prompt = HRM_USER_FMT.format(idea=idea)
         try:
-            out = complete(HRM_SYSTEM, user_prompt, model=os.getenv("DRRD_PLAN_MODEL", "gpt-5"))
+            out = complete(HRM_SYSTEM, user_prompt, model=os.getenv("DRRD_PLAN_MODEL", "gpt-4.1-mini"))
         except TypeError:
             out = complete(HRM_SYSTEM, user_prompt)
         text = out if isinstance(out, str) else getattr(out, "content", str(out))

--- a/core/agents/planner_agent.py
+++ b/core/agents/planner_agent.py
@@ -130,9 +130,9 @@ def run_planner(
 class PlannerAgent:
     """Lightweight wrapper maintaining backwards compatible interface."""
 
-    def __init__(self, model: str = "gpt-5", repair_model: Optional[str] = "gpt-5"):
+    def __init__(self, model: str = "gpt-4.1-mini", repair_model: Optional[str] = None):
         self.model = model
-        self.repair_model = repair_model
+        self.repair_model = repair_model or model
         self.system_message = SYSTEM
         self.name = "Planner"
 

--- a/core/agents/registry.py
+++ b/core/agents/registry.py
@@ -47,7 +47,7 @@ def get_agent_class(role: str) -> Optional[Type[BaseAgent]]:
 # Factory utilities for creating commonly used agent instances
 # ---------------------------------------------------------------------------
 
-DEFAULT_EXEC_MODEL = AGENT_MODEL_MAP.get("Research Scientist", "gpt-5")
+DEFAULT_EXEC_MODEL = AGENT_MODEL_MAP.get("Research Scientist", "gpt-4.1-mini")
 AGENT_MODEL_MAP.setdefault(
     "Marketing Analyst", AGENT_MODEL_MAP.get("Research Scientist", DEFAULT_EXEC_MODEL)
 )
@@ -193,8 +193,8 @@ def load_mode_models(mode: str | None = None) -> dict:
     AGENTS = build_agents(mode, models=m)
     # Map planner/synth plus sensible defaults for exec/default
     return {
-        "Planner": m.get("plan", "gpt-5"),
-        "exec": m.get("exec", m.get("plan", "gpt-5")),
-        "synth": m.get("synth", m.get("exec", "gpt-5")),
-        "default": m.get("exec", m.get("plan", "gpt-5")),
+        "Planner": m.get("plan", "gpt-4.1-mini"),
+        "exec": m.get("exec", m.get("plan", "gpt-4.1-mini")),
+        "synth": m.get("synth", m.get("exec", "gpt-4.1-mini")),
+        "default": m.get("exec", m.get("plan", "gpt-4.1-mini")),
     }

--- a/core/agents/unified_registry.py
+++ b/core/agents/unified_registry.py
@@ -19,11 +19,11 @@ logger = logging.getLogger("unified_registry")
 def resolve_model(role: str, purpose: str = "exec") -> str:
     """
     purpose: 'exec' | 'plan' | 'synth'
-    Uses environment overrides to decide model. Defaults to ``gpt-5`` for most
+    Uses environment overrides to decide model. Defaults to ``gpt-4.1-mini`` for most
     profiles and ``gpt-4-turbo`` for ``test`` unless overridden.
     """
     profile = os.getenv("DRRD_PROFILE", "deep").lower()
-    default_model = os.getenv("OPENAI_MODEL", "gpt-5")
+    default_model = os.getenv("OPENAI_MODEL", "gpt-4.1-mini")
 
     if purpose == "plan":
         return os.getenv("DRRD_MODEL_PLAN") or default_model

--- a/core/privacy.py
+++ b/core/privacy.py
@@ -93,10 +93,26 @@ def rehydrate_output(obj: Union[dict, str], alias_map: Dict[str, str]) -> Union[
     return _apply_aliases(obj, reverse)
 
 
+ALLOWLIST = {
+    "CTO",
+    "Planner",
+    "Research Scientist",
+    "Regulatory",
+    "Synthesizer",
+    "Finance",
+    "IP Analyst",
+    "Marketing Analyst",
+    "Mechanical Systems Lead",
+    "Project Manager",
+    "Risk Manager",
+}
+
+
 def redact_for_logging(obj: Union[dict, str]) -> Union[dict, str]:
     text = _gather_text(obj)
     alias_map = generate_alias_map(text)
-    redactions = {orig: alias.replace("[", "[REDACTED:") for orig, alias in alias_map.items()}
+    filtered = {orig: alias for orig, alias in alias_map.items() if orig not in ALLOWLIST}
+    redactions = {orig: alias.replace("[", "[REDACTED:") for orig, alias in filtered.items()}
     return _apply_aliases(obj, redactions)
 
 

--- a/core/router.py
+++ b/core/router.py
@@ -6,6 +6,7 @@ import logging
 from typing import Dict, Tuple, Type
 
 from core.agents.registry import AGENT_REGISTRY
+from core.llm import select_model
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +34,14 @@ ALIASES: Dict[str, str] = {
 }
 
 
+ROLE_SYNONYMS: Dict[str, str] = {
+    "Project Manager": "Planner",
+    "Program Manager": "Planner",
+    "Product Manager": "Planner",
+    "Risk Manager": "Regulatory",
+}
+
+
 def _alias(role: str | None) -> str | None:
     if not role:
         return role
@@ -40,9 +49,12 @@ def _alias(role: str | None) -> str | None:
 
 
 def choose_agent_for_task(
-    planned_role: str | None, title: str, description: str
-) -> Tuple[str, Type]:
-    """Return the canonical role and agent class for a task.
+    planned_role: str | None,
+    title: str,
+    description: str,
+    ui_model: str | None = None,
+) -> Tuple[str, Type, str]:
+    """Return the canonical role, agent class, and model for a task.
 
     Parameters
     ----------
@@ -61,31 +73,38 @@ def choose_agent_for_task(
 
     # 1) Exact match on planned_role via the central registry
     role = _alias(planned_role)
+    if role:
+        role = ROLE_SYNONYMS.get(role, role)
     if role and role in AGENT_REGISTRY:
-        return role, AGENT_REGISTRY[role]
+        model = select_model("agent", ui_model, agent_name=role)
+        return role, AGENT_REGISTRY[role], model
 
     # 2) Keyword heuristics over title + description
     text = f"{title} {description}".lower()
     for kw, role in KEYWORDS.items():
         if kw in text and role in AGENT_REGISTRY:
-            return role, AGENT_REGISTRY[role]
+            model = select_model("agent", ui_model, agent_name=role)
+            return role, AGENT_REGISTRY[role], model
 
-    # 3) Default to Research Scientist with warning
+    # 3) Fallback to Synthesizer with info log
     if planned_role:
-        logger.warning("Unresolved role: %s", planned_role)
-    return "Research Scientist", AGENT_REGISTRY["Research Scientist"]
+        logger.info("Fallback routing %r → Synthesizer", planned_role)
+    model = select_model("agent", ui_model, agent_name="Synthesizer")
+    return "Synthesizer", AGENT_REGISTRY["Synthesizer"], model
 
 
-def route_task(task: Dict[str, str]) -> Tuple[str, Type, Dict[str, str]]:
+def route_task(
+    task: Dict[str, str], ui_model: str | None = None
+) -> Tuple[str, Type, str, Dict[str, str]]:
     """Resolve role/agent for a task dict without dropping fields."""
-    role, cls = choose_agent_for_task(
-        task.get("role"), task.get("title", ""), task.get("description", "")
+    role, cls, model = choose_agent_for_task(
+        task.get("role"), task.get("title", ""), task.get("description", ""), ui_model
     )
     out = dict(task)
     out["role"] = role
     out.setdefault("stop_rules", task.get("stop_rules", []))
-    return role, cls, out
+    return role, cls, model, out
 
 
-__all__ = ["choose_agent_for_task", "KEYWORDS", "ALIASES", "route_task"]
+__all__ = ["choose_agent_for_task", "KEYWORDS", "ALIASES", "ROLE_SYNONYMS", "route_task"]
 

--- a/core/schemas.py
+++ b/core/schemas.py
@@ -33,7 +33,7 @@ class Task(BaseModel):
 class Plan(BaseModel):
     """Planner response schema."""
 
-    tasks: List[Task] = Field(default_factory=list)
+    tasks: List[Task] = Field(min_length=1)
 
 
 class ConceptBrief(BaseModel):

--- a/tests/test_agent_model_selection.py
+++ b/tests/test_agent_model_selection.py
@@ -1,0 +1,60 @@
+import types
+import os
+import core.llm_client as llm_client
+from core import router
+
+
+def _run(task, ui_model, monkeypatch):
+    captured = {}
+
+    def fake_call(model, messages, **kwargs):
+        captured["model"] = model
+        return {"raw": types.SimpleNamespace(), "text": ""}
+
+    monkeypatch.setattr(llm_client, "call_openai", fake_call)
+    monkeypatch.setattr("core.llm.call_openai", fake_call)
+    role, cls, model, routed = router.route_task(task, ui_model)
+    agent = cls(model)
+    try:
+        agent.act("idea", routed, model=model)
+    except Exception:
+        try:
+            agent.run("idea", {}, model=model)
+        except Exception:
+            pass
+    return captured.get("model")
+
+
+def test_ui_model(monkeypatch):
+    task = {"role": "Research Scientist", "title": "t", "description": "d"}
+    used = _run(task, "ui-model", monkeypatch)
+    assert used == "ui-model"
+
+
+def test_env_model(monkeypatch):
+    task = {"role": "Research Scientist", "title": "t", "description": "d"}
+    monkeypatch.delenv("DRRD_FORCE_MODEL", raising=False)
+    monkeypatch.setenv("DRRD_MODEL_AGENT", "env-model")
+    used = _run(task, None, monkeypatch)
+    assert used == "env-model"
+    monkeypatch.delenv("DRRD_MODEL_AGENT", raising=False)
+
+
+def test_per_agent_override(monkeypatch):
+    monkeypatch.delenv("DRRD_MODEL_AGENT", raising=False)
+    monkeypatch.setenv("DRRD_MODEL_AGENT_SYNTHESIZER", "synth-model")
+    synth_task = {"role": "Synthesizer", "title": "", "description": ""}
+    used_s = _run(synth_task, None, monkeypatch)
+    assert used_s == "synth-model"
+    rs_task = {"role": "Research Scientist", "title": "t", "description": "d"}
+    used_r = _run(rs_task, None, monkeypatch)
+    assert used_r == "gpt-4.1-mini"
+    monkeypatch.delenv("DRRD_MODEL_AGENT_SYNTHESIZER", raising=False)
+
+
+def test_force_model(monkeypatch):
+    task = {"role": "Research Scientist", "title": "t", "description": "d"}
+    monkeypatch.setenv("DRRD_FORCE_MODEL", "forced")
+    used = _run(task, "ui-model", monkeypatch)
+    assert used == "forced"
+    monkeypatch.delenv("DRRD_FORCE_MODEL", raising=False)

--- a/tests/test_business_agents.py
+++ b/tests/test_business_agents.py
@@ -63,11 +63,11 @@ def test_ip_agent_contract(mock_call):
 
 
 def test_router_dispatches_to_new_agents():
-    role1, cls1 = choose_agent_for_task(
+    role1, cls1, _ = choose_agent_for_task(
         None, "Analyze competitor pricing and market segments", ""
     )
     assert cls1.__name__ == "MarketingAgent" and role1 == "Marketing Analyst"
-    role2, cls2 = choose_agent_for_task(
+    role2, cls2, _ = choose_agent_for_task(
         None, "Review patent claims for novelty", ""
     )
     assert cls2.__name__ == "IPAnalystAgent" and role2 == "IP Analyst"

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -6,7 +6,7 @@ from core.orchestrator import generate_plan, execute_plan, compile_proposal
 @patch("core.orchestrator.complete")
 def test_generate_plan_parses_llm_output(mock_complete):
     mock_complete.return_value = Mock(
-        content='[{"role": "CTO", "title": "Plan", "description": "Design"}]'
+        content='{"tasks": [{"role": "CTO", "title": "Plan", "summary": "Design"}]}'
     )
     tasks = generate_plan("new idea")
     assert tasks == [
@@ -16,15 +16,18 @@ def test_generate_plan_parses_llm_output(mock_complete):
 
 
 @patch("core.orchestrator._invoke_agent")
-@patch("core.orchestrator.choose_agent_for_task")
-def test_execute_plan_routes_and_invokes_agents(mock_choose, mock_invoke):
+@patch("core.orchestrator.route_task")
+def test_execute_plan_routes_and_invokes_agents(mock_route, mock_invoke):
     class DummyAgent:
         def __init__(self, model):
             self.model = model
 
-    mock_choose.return_value = ("Research Scientist", DummyAgent)
+    mock_route.side_effect = [
+        ("Research Scientist", DummyAgent, "m1", {"title": "t1", "description": "d1", "role": "Research Scientist", "stop_rules": []}),
+        ("Research Scientist", DummyAgent, "m1", {"title": "t2", "description": "d2", "role": "Research Scientist", "stop_rules": []}),
+    ]
 
-    def side_effect(agent, idea, task):
+    def side_effect(agent, idea, task, model=None):
         return f"{task['title']}-out"
 
     mock_invoke.side_effect = side_effect
@@ -32,9 +35,9 @@ def test_execute_plan_routes_and_invokes_agents(mock_choose, mock_invoke):
         {"role": "Research Scientist", "title": "t1", "description": "d1"},
         {"role": "Research Scientist", "title": "t2", "description": "d2"},
     ]
-    answers = execute_plan("idea", tasks)
+    answers = execute_plan("idea", tasks, ui_model=None)
     assert answers["Research Scientist"] == "t1-out\n\nt2-out"
-    assert mock_choose.call_count == 2
+    assert mock_route.call_count == 2
 
 
 @patch("core.orchestrator.complete")

--- a/tests/test_plan_min_items.py
+++ b/tests/test_plan_min_items.py
@@ -1,0 +1,16 @@
+import pytest
+from pydantic import ValidationError
+from core.schemas import Plan
+from core.orchestrator import _normalize_plan_payload
+
+
+def test_plan_requires_tasks():
+    with pytest.raises(ValidationError):
+        Plan.model_validate({"tasks": []})
+
+
+def test_normalizer_injects_ids():
+    data = {"tasks": [{"role": "Research Scientist", "title": "A", "summary": "B"}]}
+    norm = _normalize_plan_payload(data)
+    validated = Plan.model_validate(norm)
+    assert validated.tasks[0].id == "T01"

--- a/tests/test_redaction_allowlist.py
+++ b/tests/test_redaction_allowlist.py
@@ -1,0 +1,8 @@
+from core.privacy import redact_for_logging
+
+
+def test_allowlist_roles():
+    text = "You are the CTO AI. Contact test@example.com"
+    redacted = redact_for_logging(text)
+    assert "CTO" in redacted
+    assert "example.com" not in redacted

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -3,40 +3,40 @@ from core.agents.registry import AGENT_REGISTRY
 
 
 def test_agent_mapping_cto():
-    role, cls = choose_agent_for_task(
+    role, cls, _ = choose_agent_for_task(
         None, "Evaluate system architecture and risk", ""
     )
     assert role == "CTO" and cls is AGENT_REGISTRY["CTO"]
 
 
 def test_agent_mapping_research():
-    role, cls = choose_agent_for_task(
+    role, cls, _ = choose_agent_for_task(
         None, "Survey materials and physics literature", ""
     )
-    assert role == "Research Scientist" and cls is AGENT_REGISTRY["Research Scientist"]
+    assert role == "Synthesizer" and cls is AGENT_REGISTRY["Synthesizer"]
 
 
 def test_agent_mapping_regulatory():
-    role, cls = choose_agent_for_task(
+    role, cls, _ = choose_agent_for_task(
         None, "Check FDA compliance and ISO standards", ""
     )
     assert role == "Regulatory" and cls is AGENT_REGISTRY["Regulatory"]
 
 
 def test_agent_mapping_finance_keyword():
-    role, cls = choose_agent_for_task(
+    role, cls, _ = choose_agent_for_task(
         None, "Estimate BOM cost and budget", ""
     )
     assert role == "Finance" and cls is AGENT_REGISTRY["Finance"]
 
 
 def test_agent_exact_role_over_keyword():
-    role, cls = choose_agent_for_task(
+    role, cls, _ = choose_agent_for_task(
         "Finance", "Analyze competitor pricing and market segments", ""
     )
     assert role == "Finance" and cls is AGENT_REGISTRY["Finance"]
 
 
 def test_agent_mapping_default():
-    role, cls = choose_agent_for_task(None, "Unrecognized task", "")
-    assert role == "Research Scientist" and cls is AGENT_REGISTRY["Research Scientist"]
+    role, cls, _ = choose_agent_for_task(None, "Unrecognized task", "")
+    assert role == "Synthesizer" and cls is AGENT_REGISTRY["Synthesizer"]

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -5,20 +5,20 @@ from core.agents.registry import AGENT_REGISTRY
 
 
 def test_alias_mapping():
-    role, cls = choose_agent_for_task("Manufacturing Technician", "", "")
+    role, cls, _ = choose_agent_for_task("Manufacturing Technician", "", "")
     assert role == "Research Scientist"
     assert cls is AGENT_REGISTRY[role]
 
 
 def test_unresolved_role_logs(caplog):
-    caplog.set_level(logging.WARNING)
-    role, cls = choose_agent_for_task("Unknown Role", "title", "desc")
-    assert role == "Research Scientist"
-    assert any("Unknown Role" in r.message for r in caplog.records)
+    caplog.set_level(logging.INFO)
+    role, cls, _ = choose_agent_for_task("Unknown Role", "title", "desc")
+    assert role == "Synthesizer"
+    assert any("Fallback routing" in r.message for r in caplog.records)
 
 
 def test_stop_rules_propagation():
     task = {"role": "Finance", "title": "Budget", "description": "", "stop_rules": ["halt"]}
-    role, cls, routed = route_task(task)
+    role, cls, _, routed = route_task(task)
     assert routed["stop_rules"] == ["halt"]
     assert role == routed["role"]

--- a/tests/test_router_no_drop.py
+++ b/tests/test_router_no_drop.py
@@ -3,7 +3,7 @@ from core.agents.registry import AGENT_REGISTRY
 
 
 def test_keyword_routing():
-    role, cls = choose_agent_for_task(
+    role, cls, _ = choose_agent_for_task(
         None, "Budget Planning", "ROI and BOM"
     )
     assert role == "Finance"
@@ -11,8 +11,8 @@ def test_keyword_routing():
 
 
 def test_default_role():
-    role, cls = choose_agent_for_task(
+    role, cls, _ = choose_agent_for_task(
         None, "Investigate", "quantum entanglement"
     )
-    assert role == "Research Scientist"
-    assert cls is AGENT_REGISTRY["Research Scientist"]
+    assert role == "Synthesizer"
+    assert cls is AGENT_REGISTRY["Synthesizer"]

--- a/tests/test_router_synonyms.py
+++ b/tests/test_router_synonyms.py
@@ -1,0 +1,16 @@
+import logging
+from core.router import choose_agent_for_task
+
+
+def test_synonym_mapping():
+    role, _, _ = choose_agent_for_task("Project Manager", "", "")
+    assert role == "Planner"
+    role, _, _ = choose_agent_for_task("Risk Manager", "", "")
+    assert role == "Regulatory"
+
+
+def test_fallback_to_synthesizer(caplog):
+    caplog.set_level(logging.INFO)
+    role, _, _ = choose_agent_for_task("Unknown", "", "")
+    assert role == "Synthesizer"
+    assert any("Fallback routing" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- Centralize model resolution with agent-specific env overrides and forced model warnings
- Route all tasks through synonym-aware agent selection with Synthesizer fallback
- Require at least one planner task and allowlist common role titles during log redaction

## Testing
- `pytest tests/test_agent_model_selection.py tests/test_router_synonyms.py tests/test_plan_min_items.py tests/test_redaction_allowlist.py tests/test_router.py tests/test_router_no_drop.py tests/test_registry.py tests/test_business_agents.py tests/test_orchestrator.py tests/test_model_selection.py`
- `pytest` *(fails: ImportError in memory/test_memory_manager.py, test_intake_scoping.py, test_pdf_generator.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a77db09d90832c81c3a0744dad1fe0