### PR TITLE
chore: add repository map generation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+repo_map.yaml @dr-rd-maintainers
+docs/REPO_MAP.md @dr-rd-maintainers
+docs/REPO_RULES.md @dr-rd-maintainers

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+## Checklist
+
+- [ ] Ran `make repo-map` and committed updated `repo_map.yaml` and `docs/REPO_MAP.md`
+- [ ] If new/changed agent: updated `core/agents_registry.py` and tests
+- [ ] If config touched: updated `config/*` and regenerated map
+- [ ] Verified no duplicate modules or responsibilities

--- a/.github/workflows/repo-map.yml
+++ b/.github/workflows/repo-map.yml
@@ -1,0 +1,28 @@
+name: Repo Map
+
+on:
+  pull_request:
+
+jobs:
+  repo-map:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get changed files
+        id: diff
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          git diff --name-only origin/${{ github.base_ref }}... > changed_files.txt
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install pyyaml jinja2 rich
+      - name: Generate repo map
+        run: make repo-map
+      - name: Ensure map committed
+        run: |
+          git diff --exit-code repo_map.yaml docs/REPO_MAP.md || (echo 'Repo map not up to date. Run make repo-map and commit changes.' && exit 1)
+      - name: Validate repo map
+        run: |
+          CHANGED_FILES="$(tr '\n' ' ' < changed_files.txt)" make repo-validate

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
-
-.PHONY: audit
+.PHONY: audit repo-map repo-validate
 
 audit:
 	pytest -q tests/audit
+
+repo-map:
+	python scripts/generate_repo_map.py
+
+repo-validate:
+	python scripts/validate_repo_map.py

--- a/docs/CODEX_RULES.md
+++ b/docs/CODEX_RULES.md
@@ -1,0 +1,6 @@
+# Codex Contribution Rules
+
+- Before editing files, parse and understand `repo_map.yaml`.
+- After making changes, run `make repo-map` to regenerate `repo_map.yaml` and `docs/REPO_MAP.md`.
+- Commit the regenerated map and docs in the same pull request as the changes.
+- Run `make repo-validate` before submitting to ensure the map and configuration are consistent.

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -1,0 +1,46 @@
+# Repository Map
+
+## Overview & Flow Diagram
+User idea → Planner → Router/Registry → Executor → Synthesizer → UI
+
+## Entry Points & Run Modes
+
+### Entry Points
+- streamlit_app: `app.py`
+- package_init: `app/__init__.py:main`
+
+
+### Runtime Modes
+- **test**: target cost USD 2.5
+- **deep**: target cost USD 2.5
+
+
+## Agent Roster
+| Role | Module | Contract |
+| --- | --- | --- |
+| HRM | `core/agents/hrm_agent.py` | JSON |
+| Planner | `core/agents/planner_agent.py` | JSON |
+| Reflection | `core/agents/reflection_agent.py` | JSON |
+| ChiefScientist | `core/agents/chief_scientist_agent.py` | JSON |
+| MaterialsEngineer | `core/agents/materials_engineer_agent.py` | JSON |
+| RegulatorySpecialist | `core/agents/regulatory_specialist_agent.py` | JSON |
+
+
+## Orchestrator & Executor Responsibilities
+Contracts are strict JSON between pipeline stages.
+
+## Config & Env Flags
+Config files:
+- `config/modes.yaml` (requires keys: test, deep)
+- `config/prices.yaml` (requires keys: models)
+
+
+Environment flags: DRRD_MODE, RAG_ENABLED, ENABLE_LIVE_SEARCH, SERPAPI_KEY
+
+## What Runs When
+Streamlit imports `app.main` from `app/__init__.py`.
+
+## Change Rules & Conventions
+See [REPO_RULES.md](REPO_RULES.md).
+
+_Last generated at 2025-08-21T22:38:09.043378Z from commit 4f977b9_

--- a/docs/REPO_RULES.md
+++ b/docs/REPO_RULES.md
@@ -1,0 +1,28 @@
+# Repository Rules
+
+## Single Source of Truth
+- `repo_map.yaml` and `docs/REPO_MAP.md` describe how the system is wired. Regenerate them with `make repo-map` whenever components move or change.
+- Avoid duplicating modules. UI code in `app.py` stays thin, while business logic lives in orchestrators under `orchestrators/`.
+
+## Adding an Agent
+1. Place the agent implementation in `core/agents/`.
+2. Register the role in `core/agents_registry.py`.
+3. Provide prompts/contracts and add tests in `tests/`.
+4. Run `make repo-map` and commit the updated map and docs.
+
+## Configuration Changes
+- Only modify `config/modes.yaml` or `config/prices.yaml` when changing budgets or model pricing.
+- After editing, regenerate the map with `make repo-map`.
+
+## File Naming & Placement
+- Agents: `core/agents/<role>_agent.py`
+- Prompts: `prompts/`
+- Orchestrators: `orchestrators/`
+- Tests: `tests/`
+- Docs: `docs/`
+
+## Pull Request Checklist
+- `make repo-map` run and changes committed.
+- New or changed agent includes registry update and tests.
+- Config updates accompanied by regenerated map.
+- Verified no duplicate modules or conflicting responsibilities.

--- a/docs/templates/repo_map.md.j2
+++ b/docs/templates/repo_map.md.j2
@@ -1,0 +1,39 @@
+# Repository Map
+
+## Overview & Flow Diagram
+{{ execution_flow }}
+
+## Entry Points & Run Modes
+
+### Entry Points
+{% for ep in entry_points %}- {{ ep.name }}: `{{ ep.path }}`
+{% endfor %}
+
+### Runtime Modes
+{% for name, mode in runtime_modes.items() %}- **{{ name }}**: target cost USD {{ mode.target_cost_usd }}
+{% endfor %}
+
+## Agent Roster
+| Role | Module | Contract |
+| --- | --- | --- |
+{% for role, module in agent_registry.items() %}| {{ role }} | `{{ module }}` | JSON |
+{% endfor %}
+
+## Orchestrator & Executor Responsibilities
+Contracts are strict JSON between pipeline stages.
+
+## Config & Env Flags
+Config files:
+{% for cfg in config_files %}- `{{ cfg.path }}` (requires keys: {{ cfg.required_keys | join(', ') }})
+{% endfor %}
+
+Environment flags: {{ env_flags | join(', ') }}
+
+## What Runs When
+Streamlit imports `app.main` from `app/__init__.py`.
+
+## Change Rules & Conventions
+See [REPO_RULES.md](REPO_RULES.md).
+
+_Last generated at {{ generated_at }} from commit {{ git_sha[:7] }}_
+

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,0 +1,164 @@
+version: 1
+generated_at: '2025-08-21T22:38:09.043378Z'
+git_sha: 4f977b98f798592522bee42179f8ba9b8f2a3c37
+entry_points:
+- name: streamlit_app
+  path: app.py
+- name: package_init
+  path: app/__init__.py:main
+architecture: "Planner \u2192 Router/Registry \u2192 Executor \u2192 Synthesizer"
+runtime_modes:
+  test:
+    target_cost_usd: 2.5
+    enforce_caps: false
+    models:
+      plan: gpt-4-turbo
+      exec: gpt-4-turbo
+      synth: gpt-4-turbo
+    k_search: 6
+    max_loops: 5
+    stage_weights:
+      plan: 0.2
+      exec: 0.5
+      synth: 0.3
+  deep:
+    target_cost_usd: 2.5
+    enforce_caps: false
+    models:
+      plan: gpt-5
+      exec: gpt-5
+      synth: gpt-5
+    k_search: 6
+    max_loops: 5
+    stage_weights:
+      plan: 0.2
+      exec: 0.5
+      synth: 0.3
+env_flags:
+- DRRD_MODE
+- RAG_ENABLED
+- ENABLE_LIVE_SEARCH
+- SERPAPI_KEY
+modules:
+- path: core/agents/hrm_agent.py
+  role: Agent[HRM]
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/agents/planner_agent.py
+  role: Agent[Planner]
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/agents/reflection_agent.py
+  role: Agent[Reflection]
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/agents/chief_scientist_agent.py
+  role: Agent[ChiefScientist]
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/agents/materials_engineer_agent.py
+  role: Agent[MaterialsEngineer]
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/agents/regulatory_specialist_agent.py
+  role: Agent[RegulatorySpecialist]
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/spec_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/__init__.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/router.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/qa_router.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/plan_utils.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/app_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: app.py
+  role: UI
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: app/__init__.py
+  role: UI
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+agent_registry:
+  HRM: core/agents/hrm_agent.py
+  Planner: core/agents/planner_agent.py
+  Reflection: core/agents/reflection_agent.py
+  ChiefScientist: core/agents/chief_scientist_agent.py
+  MaterialsEngineer: core/agents/materials_engineer_agent.py
+  RegulatorySpecialist: core/agents/regulatory_specialist_agent.py
+config_files:
+- path: config/modes.yaml
+  required_keys:
+  - test
+  - deep
+- path: config/prices.yaml
+  required_keys:
+  - models
+prompts_dir: prompts
+tests_dir: tests
+orchestrators_dir: orchestrators
+ui_files:
+- app.py
+- app/__init__.py
+execution_flow: "User idea \u2192 Planner \u2192 Router/Registry \u2192 Executor \u2192\
+  \ Synthesizer \u2192 UI"
+rules_ref: docs/REPO_RULES.md

--- a/scripts/generate_repo_map.py
+++ b/scripts/generate_repo_map.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Generate repo_map.yaml and docs/REPO_MAP.md from repository state."""
+from __future__ import annotations
+
+import datetime
+import re
+import subprocess
+from pathlib import Path
+
+import yaml
+from jinja2 import Environment, FileSystemLoader
+
+ROOT = Path(__file__).resolve().parent.parent
+YAML_PATH = ROOT / "repo_map.yaml"
+DOC_PATH = ROOT / "docs" / "REPO_MAP.md"
+TEMPLATE_PATH = ROOT / "docs" / "templates" / "repo_map.md.j2"
+
+
+def _git_sha() -> str:
+    return subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=ROOT).decode().strip()
+
+
+def _load_yaml(path: Path):
+    return yaml.safe_load(path.read_text())
+
+
+def _get_runtime_modes():
+    return _load_yaml(ROOT / "config" / "modes.yaml")
+
+
+def _get_agent_registry() -> dict[str, str]:
+    content = (ROOT / "core" / "agents_registry.py").read_text()
+    imports = re.findall(
+        r"from core\.agents\.([a-zA-Z0-9_]+)_agent import ([A-Za-z0-9_]+)", content
+    )
+    class_to_module = {cls: f"core/agents/{name}_agent.py" for name, cls in imports}
+    mapping: dict[str, str] = {}
+    entries = re.findall(r"\"([^\"]+)\":\s*([A-Za-z0-9_]+)\(", content)
+    for role, cls in entries:
+        module_path = class_to_module.get(cls)
+        if module_path:
+            mapping[role] = module_path
+    return mapping
+
+
+def build_repo_map() -> dict:
+    git_sha = _git_sha()
+    modes = _get_runtime_modes()
+    agent_registry = _get_agent_registry()
+    modules = []
+    for role, module in agent_registry.items():
+        modules.append(
+            {
+                "path": module,
+                "role": f"Agent[{role}]",
+                "responsibilities": [],
+                "inputs": [],
+                "outputs": [],
+                "invoked_by": [],
+                "invokes": [],
+            }
+        )
+    for path in (ROOT / "orchestrators").glob("*.py"):
+        modules.append(
+            {
+                "path": f"orchestrators/{path.name}",
+                "role": "Orchestrator",
+                "responsibilities": [],
+                "inputs": [],
+                "outputs": [],
+                "invoked_by": [],
+                "invokes": [],
+            }
+        )
+    for path in ["app.py", "app/__init__.py"]:
+        modules.append(
+            {
+                "path": path,
+                "role": "UI",
+                "responsibilities": [],
+                "inputs": [],
+                "outputs": [],
+                "invoked_by": [],
+                "invokes": [],
+            }
+        )
+
+    data = {
+        "version": 1,
+        "generated_at": datetime.datetime.utcnow().isoformat() + "Z",
+        "git_sha": git_sha,
+        "entry_points": [
+            {"name": "streamlit_app", "path": "app.py"},
+            {"name": "package_init", "path": "app/__init__.py:main"},
+        ],
+        "architecture": "Planner → Router/Registry → Executor → Synthesizer",
+        "runtime_modes": modes,
+        "env_flags": [
+            "DRRD_MODE",
+            "RAG_ENABLED",
+            "ENABLE_LIVE_SEARCH",
+            "SERPAPI_KEY",
+        ],
+        "modules": modules,
+        "agent_registry": agent_registry,
+        "config_files": [
+            {"path": "config/modes.yaml", "required_keys": ["test", "deep"]},
+            {"path": "config/prices.yaml", "required_keys": ["models"]},
+        ],
+        "prompts_dir": "prompts",
+        "tests_dir": "tests",
+        "orchestrators_dir": "orchestrators",
+        "ui_files": ["app.py", "app/__init__.py"],
+        "execution_flow": "User idea → Planner → Router/Registry → Executor → Synthesizer → UI",
+        "rules_ref": "docs/REPO_RULES.md",
+    }
+    return data
+
+
+def render_repo_map_doc(data: dict) -> str:
+    env = Environment(loader=FileSystemLoader(str(TEMPLATE_PATH.parent)))
+    template = env.get_template(TEMPLATE_PATH.name)
+    return template.render(**data)
+
+
+def main() -> None:
+    data = build_repo_map()
+    YAML_PATH.write_text(yaml.safe_dump(data, sort_keys=False))
+    DOC_PATH.write_text(render_repo_map_doc(data))
+    print(f"Wrote {YAML_PATH} and {DOC_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_repo_map.py
+++ b/scripts/validate_repo_map.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Validate repo_map.yaml and generated docs are up to date and consistent."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.append(str(Path(__file__).parent))
+from generate_repo_map import (  # noqa: E402
+    DOC_PATH,
+    YAML_PATH,
+    build_repo_map,
+    render_repo_map_doc,
+)
+
+
+def _compare_dicts(a: dict, b: dict) -> bool:
+    return yaml.safe_dump(a, sort_keys=True) == yaml.safe_dump(b, sort_keys=True)
+
+
+def main() -> None:
+    current = yaml.safe_load(YAML_PATH.read_text())
+    regenerated = build_repo_map()
+    cur_cmp = dict(current)
+    regen_cmp = dict(regenerated)
+    for d in (cur_cmp, regen_cmp):
+        d.pop("generated_at", None)
+        d.pop("git_sha", None)
+    if not _compare_dicts(cur_cmp, regen_cmp):
+        print("repo_map.yaml is out of date. Run make repo-map and commit updates.")
+        sys.exit(1)
+    rendered = render_repo_map_doc(current)
+    if DOC_PATH.read_text() != rendered:
+        print("docs/REPO_MAP.md is out of date. Run make repo-map and commit updates.")
+        sys.exit(1)
+
+    modes = yaml.safe_load(Path("config/modes.yaml").read_text())
+    prices = yaml.safe_load(Path("config/prices.yaml").read_text())
+    for key in ["test", "deep"]:
+        if key not in modes or "target_cost_usd" not in modes[key]:
+            print(f"config/modes.yaml missing {key}.target_cost_usd")
+            sys.exit(1)
+    if "models" not in prices:
+        print("config/prices.yaml missing 'models' key")
+        sys.exit(1)
+
+    roles = current.get("agent_registry", {})
+    if len(roles) != len(set(roles)):
+        print("Duplicate agent roles detected")
+        sys.exit(1)
+
+    print("Repo map validation passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add repo_map.yaml and generated docs for repository architecture
- include Codex and contributor rules plus pull request template
- add generator/validator scripts with CI workflow and Makefile targets

## Testing
- `pre-commit run --files scripts/generate_repo_map.py scripts/validate_repo_map.py`
- `make repo-validate`


------
https://chatgpt.com/codex/tasks/task_e_68a79ea74a2c832c9491f0395998ab44