### PR TITLE
chore: robust changed file detection

### DIFF
--- a/.github/workflows/repo-map.yml
+++ b/.github/workflows/repo-map.yml
@@ -7,12 +7,36 @@ jobs:
   repo-map:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Get changed files
-        id: diff
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # needed for merge-base with triple-dot
+      - name: Compute changed files (robust)
+        shell: bash
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          git fetch origin ${{ github.base_ref }}
-          git diff --name-only origin/${{ github.base_ref }}... > changed_files.txt
+          set -euo pipefail
+          BASE="${BASE_REF:-$DEFAULT_BRANCH}"
+
+          # Fetch the tip of the base branch
+          git fetch --no-tags --prune origin "$BASE"
+
+          echo "Resolved BASE=$BASE"
+          echo "HEAD=$(git rev-parse --short HEAD)"
+          echo "BASE_TIP=$(git rev-parse --short origin/$BASE || true)"
+
+          # Try triple-dot (merge base); if unavailable, fall back to two-dot
+          if git merge-base --is-ancestor origin/$BASE HEAD 2>/dev/null || git merge-base HEAD origin/$BASE >/dev/null 2>&1; then
+            echo "Using triple-dot diff: origin/$BASE...HEAD"
+            git diff --name-only "origin/$BASE...HEAD" > changed_files.txt
+          else
+            echo "No merge base; using two-dot diff: origin/$BASE..HEAD"
+            git diff --name-only "origin/$BASE..HEAD" > changed_files.txt
+          fi
+
+          echo "Changed files:"
+          cat changed_files.txt || true
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -43,4 +43,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-23T00:08:29.039572Z from commit 670192c_
+_Last generated at 2025-08-23T00:23:02.680978Z from commit 76c5c01_

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-23T00:08:29.039572Z'
-git_sha: 670192cd347d1258624ef2456c13cc5241bea11f
+generated_at: '2025-08-23T00:23:02.680978Z'
+git_sha: 76c5c0133b9126230aa9311bb60f3bc3b3fb537b
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -98,20 +98,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/qa_router.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/spec_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/__init__.py
   role: Orchestrator
   responsibilities: []
@@ -134,6 +120,20 @@ modules:
   invoked_by: []
   invokes: []
 - path: orchestrators/router.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/qa_router.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []


### PR DESCRIPTION
## Summary
- make repo-map workflow resilient to missing merge base
- regenerate repo map artifacts

## Testing
- `python scripts/generate_repo_map.py`
- `pytest -q` *(fails: openai API connection errors, planner mocks, environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a9098ce4e0832c938bb5cb173c3482