### PR TITLE
Default to web-only retrieval

### DIFF
--- a/config/modes.yaml
+++ b/config/modes.yaml
@@ -9,10 +9,11 @@ test:
   rag_top_k: 5
   live_search_enabled: true
   live_search_backend: openai
-  live_search_max_calls: 2
+  live_search_max_calls: 3
   live_search_summary_tokens: 256
   faiss_index_local_dir: .faiss_index
-  faiss_bootstrap_mode: download
+  faiss_bootstrap_mode: skip
+  faiss_index_uri: ""
   enable_images: false
 deep:
   target_cost_usd: 2.50
@@ -25,9 +26,10 @@ deep:
   rag_top_k: 5
   live_search_enabled: true
   live_search_backend: openai
-  live_search_max_calls: 2
+  live_search_max_calls: 3
   live_search_summary_tokens: 256
   faiss_index_local_dir: .faiss_index
-  faiss_bootstrap_mode: download
+  faiss_bootstrap_mode: skip
+  faiss_index_uri: ""
   enable_images: false
 # redaction time

--- a/core/agents/planner_agent.py
+++ b/core/agents/planner_agent.py
@@ -21,6 +21,7 @@ from config.feature_flags import (
     LIVE_SEARCH_BACKEND,
     LIVE_SEARCH_MAX_CALLS,
     LIVE_SEARCH_SUMMARY_TOKENS,
+    VECTOR_INDEX_PRESENT,
 )
 from prompts.prompts import (
     PLANNER_SYSTEM_PROMPT,
@@ -104,8 +105,9 @@ def run_planner(
         constraints_section=constraints_section,
         risk_section=risk_section,
     )
+    vector_available = VECTOR_INDEX_PRESENT
     cfg = {
-        "rag_enabled": RAG_ENABLED,
+        "rag_enabled": RAG_ENABLED and vector_available,
         "rag_top_k": RAG_TOPK,
         "live_search_enabled": ENABLE_LIVE_SEARCH,
         "live_search_backend": LIVE_SEARCH_BACKEND,
@@ -114,6 +116,9 @@ def run_planner(
     }
     bundle = collect_context(idea, idea, cfg)
     meta = bundle.meta
+    if not vector_available:
+        meta["rag_hits"] = 0
+        meta["reason"] = "no_vector_index"
     logger.info(
         "RetrievalTrace agent=Planner task_id=plan rag_hits=%d web_used=%s backend=%s sources=%d reason=%s",
         meta.get("rag_hits", 0),

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -28,9 +28,51 @@ Vector search uses a FAISS bundle that can be downloaded on startup. Modes may s
 
 Budget tracking exposes counters: `retrieval_calls`, `web_search_calls`, `retrieval_tokens`, and increments `skipped_due_to_budget` when live search is skipped because the call cap is reached.
 
+### Web-only (no FAISS)
+
+By default the application starts without a vector index and performs retrieval exclusively through live web search.
+
+Default mode settings:
+
+```
+rag_enabled: true
+live_search_enabled: true
+live_search_backend: openai
+live_search_max_calls: 3
+faiss_bootstrap_mode: skip
+faiss_index_uri: ""
+faiss_index_dir: .faiss_index
+```
+
+Equivalent environment variables:
+
+```
+RAG_ENABLED=true
+ENABLE_LIVE_SEARCH=true
+LIVE_SEARCH_BACKEND=openai   # or serpapi
+LIVE_SEARCH_MAX_CALLS=3
+FAISS_BOOTSTRAP_MODE=skip
+FAISS_INDEX_URI=
+FAISS_INDEX_DIR=.faiss_index
+```
+
+Expected logs:
+
+- `FAISSLoad path=.faiss_index result=skip reason=bootstrap_skip`
+- `RetrievalTrace … rag_hits=0 web_used=true backend=<openai|serpapi> reason=no_vector_index`
+
+To re-enable FAISS later set:
+
+```
+FAISS_BOOTSTRAP_MODE=download
+FAISS_INDEX_URI=gs://<bucket>/<prefix>/nightly/latest  # or prod/v1
+```
+
+Live search may remain enabled for fallback.
+
 ### Nightly FAISS Build & Publish
 
-A nightly workflow builds and validates a FAISS index bundle and pushes it to Google Cloud Storage:
+A nightly workflow builds and validates a FAISS index bundle and pushes it to Google Cloud Storage. FAISS is disabled by default; these bundles are available for future use when vector search is re-enabled:
 
 - `gs://drrdfaiss/Projects/nightly/<run>-<sha>` — immutable snapshot for each run.
 - `gs://drrdfaiss/Projects/nightly/latest` — rolling pointer updated every run.

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -43,4 +43,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-23T02:11:24.316887Z from commit 589f940_
+_Last generated at 2025-08-23T06:49:10.980290Z from commit 2ee223e_

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-23T02:11:24.316887Z'
-git_sha: 589f940f466dc5fd0ca305f3895ff2814c6f1938
+generated_at: '2025-08-23T06:49:10.980290Z'
+git_sha: 2ee223e8d11c39b43e23ad73e6846b17bcebd3c2
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -25,10 +25,11 @@ runtime_modes:
     rag_top_k: 5
     live_search_enabled: true
     live_search_backend: openai
-    live_search_max_calls: 2
+    live_search_max_calls: 3
     live_search_summary_tokens: 256
     faiss_index_local_dir: .faiss_index
-    faiss_bootstrap_mode: download
+    faiss_bootstrap_mode: skip
+    faiss_index_uri: ''
     enable_images: false
   deep:
     target_cost_usd: 2.5
@@ -47,10 +48,11 @@ runtime_modes:
     rag_top_k: 5
     live_search_enabled: true
     live_search_backend: openai
-    live_search_max_calls: 2
+    live_search_max_calls: 3
     live_search_summary_tokens: 256
     faiss_index_local_dir: .faiss_index
-    faiss_bootstrap_mode: download
+    faiss_bootstrap_mode: skip
+    faiss_index_uri: ''
     enable_images: false
 env_flags:
 - DRRD_MODE
@@ -100,7 +102,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/plan_utils.py
+- path: orchestrators/qa_router.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -114,14 +116,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/spec_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/qa_router.py
+- path: orchestrators/__init__.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -135,7 +130,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/__init__.py
+- path: orchestrators/spec_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/plan_utils.py
   role: Orchestrator
   responsibilities: []
   inputs: []

--- a/tests/test_retrieval_web_only.py
+++ b/tests/test_retrieval_web_only.py
@@ -1,0 +1,94 @@
+import json
+import logging
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import config.feature_flags as ff
+from core.agents import base_agent as base_mod
+from core.agents import planner_agent as planner_mod
+from core.agents.base_agent import BaseAgent
+from core.agents.planner_agent import run_planner
+from dr_rd.retrieval import pipeline
+from dr_rd.retrieval.live_search import Source
+
+
+class DummyWeb:
+    def __init__(self):
+        self.called = 0
+
+    def search_and_summarize(self, query, k, max_tokens):
+        self.called += 1
+        return "s1\ns2", [Source(title="t1", url="u1"), Source(title="t2", url="u2")]
+
+
+def _set_web_only_flags(monkeypatch):
+    for mod in (ff, base_mod, planner_mod):
+        monkeypatch.setattr(mod, "RAG_ENABLED", True, raising=False)
+        monkeypatch.setattr(mod, "ENABLE_LIVE_SEARCH", True, raising=False)
+        monkeypatch.setattr(mod, "LIVE_SEARCH_BACKEND", "openai", raising=False)
+        monkeypatch.setattr(mod, "LIVE_SEARCH_MAX_CALLS", 3, raising=False)
+        monkeypatch.setattr(mod, "LIVE_SEARCH_SUMMARY_TOKENS", 256, raising=False)
+        monkeypatch.setattr(mod, "VECTOR_INDEX_PRESENT", False, raising=False)
+
+
+def test_planner_web_only(monkeypatch, caplog):
+    _set_web_only_flags(monkeypatch)
+    dummy = DummyWeb()
+    monkeypatch.setattr(pipeline, "get_live_client", lambda b: dummy)
+
+    captured = {}
+
+    def fake_llm_call(_a, _b, _c, messages, **_kw):
+        captured["messages"] = messages
+        return SimpleNamespace(output_text="{}", choices=[SimpleNamespace(finish_reason="stop", usage=SimpleNamespace(prompt_tokens=0, completion_tokens=0))])
+
+    with caplog.at_level(logging.INFO):
+        with patch("core.agents.planner_agent.llm_call", fake_llm_call):
+            run_planner("idea", "model")
+    assert dummy.called == 1
+    assert any(
+        "RetrievalTrace agent=Planner" in r.message
+        and "rag_hits=0" in r.message
+        and "web_used=true" in r.message
+        and "backend=openai" in r.message
+        and "reason=no_vector_index" in r.message
+        for r in caplog.records
+    )
+    user_content = next(m["content"] for m in captured["messages"] if m["role"] == "user")
+    assert "Web Search Results" in user_content
+    assert "s1" in user_content and "s2" in user_content
+    assert "# RAG Knowledge" not in user_content
+
+
+def test_executor_web_only(monkeypatch, caplog):
+    _set_web_only_flags(monkeypatch)
+    dummy = DummyWeb()
+    monkeypatch.setattr(pipeline, "get_live_client", lambda b: dummy)
+
+    fake_resp = {
+        "raw": SimpleNamespace(choices=[SimpleNamespace(usage=SimpleNamespace(prompt_tokens=0, completion_tokens=0))]),
+        "text": json.dumps({}),
+    }
+    captured = {}
+
+    def fake_call_openai(*, messages, **_kw):
+        captured["messages"] = messages
+        return fake_resp
+
+    with caplog.at_level(logging.INFO):
+        with patch("core.agents.base_agent.call_openai", fake_call_openai):
+            agent = BaseAgent("Exec", "gpt", "sys", "Task: {task}")
+            agent.run("idea", {"id": "T1", "title": "t", "description": "d"})
+    assert dummy.called == 1
+    assert any(
+        "RetrievalTrace agent=Exec" in r.message
+        and "rag_hits=0" in r.message
+        and "web_used=true" in r.message
+        and "backend=openai" in r.message
+        and "reason=no_vector_index" in r.message
+        for r in caplog.records
+    )
+    user_content = next(m["content"] for m in captured["messages"] if m["role"] == "user")
+    assert "Web Search Results" in user_content
+    assert "s1" in user_content and "s2" in user_content
+    assert "# RAG Knowledge" not in user_content


### PR DESCRIPTION
## Summary
- Default test and deep modes to live web search and skip FAISS bootstrap
- Skip FAISS load when no index URI and log explicit skip message
- Agents fall back to web search when vector index absent and log `reason=no_vector_index`
- Document web-only configuration and re-enabling FAISS
- Add web-only retrieval tests and refresh repo map

## Testing
- `pytest tests/test_retrieval_web_only.py -q`
- `pytest -q` *(fails: openai API connection / env-specific issues)*
- `python scripts/generate_repo_map.py`

------
https://chatgpt.com/codex/tasks/task_e_68a963447160832c9c01968d2434791e