### PR TITLE
Normalize evidence inputs and preserve structured payloads

### DIFF
--- a/core/observability/evidence.py
+++ b/core/observability/evidence.py
@@ -1,27 +1,73 @@
-from pydantic import BaseModel, Field
-from typing import List, Optional, Dict
-from datetime import datetime
+import json
+import re
 import uuid
+from datetime import datetime
+from typing import Dict, List
+
+from pydantic import BaseModel, Field, field_validator
 
 
 class EvidenceItem(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     project_id: str
     role: str
-    task_title: str
-    claim: str
-    sources: List[str] = []
-    quotes: List[str] = []
+    task_title: str = ""
+    claim: str = ""
+    evidence: str = ""
+    sources: List[str] = Field(default_factory=list)
+    quotes: List[str] = Field(default_factory=list)
     confidence: float = 0.0   # 0..1
     tokens_in: int = 0
     tokens_out: int = 0
     cost_usd: float = 0.0
     created_at: str = Field(default_factory=lambda: datetime.utcnow().isoformat())
+    meta: dict | None = None
+
+    @field_validator("claim", "evidence", mode="before")
+    @classmethod
+    def _coerce_text(cls, v):
+        if v is None:
+            return ""
+        if isinstance(v, (dict, list)):
+            return json.dumps(v, ensure_ascii=False, separators=(",", ":"))
+        return str(v)
+
+    @field_validator("sources", mode="before")
+    @classmethod
+    def _coerce_sources(cls, v):
+        if v is None:
+            return []
+        if isinstance(v, str):
+            return [s.strip() for s in re.split(r"[\n,]+", v) if s.strip()]
+        if isinstance(v, dict):
+            urls = v.get("urls") or v.get("links")
+            if isinstance(urls, list):
+                return [str(u) for u in urls]
+            return [json.dumps(v, ensure_ascii=False, separators=(",", ":"))]
+        if isinstance(v, list):
+            out: List[str] = []
+            for item in v:
+                if isinstance(item, (dict, list)):
+                    out.append(json.dumps(item, ensure_ascii=False, separators=(",", ":")))
+                else:
+                    out.append(str(item))
+            return out
+        return [str(v)]
+
+    @field_validator("cost_usd", mode="before")
+    @classmethod
+    def _coerce_cost(cls, v):
+        if v is None:
+            return 0.0
+        try:
+            return float(v)
+        except Exception:
+            return 0.0
 
 
 class EvidenceSet(BaseModel):
     project_id: str
-    items: List[EvidenceItem] = []
+    items: List[EvidenceItem] = Field(default_factory=list)
 
     def add(self, **kwargs) -> None:
         self.items.append(EvidenceItem(project_id=self.project_id, **kwargs))

--- a/tests/test_evidence_normalization.py
+++ b/tests/test_evidence_normalization.py
@@ -1,0 +1,41 @@
+from core.observability.evidence import EvidenceItem
+from core.orchestrator import _normalize_evidence_payload
+
+
+def test_dict_claim_and_sources_dict():
+    item = EvidenceItem(
+        project_id="p",
+        role="Marketing Analyst",
+        claim={"target_segments": ["fitness centers", "physical therapy clinics"]},
+        evidence={"size": 123},
+        sources={"urls": ["https://ex.com/a", "https://ex.com/b"]},
+        cost_usd="12.5",
+    )
+    assert isinstance(item.claim, str) and '"target_segments"' in item.claim
+    assert isinstance(item.evidence, str) and '"size":123' in item.evidence
+    assert item.sources == ["https://ex.com/a", "https://ex.com/b"]
+    assert item.cost_usd == 12.5
+
+
+def test_orchestrator_normalization_meta_and_cost():
+    norm = _normalize_evidence_payload({
+        "claim": {"x": 1},
+        "evidence": ["a", "b"],
+        "sources": "https://one.com, https://two.com",
+        "cost": "7",
+    })
+    assert "meta" in norm and "claim_structured" in norm["meta"]
+    assert norm["cost_usd"] == "7" or norm["cost_usd"] == 7
+
+
+def test_sources_mixed_list_and_cost_none():
+    item = EvidenceItem(
+        project_id="p",
+        role="IP Analyst",
+        claim="c",
+        sources=["https://a.com", {"u": "x"}],
+        cost_usd=None,
+    )
+    assert item.sources[0] == "https://a.com"
+    assert item.sources[1].startswith("{")
+    assert item.cost_usd == 0.0


### PR DESCRIPTION
## Summary
- Safely coerce structured claim, evidence, source, and cost fields in `EvidenceItem` and retain raw data in optional `meta`
- Normalize agent evidence payloads in `orchestrator` before creating items and log when structured fields are coerced
- Add tests covering normalization and source handling

## Testing
- `pytest tests/test_evidence_normalization.py tests/test_evidence_parsing.py -q`
- `pytest tests/test_smoke.py::test_run_smoke -q` *(fails: openai.APIConnectionError)*

------
https://chatgpt.com/codex/tasks/task_e_68a898041a88832c82107dffb48b390f