### PR TITLE
Improve planner payload parsing

### DIFF
--- a/tests/test_planner_parse_paths.py
+++ b/tests/test_planner_parse_paths.py
@@ -1,0 +1,40 @@
+import json
+from types import SimpleNamespace
+
+from core.llm_client import extract_planner_payload
+
+
+def test_extract_parsed_path():
+    resp = SimpleNamespace(
+        output=[
+            SimpleNamespace(
+                type="message",
+                content=[
+                    SimpleNamespace(parsed={"tasks": [
+                        {"role": "a", "title": "b", "description": "c"}
+                    ]})
+                ],
+            )
+        ]
+    )
+    data = extract_planner_payload(resp)
+    assert data == {"tasks": [{"role": "a", "title": "b", "description": "c"}]}
+
+
+def test_extract_text_path():
+    payload = {"tasks": []}
+    resp = SimpleNamespace(output=[], output_text="```json\n{}\n```".format(
+        json.dumps(payload)
+    ))
+    data = extract_planner_payload(resp)
+    assert data == payload
+
+
+def test_extract_chat_path():
+    payload = {"tasks": []}
+    resp = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=json.dumps(payload)))]
+    )
+    data = extract_planner_payload(resp)
+    assert data == payload
+


### PR DESCRIPTION
## Summary
- add `_strip_code_fences` and `extract_planner_payload` to safely pull planner JSON from Responses or Chat outputs
- update planner agent to use new extractor with safe fallback repair
- test JSON extraction across parsed, text, and chat response paths

## Testing
- `pytest tests/test_planner_parse_paths.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7da989ec4832cbb27689f7abc78ed