### PR TITLE
Handle seed param for Responses API and optional chat routing

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -19,6 +19,11 @@ LIVE_SEARCH_BACKEND=openai|serpapi
 SERPAPI_KEY=your_key
 ```
 
+## Seeding behavior
+
+- `DRRD_USE_CHAT_FOR_SEEDED`: when true, and a seed is supplied and no `response_format` is requested, the client uses Chat Completions so seed works; otherwise Responses is used and seed is ignored.
+- `DRRD_PLANNER_SEED`: optional. If set, the planner may pass a seed. This is effective only when `DRRD_USE_CHAT_FOR_SEEDED=true` and the planner does not require a Responses JSON schema.
+
 Budget tracking now exposes counters: `retrieval_calls`, `web_search_calls`,
 `retrieval_tokens`, and increments `skipped_due_to_budget` when live search is
 skipped because the call cap is reached.

--- a/tests/test_seed_param_handling.py
+++ b/tests/test_seed_param_handling.py
@@ -1,0 +1,89 @@
+import logging
+
+import pytest
+
+from core import llm_client
+
+
+class DummyResp:
+    http_status = 200
+    output = []
+    output_text = "ok"
+
+
+@pytest.fixture(autouse=True)
+def reset_env(monkeypatch):
+    monkeypatch.delenv("DRRD_USE_CHAT_FOR_SEEDED", raising=False)
+    yield
+
+
+def test_seed_stripped_default(monkeypatch, caplog):
+    called = {}
+
+    def fake_create(**kwargs):
+        nonlocal called
+        called = kwargs
+        return DummyResp()
+
+    monkeypatch.setattr(llm_client.client.responses, "create", fake_create)
+    monkeypatch.setattr(
+        llm_client.client.chat.completions, "create", lambda **kwargs: (_ for _ in ()).throw(RuntimeError("chat called"))
+    )
+    monkeypatch.setattr(llm_client, "extract_text", lambda resp: "ok")
+    caplog.set_level(logging.INFO)
+    llm_client.call_openai(
+        model="m",
+        messages=[{"role": "user", "content": "hi"}],
+        response_params={"seed": 123},
+    )
+    assert "seed" not in called
+    assert any("Ignoring unsupported Responses param: seed" in r.message for r in caplog.records)
+
+
+def test_seed_routes_to_chat(monkeypatch, caplog):
+    monkeypatch.setenv("DRRD_USE_CHAT_FOR_SEEDED", "true")
+    chat_called = {}
+
+    def fake_chat_create(**kwargs):
+        nonlocal chat_called
+        chat_called = kwargs
+        return DummyResp()
+
+    monkeypatch.setattr(llm_client.client.chat.completions, "create", fake_chat_create)
+    monkeypatch.setattr(
+        llm_client.client.responses, "create", lambda **kwargs: (_ for _ in ()).throw(RuntimeError("responses called"))
+    )
+    monkeypatch.setattr(llm_client, "extract_text", lambda resp: "ok")
+    caplog.set_level(logging.INFO)
+    llm_client.call_openai(
+        model="m",
+        messages=[{"role": "user", "content": "hi"}],
+        response_params={"seed": 42},
+    )
+    assert chat_called.get("seed") == 42
+    assert any("Using chat.completions for seeded request" in r.message for r in caplog.records)
+
+
+def test_seed_stripped_when_schema(monkeypatch, caplog):
+    monkeypatch.setenv("DRRD_USE_CHAT_FOR_SEEDED", "true")
+    called = {}
+
+    def fake_create(**kwargs):
+        nonlocal called
+        called = kwargs
+        return DummyResp()
+
+    monkeypatch.setattr(llm_client.client.responses, "create", fake_create)
+    monkeypatch.setattr(
+        llm_client.client.chat.completions, "create", lambda **kwargs: (_ for _ in ()).throw(RuntimeError("chat called"))
+    )
+    monkeypatch.setattr(llm_client, "extract_text", lambda resp: "ok")
+    caplog.set_level(logging.INFO)
+    llm_client.call_openai(
+        model="m",
+        messages=[{"role": "user", "content": "hi"}],
+        response_format={"type": "json_object"},
+        response_params={"seed": 99},
+    )
+    assert "seed" not in called
+    assert any("Ignoring unsupported Responses param: seed" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- sanitize unsupported seed parameter before calling OpenAI Responses API
- optionally route seeded requests to Chat Completions when DRRD_USE_CHAT_FOR_SEEDED=true
- add planner seed env support and docs

## Testing
- `pytest tests/test_seed_param_handling.py -q`
- `pytest tests/test_llm_client_logging.py -q`
- `pytest tests/test_planner_agent.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a7c5a0b0b8832cbb11b37da1c3a726