### PR TITLE
refactor: unify model selection and logging

### DIFF
--- a/app/ui_cost_meter.py
+++ b/app/ui_cost_meter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import streamlit as st
 from config.mode_profiles import UI_PRESETS
 from app.price_loader import cost_usd, load_prices
+from core.llm import select_model
 
 
 def _estimate_remaining(plan: dict | list | None, stage_counts: dict[str, int], mode: str) -> float:
@@ -25,7 +26,10 @@ def _estimate_remaining(plan: dict | list | None, stage_counts: dict[str, int], 
         remaining = calls - stage_counts.get(stage, 0)
         if remaining <= 0:
             continue
-        model = models.get(stage, models.get("exec", models.get("plan", "gpt-5")))
+        model = models.get(
+            stage,
+            models.get("exec", models.get("plan", select_model("agent"))),
+        )
         weight = weights.get(stage, 0.0)
         stage_budget = target * weight
         per_call_budget = stage_budget / calls if calls else 0.0

--- a/core/agents/invoke.py
+++ b/core/agents/invoke.py
@@ -1,0 +1,15 @@
+"""Agent invocation utilities."""
+from typing import Callable
+
+CALL_ATTRS = ("run", "invoke", "__call__")
+
+
+def resolve_invoker(agent) -> Callable:
+    """Return the first callable attr from CALL_ATTRS or raise TypeError."""
+    for name in CALL_ATTRS:
+        fn = getattr(agent, name, None)
+        if callable(fn):
+            return fn
+    raise TypeError(
+        f"{type(agent).__name__} has no callable interface (expected one of {CALL_ATTRS})"
+    )

--- a/core/agents_registry.py
+++ b/core/agents_registry.py
@@ -1,4 +1,3 @@
-import os
 from core.agents.base_agent import LLMRoleAgent
 from core.agents.hrm_agent import HRMAgent
 from core.agents.planner_agent import PlannerAgent
@@ -7,8 +6,9 @@ from core.agents.chief_scientist_agent import ChiefScientistAgent
 from core.agents.materials_engineer_agent import MaterialsEngineerAgent
 from core.agents.regulatory_specialist_agent import RegulatorySpecialistAgent
 from core.agents.registry import get_agent_class
+from core.llm import select_model
 
-MODEL = os.getenv("OPENAI_MODEL", "gpt-5").strip()
+MODEL = select_model("agent")
 
 agents_dict = {
     "HRM": HRMAgent("HRM", MODEL),

--- a/core/model_router.py
+++ b/core/model_router.py
@@ -6,23 +6,25 @@ from config.model_routing import (
     _cheap_default,
 )
 import streamlit as st
+from core.llm import select_model
 
 
 def pick_model(h: CallHints) -> dict:
+    hard_model = select_model("agent")
     if h.stage == "plan":
-        sel = {"model": DEFAULTS["PLANNER"], "repair_model": "gpt-5", "params": {}}
+        sel = {"model": DEFAULTS["PLANNER"], "repair_model": hard_model, "params": {}}
         if h.difficulty == "hard":
-            sel["model"] = "gpt-5"
+            sel["model"] = hard_model
     elif h.stage == "exec":
         sel = {"model": DEFAULTS["RESEARCHER"], "params": {}}
         if h.difficulty == "hard":
-            sel["model"] = "gpt-5"
+            sel["model"] = hard_model
     elif h.stage == "eval":
         sel = {"model": DEFAULTS["EVALUATOR"], "params": {}}
     elif h.stage == "brain":
         model = DEFAULTS["BRAIN_MODE_LOOP"]
         if h.deep_reasoning:
-            model = "gpt-5"
+            model = hard_model
         sel = {"model": model, "params": {}}
     elif h.stage == "synth":
         model = DEFAULTS["SYNTHESIZER"]

--- a/tests/test_agent_invocation.py
+++ b/tests/test_agent_invocation.py
@@ -1,0 +1,23 @@
+import pytest
+
+from core.agents.invoke import resolve_invoker
+
+
+class NoIface:
+    pass
+
+
+class Runs:
+    def run(self, *, task, model: str | None = None):
+        return task["x"]
+
+
+def test_missing_interface():
+    with pytest.raises(TypeError) as exc:
+        resolve_invoker(NoIface())
+    assert "no callable interface" in str(exc.value)
+
+
+def test_run_invocation():
+    inv = resolve_invoker(Runs())
+    assert inv(task={"x": 1}, model="m") == 1

--- a/tests/test_llm_client_logging.py
+++ b/tests/test_llm_client_logging.py
@@ -1,0 +1,25 @@
+import logging
+import re
+
+import pytest
+
+from core import llm_client
+
+
+class DummyResp:
+    http_status = 200
+    output = []
+
+
+def test_logging_includes_request_id(monkeypatch, caplog):
+    monkeypatch.setattr(llm_client.client.responses, "create", lambda **kwargs: DummyResp())
+    monkeypatch.setattr(llm_client, "extract_text", lambda resp: "hi")
+    caplog.set_level(logging.INFO)
+    llm_client.call_openai(model="m", messages=[{"role": "user", "content": "hi"}], meta={"purpose": "p", "agent": "a"})
+    start = next(r.message for r in caplog.records if r.message.startswith("LLM start"))
+    end = next(r.message for r in caplog.records if r.message.startswith("LLM end"))
+    rid_start = re.search(r"req=([0-9a-f]+)", start).group(1)
+    rid_end = re.search(r"req=([0-9a-f]+)", end).group(1)
+    assert rid_start == rid_end
+    duration = int(re.search(r"duration_ms=(\d+)", end).group(1))
+    assert duration >= 0

--- a/tests/test_planner_schema.py
+++ b/tests/test_planner_schema.py
@@ -1,0 +1,17 @@
+import pytest
+from pydantic import ValidationError
+
+from core.schemas import Plan
+from core.orchestrator import _normalize_plan_payload
+
+
+def test_zero_tasks_invalid():
+    with pytest.raises(ValidationError):
+        Plan.model_validate({"tasks": []})
+
+
+def test_missing_ids_injected():
+    data = {"tasks": [{"role": "Research Scientist", "title": "A", "summary": "B"}]}
+    norm = _normalize_plan_payload(data)
+    validated = Plan.model_validate(norm)
+    assert validated.tasks[0].id == "T01"

--- a/tests/test_privacy_redaction.py
+++ b/tests/test_privacy_redaction.py
@@ -1,0 +1,16 @@
+from core.privacy import redact_for_logging, pseudonymize_for_model, rehydrate_output
+
+
+def test_roles_preserved_and_pii_redacted():
+    text = "CTO Jane Doe <jane@example.com>"
+    red = redact_for_logging(text)
+    assert "CTO" in red
+    assert "Jane" not in red and "example.com" not in red
+
+
+def test_pseudonymize_roundtrip():
+    payload = {"name": "Jane Doe", "email": "jane@example.com"}
+    pseudo, mapping = pseudonymize_for_model(payload)
+    assert "Jane" not in str(pseudo)
+    restored = rehydrate_output(pseudo, mapping)
+    assert restored == payload


### PR DESCRIPTION
## Summary
- centralize model routing and remove hard-coded gpt-5 defaults
- add request-scoped logging with request IDs and latency measurements
- introduce agent invocation helper and cover privacy redaction & planner schema in tests

## Testing
- `pytest tests/test_model_selection.py tests/test_router_synonyms.py tests/test_agent_invocation.py tests/test_privacy_redaction.py tests/test_planner_schema.py tests/test_llm_client_logging.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a79010c65c832cb69537f8c187ea5a