### PR TITLE
Improve LLM logging and model overrides

### DIFF
--- a/core/agents/synthesizer_agent.py
+++ b/core/agents/synthesizer_agent.py
@@ -11,6 +11,7 @@ Call:
 """
 from typing import Dict
 import logging
+import os
 import streamlit as st
 
 from core.llm import complete, select_model

--- a/core/llm.py
+++ b/core/llm.py
@@ -38,12 +38,19 @@ def select_model(
     if not model:
         model = "gpt-4.1-mini"
 
-    force = os.getenv("DRRD_FORCE_MODEL")
-    if force:
-        logger.warning("select_model: forced override %s", force)
-        model = force.strip()
+    resolved = model
+    forced = os.getenv("DRRD_FORCE_MODEL")
+    if forced and forced.strip() != resolved:
+        logger.warning(
+            "FORCING model override: %s -> %s [purpose=%s agent=%s]",
+            resolved,
+            forced.strip(),
+            purpose,
+            agent_name,
+        )
+        return forced.strip()
 
-    return model
+    return resolved
 
 
 @dataclass

--- a/tests/test_import_env_modules.py
+++ b/tests/test_import_env_modules.py
@@ -1,0 +1,11 @@
+import importlib
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "module",
+    ["core.router", "core.agents.synthesizer_agent", "core.llm"],
+)
+def test_import_modules_no_nameerror(module):
+    importlib.import_module(module)

--- a/tests/test_llm_client_logging.py
+++ b/tests/test_llm_client_logging.py
@@ -9,17 +9,47 @@ from core import llm_client
 class DummyResp:
     http_status = 200
     output = []
+    output_text = "hi"
 
 
-def test_logging_includes_request_id(monkeypatch, caplog):
-    monkeypatch.setattr(llm_client.client.responses, "create", lambda **kwargs: DummyResp())
+def test_llm_logging_success(monkeypatch, caplog):
+    monkeypatch.setattr(
+        llm_client.client.responses,
+        "create",
+        lambda **kwargs: DummyResp(),
+    )
     monkeypatch.setattr(llm_client, "extract_text", lambda resp: "hi")
     caplog.set_level(logging.INFO)
-    llm_client.call_openai(model="m", messages=[{"role": "user", "content": "hi"}], meta={"purpose": "p", "agent": "a"})
-    start = next(r.message for r in caplog.records if r.message.startswith("LLM start"))
-    end = next(r.message for r in caplog.records if r.message.startswith("LLM end"))
-    rid_start = re.search(r"req=([0-9a-f]+)", start).group(1)
-    rid_end = re.search(r"req=([0-9a-f]+)", end).group(1)
+    llm_client.call_openai(model="m", messages=[{"role": "user", "content": "hi"}])
+    starts = [r for r in caplog.records if r.message.startswith("LLM start")]
+    ends = [r for r in caplog.records if r.message.startswith("LLM end")]
+    assert len(starts) == 1 and len(ends) == 1
+    rid_start = re.search(r"req=([0-9a-f]+)", starts[0].message).group(1)
+    rid_end = re.search(r"req=([0-9a-f]+)", ends[0].message).group(1)
     assert rid_start == rid_end
-    duration = int(re.search(r"duration_ms=(\d+)", end).group(1))
+    assert "status=200" in ends[0].message
+    duration = int(re.search(r"duration_ms=(\d+)", ends[0].message).group(1))
     assert duration >= 0
+
+
+def test_llm_logging_exception(monkeypatch, caplog):
+    def boom(**kwargs):
+        raise RuntimeError("404 boom")
+
+    monkeypatch.setattr(llm_client.client.responses, "create", boom)
+
+    class BoomChat:
+        def create(self, *args, **kwargs):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(llm_client.client.chat, "completions", BoomChat())
+    caplog.set_level(logging.INFO)
+    with pytest.raises(RuntimeError):
+        llm_client.call_openai(model="m", messages=[{"role": "user", "content": "hi"}])
+    starts = [r for r in caplog.records if r.message.startswith("LLM start")]
+    ends = [r for r in caplog.records if r.message.startswith("LLM end")]
+    assert len(starts) == 1 and len(ends) == 1
+    rid_start = re.search(r"req=([0-9a-f]+)", starts[0].message).group(1)
+    rid_end = re.search(r"req=([0-9a-f]+)", ends[0].message).group(1)
+    assert rid_start == rid_end
+    assert "status=EXC" in ends[0].message

--- a/tests/test_select_model_forced_logging.py
+++ b/tests/test_select_model_forced_logging.py
@@ -1,0 +1,16 @@
+import logging
+
+from core.llm import select_model
+
+
+def test_select_model_forced_logging(monkeypatch, caplog):
+    monkeypatch.setenv("DRRD_MODEL_AGENT_SYNTHESIZER", "gpt-4-turbo")
+    monkeypatch.setenv("DRRD_FORCE_MODEL", "gpt-4.1-mini")
+    caplog.set_level(logging.WARNING)
+    model = select_model("agent", None, agent_name="Synthesizer")
+    assert model == "gpt-4.1-mini"
+    msg = caplog.records[0].message
+    assert (
+        "FORCING model override: gpt-4-turbo -> gpt-4.1-mini" in msg
+        and "agent=Synthesizer" in msg
+    )

--- a/utils/logging.py
+++ b/utils/logging.py
@@ -9,7 +9,10 @@ h.setFormatter(fmt)
 logger.addHandler(h)
 
 
-def safe_exc(log, idea, msg, exc):
+def safe_exc(log, idea, msg, exc, request_id: str | None = None):
     from utils.search_tools import obfuscate_query
 
-    (log or logger).error(obfuscate_query("error", idea or "", f"{msg}: {exc}"))
+    base = f"{msg}: {exc}"
+    if request_id:
+        base = f"{base} [req={request_id}]"
+    (log or logger).error(obfuscate_query("error", idea or "", base))


### PR DESCRIPTION
## Summary
- ensure agents import `os` when using environment variables
- pair LLM start/end logs with request IDs and duration
- warn when model overrides occur and show original→forced model
- add tests for logging and import checks

## Testing
- `pytest tests/test_llm_client_logging.py tests/test_select_model_forced_logging.py tests/test_import_env_modules.py tests/test_model_selection.py tests/test_agent_model_selection.py`


------
https://chatgpt.com/codex/tasks/task_e_68a79c5ddb88832caf9e43e3061d76ce