### PR TITLE
Add FAISS nightly build pipeline

### DIFF
--- a/.github/workflows/faiss_nightly.yml
+++ b/.github/workflows/faiss_nightly.yml
@@ -1,0 +1,118 @@
+name: faiss-nightly
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+    inputs:
+      release_to_prod:
+        description: "Also sync to gs://$GCS_BUCKET/prod/v1"
+        required: false
+        default: "false"
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      FAISS_SRC_DIR: knowledge/source_docs
+      FAISS_DST_DIR: .faiss_index
+      GCS_BUCKET: ${{ secrets.GCS_BUCKET }}
+      GCS_PREFIX: ${{ secrets.GCS_PREFIX }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install "faiss-cpu>=1.7.4" "google-cloud-storage>=2.16.0"
+
+      - name: Select source corpus
+        id: src
+        run: |
+          if [ -d "knowledge/source_docs" ]; then
+            echo "src=knowledge/source_docs" >> $GITHUB_OUTPUT
+          elif [ -d "docs" ]; then
+            echo "src=docs" >> $GITHUB_OUTPUT
+          else
+            echo "ERROR: No default corpus found (expected knowledge/source_docs or docs/)"; exit 1
+          fi
+
+      - name: Build FAISS index
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          python scripts/build_faiss_index.py -h || true
+          python scripts/build_faiss_index.py --root "${{ steps.src.outputs.src }}" --out "${{ env.FAISS_DST_DIR }}"
+
+      - name: Validate bundle and emit manifest
+        run: |
+          python scripts/validate_faiss_bundle.py --path "${{ env.FAISS_DST_DIR }}" --out manifest.json
+
+      - name: Pack artifact
+        run: |
+          tar -C "${{ env.FAISS_DST_DIR }}" -czf faiss_index.tar.gz .
+
+      - name: Upload artifact (debug)
+        uses: actions/upload-artifact@v4
+        with:
+          name: faiss-bundle
+          path: |
+            faiss_index.tar.gz
+            manifest.json
+          retention-days: 7
+
+      - name: Auth to GCP (WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SA_EMAIL }}
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          install_components: "gcloud,gsutil"
+
+      - name: Publish to GCS (nightly path + latest)
+        env:
+          NIGHTLY_DST: gs://${{ env.GCS_BUCKET }}/${{ env.GCS_PREFIX }}/nightly/${{ github.run_id }}-${{ github.sha }}
+          LATEST_DST: gs://${{ env.GCS_BUCKET }}/${{ env.GCS_PREFIX }}/nightly/latest
+        run: |
+          gsutil -m rsync -r "${{ env.FAISS_DST_DIR }}" "$NIGHTLY_DST"
+          gsutil -m rsync -d -r "${{ env.FAISS_DST_DIR }}" "$LATEST_DST"
+          gsutil cp -n manifest.json "$NIGHTLY_DST/manifest.json"
+          gsutil cp -a public-read -n manifest.json "$LATEST_DST/manifest.json" || true
+
+      - name: Optional promote to prod
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.release_to_prod == 'true' }}
+        env:
+          PROD_DST: gs://${{ env.GCS_BUCKET }}/prod/v1
+        run: |
+          gsutil -m rsync -d -r "${{ env.FAISS_DST_DIR }}" "$PROD_DST"
+          gsutil cp -n manifest.json "$PROD_DST/manifest.json"
+
+      - name: Write run summary
+        run: |
+          DOC_COUNT=$(jq -r '.doc_count' manifest.json || echo "unknown")
+          DIMS=$(jq -r '.dims' manifest.json || echo "unknown")
+          {
+            echo "### FAISS Nightly Build"
+            echo "- Source: \`${{ steps.src.outputs.src }}\`"
+            echo "- Doc count: **$DOC_COUNT**"
+            echo "- Dims: **$DIMS**"
+            echo "- Nightly: \`gs://${{ env.GCS_BUCKET }}/${{ env.GCS_PREFIX }}/nightly/${{ github.run_id }}-${{ github.sha }}\`"
+            echo "- Latest:  \`gs://${{ env.GCS_BUCKET }}/${{ env.GCS_PREFIX }}/nightly/latest\`"
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.release_to_prod }}" = "true" ]; then
+              echo "- Promoted to: \`gs://${{ env.GCS_BUCKET }}/prod/v1\`"
+            fi
+          } >> $GITHUB_STEP_SUMMARY
+

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -28,6 +28,27 @@ Vector search uses a FAISS bundle that can be downloaded on startup. Modes may s
 
 Budget tracking exposes counters: `retrieval_calls`, `web_search_calls`, `retrieval_tokens`, and increments `skipped_due_to_budget` when live search is skipped because the call cap is reached.
 
+### Nightly FAISS Build & Publish (GCS)
+
+A nightly workflow builds and validates a FAISS index bundle and pushes it to Google Cloud Storage:
+
+- `gs://$GCS_BUCKET/$GCS_PREFIX/nightly/<run>-<sha>` — immutable snapshot for each run.
+- `gs://$GCS_BUCKET/$GCS_PREFIX/nightly/latest` — rolling pointer updated every run.
+- `gs://$GCS_BUCKET/prod/v1` — manually promoted via `workflow_dispatch` with `release_to_prod=true`.
+
+To consume the bundle in the app, set:
+
+```bash
+# For testing
+FAISS_INDEX_URI="gs://$GCS_BUCKET/$GCS_PREFIX/nightly/latest"
+
+# For production
+FAISS_INDEX_URI="gs://$GCS_BUCKET/prod/v1"
+```
+
+Always configure `FAISS_BOOTSTRAP_MODE=download` and `FAISS_INDEX_DIR` to a writable path (e.g., `/tmp/faiss_index`).
+Each run emits a `manifest.json` with `doc_count` and `dims` fields and writes a summary to the GitHub Actions run page.
+
 ## Telemetry
 
 Structured logs aid monitoring:

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -43,4 +43,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-23T00:46:38.158792Z from commit 2cfbe36_
+_Last generated at 2025-08-23T01:18:44.889046Z from commit e7d4959_

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-23T00:46:38.158792Z'
-git_sha: 2cfbe36427d8864eaef265a7cb671045aa7770c6
+generated_at: '2025-08-23T01:18:44.889046Z'
+git_sha: e7d4959c5bc4ddccd86866abda5f18bf8b856767
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -100,7 +100,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/plan_utils.py
+- path: orchestrators/router.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -114,14 +114,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
+- path: orchestrators/__init__.py
   role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/router.py
+- path: orchestrators/plan_utils.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -135,7 +135,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/__init__.py
+- path: orchestrators/app_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []

--- a/scripts/validate_faiss_bundle.py
+++ b/scripts/validate_faiss_bundle.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Validate a FAISS index bundle and emit a manifest."""
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from knowledge.faiss_store import FAISSLoadError, build_default_retriever
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--path", default=".faiss_index", help="bundle directory")
+    ap.add_argument("--out", default="manifest.json", help="output manifest path")
+    args = ap.parse_args()
+
+    bundle_dir = Path(args.path)
+    required = ["index.faiss", "docs.json"]
+    missing = [f for f in required if not (bundle_dir / f).exists()]
+    if missing:
+        print(f"Missing required files: {', '.join(missing)}", file=sys.stderr)
+        raise SystemExit(1)
+
+    try:
+        _, doc_count, dims = build_default_retriever(str(bundle_dir))
+    except FAISSLoadError as e:
+        print(f"Bundle load failed: {e}", file=sys.stderr)
+        raise SystemExit(1)
+
+    if doc_count == 0:
+        print("Doc count is zero", file=sys.stderr)
+        raise SystemExit(1)
+
+    files = sorted(p.name for p in bundle_dir.iterdir() if p.is_file())
+    manifest = {
+        "path": str(bundle_dir),
+        "doc_count": doc_count,
+        "dims": dims,
+        "files": files,
+        "built_at": datetime.now(timezone.utc).isoformat(),
+        "embedding_model": None,
+    }
+    with open(args.out, "w", encoding="utf-8") as fh:
+        json.dump(manifest, fh)
+
+    print(f"doc_count={doc_count} dims={dims}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- add nightly GitHub Actions workflow to build, validate, and publish FAISS bundles to GCS with optional promotion to prod
- create `validate_faiss_bundle.py` helper to check bundles and emit a manifest
- document FAISS index publication and consumption in configuration docs

## Testing
- `python scripts/generate_repo_map.py`
- `pytest -q` *(fails: API and environment configuration errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a916689044832c853465b3c34d4229