### PR TITLE
Validate agent registry and standardize agent invocation

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -30,8 +30,25 @@ from core.agents.unified_registry import build_agents_unified
 from config.agent_models import AGENT_MODEL_MAP, TEST_ROLE_MODELS
 from core.orchestrator import generate_plan, execute_plan, compile_proposal, run_poc
 from core.poc.testplan import TestPlan
+from core.agents.registry import validate_registry
 
 logger = logging.getLogger(__name__)
+
+# Validate and log agent registry once at startup
+_reg = validate_registry(strict=False)
+details = []
+if _reg["skipped"]:
+    details.append("skipped=" + ",".join(_reg["skipped"]))
+if _reg["errors"]:
+    err_names = ",".join(n for n, _ in _reg["errors"])
+    details.append("errors=" + err_names)
+logger.info(
+    "Agent registry ok=%d skipped=%d errors=%d%s",
+    len(_reg["ok"]),
+    len(_reg["skipped"]),
+    len(_reg["errors"]),
+    f" ({' '.join(details)})" if details else "",
+)
 
 try:
     from orchestrators.app_builder import build_app_from_idea

--- a/core/agents/invoke.py
+++ b/core/agents/invoke.py
@@ -1,15 +1,62 @@
 """Agent invocation utilities."""
-from typing import Callable
+
+from __future__ import annotations
+
+import inspect
+import logging
+from typing import Callable, Tuple
+
+
+logger = logging.getLogger(__name__)
 
 CALL_ATTRS = ("run", "invoke", "__call__")
 
 
-def resolve_invoker(agent) -> Callable:
-    """Return the first callable attr from CALL_ATTRS or raise TypeError."""
+def resolve_invoker(agent) -> Tuple[str, Callable]:
+    """Return the first callable attribute name and function.
+
+    Attributes are searched in ``CALL_ATTRS`` order.  If none are present,
+    ``TypeError`` is raised with a clear, standardised message.
+    """
+
     for name in CALL_ATTRS:
         fn = getattr(agent, name, None)
         if callable(fn):
-            return fn
+            return name, fn
     raise TypeError(
         f"{type(agent).__name__} has no callable interface (expected one of {CALL_ATTRS})"
     )
+
+
+def invoke_agent(
+    agent, *, task: dict, model: str | None = None, meta: dict | None = None
+):
+    """Invoke ``agent`` with ``task``/``model``/``meta`` keywords.
+
+    Any parameters not accepted by the agent's callable are dropped before
+    invocation.  Errors from the agent are re-raised with contextual details.
+    """
+
+    meta = meta or {}
+    method_name, method = resolve_invoker(agent)
+    logger.info("invoke agent=%s via=%s", meta.get("agent"), method_name)
+
+    try:
+        sig = inspect.signature(method)
+        kwargs = {}
+        if "task" in sig.parameters:
+            kwargs["task"] = task
+        if "model" in sig.parameters:
+            kwargs["model"] = model
+        if "meta" in sig.parameters:
+            kwargs["meta"] = meta
+        return method(**kwargs)
+    except Exception as e:  # pragma: no cover - message enrichment
+        agent_name = meta.get("agent")
+        raise type(e)(
+            f"{agent_name} ({type(agent).__name__}.{method_name}) failed: {e}"
+        ) from e
+
+
+__all__ = ["CALL_ATTRS", "resolve_invoker", "invoke_agent"]
+

--- a/tests/test_agent_invocation.py
+++ b/tests/test_agent_invocation.py
@@ -19,5 +19,6 @@ def test_missing_interface():
 
 
 def test_run_invocation():
-    inv = resolve_invoker(Runs())
+    name, inv = resolve_invoker(Runs())
+    assert name == "run"
     assert inv(task={"x": 1}, model="m") == 1

--- a/tests/test_invoke_resolution.py
+++ b/tests/test_invoke_resolution.py
@@ -1,0 +1,34 @@
+from core.agents.invoke import resolve_invoker
+
+
+class RunAgent:
+    def run(self):
+        pass
+
+    def invoke(self):
+        pass
+
+    def __call__(self):
+        pass
+
+
+class InvokeAgent:
+    def invoke(self):
+        pass
+
+    def __call__(self):
+        pass
+
+
+class CallAgent:
+    def __call__(self):
+        pass
+
+
+def test_resolution_preference():
+    name, _ = resolve_invoker(RunAgent())
+    assert name == "run"
+    name, _ = resolve_invoker(InvokeAgent())
+    assert name == "invoke"
+    name, _ = resolve_invoker(CallAgent())
+    assert name == "__call__"

--- a/tests/test_registry_validation.py
+++ b/tests/test_registry_validation.py
@@ -1,0 +1,37 @@
+import os
+
+import pytest
+
+from core.agents import registry
+
+
+class NoCall:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+class DummySynth:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def run(self, *args, **kwargs):
+        return "ok"
+
+
+def _patched_agents():
+    return {"Synthesizer": DummySynth, "Dummy": NoCall}
+
+
+def test_validation_skipped(monkeypatch):
+    monkeypatch.setattr(registry, "AGENTS", _patched_agents())
+    registry.CACHE.clear()
+    res = registry.validate_registry(strict=False)
+    assert "Dummy" in res["skipped"]
+
+
+def test_validation_strict(monkeypatch):
+    monkeypatch.setattr(registry, "AGENTS", _patched_agents())
+    registry.CACHE.clear()
+    monkeypatch.setenv("DRRD_STRICT_AGENT_REGISTRY", "true")
+    with pytest.raises(RuntimeError):
+        registry.validate_registry()

--- a/tests/test_router_fallback.py
+++ b/tests/test_router_fallback.py
@@ -1,0 +1,34 @@
+import logging
+
+from core import router
+
+
+class NoCall:
+    pass
+
+
+class Synth:
+    def run(self, *, task=None, model=None, meta=None):
+        return "synth"
+
+
+def test_router_fallback(monkeypatch, caplog):
+    monkeypatch.setattr(router, "AGENT_REGISTRY", {"Bad": object, "Synthesizer": object})
+
+    def fake_get_agent(name):
+        return NoCall() if name == "Bad" else Synth()
+
+    monkeypatch.setattr(router, "get_agent", fake_get_agent)
+    monkeypatch.setattr(
+        router,
+        "select_model",
+        lambda purpose, ui_model, agent_name=None: "m",
+    )
+
+    task = {"role": "Bad", "title": "x"}
+    with caplog.at_level(logging.WARNING):
+        result = router.dispatch(task)
+    assert result == "synth"
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert len(warnings) == 1
+    assert "Synthesizer" in warnings[0].message

--- a/tests/test_router_success_path.py
+++ b/tests/test_router_success_path.py
@@ -1,0 +1,21 @@
+from core import router
+
+
+class EchoAgent:
+    def run(self, *, task=None, model=None, meta=None):
+        return {"task": task, "model": model}
+
+
+def test_router_success(monkeypatch):
+    monkeypatch.setattr(router, "AGENT_REGISTRY", {"Echo": object, "Synthesizer": object})
+    monkeypatch.setattr(router, "get_agent", lambda name: EchoAgent())
+    monkeypatch.setattr(
+        router,
+        "select_model",
+        lambda purpose, ui_model, agent_name=None: ui_model or "m",
+    )
+
+    task = {"role": "Echo", "title": "hi"}
+    result = router.dispatch(task, ui_model="model-x")
+    assert result["task"] is task
+    assert result["model"] == "model-x"


### PR DESCRIPTION
## Summary
- validate agent registry at startup and cache instances
- add unified agent invocation helper with interface resolution
- route tasks through safe dispatcher with Synthesizer fallback

## Testing
- `pytest tests/test_registry_validation.py tests/test_invoke_resolution.py tests/test_router_fallback.py tests/test_router_success_path.py tests/test_agent_invocation.py -q`
- `pytest -q` *(fails: FileNotFoundError: config/defaults.yaml)*

------
https://chatgpt.com/codex/tasks/task_e_68a7abdd4964832c88ec144bb6f05d9e