### PR TITLE
Coerce structured coverage fields to text

### DIFF
--- a/core/observability/coverage.py
+++ b/core/observability/coverage.py
@@ -1,4 +1,8 @@
-from typing import List, Dict
+import json
+import logging
+from typing import List, Dict, Any
+
+logger = logging.getLogger(__name__)
 
 DIMENSIONS = [
     "Feasibility",
@@ -12,11 +16,51 @@ DIMENSIONS = [
 ]
 
 
+def _to_text(v: Any) -> str:
+    if v is None:
+        return ""
+    if isinstance(v, str):
+        return v
+    if isinstance(v, (bool, int, float)):
+        return str(v)
+    if isinstance(v, (list, tuple)):
+        return " ".join(_to_text(x) for x in v)
+    if isinstance(v, dict):
+        preferred = [
+            "summary",
+            "text",
+            "content",
+            "title",
+            "description",
+            "findings",
+            "claim",
+            "body",
+        ]
+        for key in preferred:
+            if key in v and v[key] is not None:
+                val = _to_text(v[key])
+                if val:
+                    return val
+        parts = [
+            _to_text(value)
+            for value in v.values()
+            if value is not None and _to_text(value)
+        ]
+        if parts:
+            return " ".join(parts)
+        return json.dumps(v, ensure_ascii=False, separators=(",", ":"))
+    return str(v)
+
+
 def build_coverage(project_id: str, role_to_findings: Dict[str, dict]) -> List[Dict]:
     rows = []
     for role, payload in role_to_findings.items():
         dims = {d: False for d in DIMENSIONS}
-        txt = (payload.get("findings") or "") + " " + (payload.get("task") or "")
+        findings_raw = payload.get("findings")
+        task_raw = payload.get("task")
+        txt = _to_text(findings_raw) + " " + _to_text(task_raw)
+        if any(isinstance(x, (list, tuple, dict)) for x in [findings_raw, task_raw]):
+            logger.info("coverage: coerced structured fields for role=%s", role)
         t = txt.lower()
         dims["Feasibility"] = any(k in t for k in ["feasible", "feasibility", "risk", "resource"])
         dims["Novelty"] = any(k in t for k in ["novel", "original", "prior art", "new"])

--- a/tests/test_coverage_text_coercion.py
+++ b/tests/test_coverage_text_coercion.py
@@ -1,0 +1,33 @@
+from core.observability.coverage import _to_text, build_coverage
+
+
+def test_dict_preferred_keys():
+    findings = {"summary": "Feasible design"}
+    task = {"title": "Study cost"}
+    assert _to_text(findings) == "Feasible design"
+    assert _to_text(task) == "Study cost"
+    rows = build_coverage("p", {"r": {"findings": findings, "task": task}})
+    assert rows[0]["Feasibility"] and rows[0]["Cost"]
+
+
+def test_list_and_dict_items():
+    findings = ["novel approach", "market analysis"]
+    task = [{"text": "reduce cost"}]
+    txt_findings = _to_text(findings)
+    txt_task = _to_text(task)
+    assert "novel approach" in txt_findings and "market analysis" in txt_findings
+    assert "reduce cost" in txt_task
+    rows = build_coverage("p", {"r": {"findings": findings, "task": task}})
+    assert rows[0]["Novelty"] and rows[0]["Market"] and rows[0]["Cost"]
+
+
+def test_dict_without_preferred_keys():
+    findings = {"foo": {"bar": "baz"}}
+    txt = _to_text(findings)
+    assert txt
+    build_coverage("p", {"r": {"findings": findings, "task": ""}})
+
+
+def test_none_and_empty_strings():
+    rows = build_coverage("p", {"r": {"findings": None, "task": ""}})
+    assert not any(rows[0][d] for d in rows[0] if d not in {"project_id", "role"})


### PR DESCRIPTION
## Summary
- add `_to_text` helper to handle dict/list payloads and avoid TypeError in coverage
- convert findings/task to text before dimension checks, logging when coercion occurs
- test coercion for dicts, lists, nested dicts, and empty values

## Testing
- `pytest tests/test_coverage_map.py tests/test_coverage_text_coercion.py`
- `pytest` *(fails: UnboundLocalError, AssertionError, APIConnectionError, NameError, AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_68a89f86de74832c97e3002c508bdbf4