### PR TITLE
Add web search fallback and robust evidence handling

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -706,7 +706,8 @@ def main():
     from core.retrieval import budget as rbudget
     import config.feature_flags as ff
 
-    cap = rbudget.get_web_search_max_calls(_mode_cfg, _os.environ)
+    cap = rbudget.get_web_search_call_cap(_mode_cfg)
+    _mode_cfg["web_search_max_calls"] = cap
     _mode_cfg["live_search_max_calls"] = cap
     rbudget.RETRIEVAL_BUDGET = rbudget.RetrievalBudget(cap)
     ff.LIVE_SEARCH_MAX_CALLS = cap

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -6,13 +6,15 @@ The system reads per-mode settings from `config/modes.yaml`. Retrieval flows in 
 - `rag_top_k`: number of snippets to retrieve.
 - `live_search_enabled`: enable web search fallback when RAG yields no context.
 - `live_search_backend`: `openai` or `serpapi`.
-- `live_search_max_calls`: maximum live-search queries per run.
+- `web_search_max_calls` (legacy `live_search_max_calls`): maximum live-search
+  queries per run.
 - `live_search_summary_tokens`: cap for web-summary tokens.
 - `enable_images`: allow image generation (default `false` for `test` and `deep`).
 
-When `live_search_enabled` is true, the system will automatically fall back to a
-web search if the vector index is absent or a RAG lookup returns zero hits,
-subject to the web-search budget cap.
+When `live_search_enabled` is true, the system automatically performs a live web
+search if the vector index is absent or a RAG lookup returns zero hits. The
+resulting summary is injected into prompts under `# Web Search Results`, subject
+to the web-search budget cap.
 
 Environment variables provide defaults when a mode omits a value:
 
@@ -26,16 +28,21 @@ SERPAPI_KEY=your_key
 
 ### Budget cap normalization
 
-`web_search_max_calls` is derived from the first available value among
-`WEB_SEARCH_MAX_CALLS` or `LIVE_SEARCH_MAX_CALLS` (environment), then
-`web_search_max_calls` or `live_search_max_calls` in the mode config. When
-running in web‑only mode (FAISS skipped), the cap defaults to `3` if unset.
+`web_search_max_calls` is resolved by preferring `web_search_max_calls` in the
+mode config, then `live_search_max_calls` for backwards compatibility. If
+neither is provided, it defaults to `3`.
 `ResolvedConfig` will show `vector_index_present=false` when the FAISS index is
 skipped.
 
 ### FAISS bootstrap
 
-Vector search uses a FAISS bundle that can be downloaded on startup. Modes may specify `faiss_index_uri`, `faiss_index_local_dir` (default `.faiss_index`), and `faiss_bootstrap_mode` (`download` or `skip`). Because container file systems are ephemeral, the bundle is fetched from GCS on each cold start when `faiss_bootstrap_mode` is `download`. If the index is unavailable, live web search still runs independently.
+Vector search uses a FAISS bundle that can be downloaded on startup. Modes may
+specify `faiss_index_uri`, `faiss_index_local_dir` (default `.faiss_index`), and
+`faiss_bootstrap_mode` (`download` or `skip`). Because container file systems are
+ephemeral, the bundle is fetched from GCS on each cold start when
+`faiss_bootstrap_mode` is `download`. If the index is unavailable and
+`live_search_enabled` is true, the system performs a web search and injects
+`# Web Search Results` into prompts.
 
 `ResolvedConfig` logs include `vector_index_source`, `vector_doc_count`, `web_search_max_calls`, and `web_search_calls_used` (initially `0`).
 
@@ -72,7 +79,7 @@ FAISS_INDEX_DIR=.faiss_index
 Expected logs:
 
 - `FAISSLoad path=.faiss_index result=skip reason=bootstrap_skip`
-- `RetrievalTrace … rag_hits=0 web_used=true backend=<openai|serpapi> reason=no_vector_index`
+- `RetrievalTrace … rag_hits=0 web_used=true backend=<openai|serpapi> reason=fallback_no_vector`
 
 To re-enable FAISS later set:
 
@@ -119,4 +126,7 @@ Structured logs aid monitoring:
 
 ## Planner integration
 
-The Planner now uses the same retrieval layer as execution agents, injecting `# RAG Knowledge` and `# Web Search Results` sections into its prompt when available. The planner JSON schema remains unchanged.
+The Planner uses the same retrieval layer as execution agents. When the vector
+index is missing or returns no results and live search is enabled, it performs a
+web search and injects a `# Web Search Results` section into the prompt. The
+planner JSON schema remains unchanged.

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -43,4 +43,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-23T16:47:02.144160Z from commit 3b1c5b5_
+_Last generated at 2025-08-23T17:31:06.867904Z from commit b678074_

--- a/dr_rd/core/config_snapshot.py
+++ b/dr_rd/core/config_snapshot.py
@@ -25,7 +25,10 @@ def build_resolved_config_snapshot(cfg: Dict[str, Any]) -> Dict[str, Any]:
         "live_search_enabled": bool(cfg.get("live_search_enabled")),
         "live_search_backend": cfg.get("live_search_backend"),
     }
-    if "live_search_max_calls" in cfg:
+    if "web_search_max_calls" in cfg:
+        snapshot["web_search_max_calls"] = cfg.get("web_search_max_calls")
+        snapshot["web_search_calls_used"] = cfg.get("web_search_calls_used", 0)
+    elif "live_search_max_calls" in cfg:
         snapshot["web_search_max_calls"] = cfg.get("live_search_max_calls")
         snapshot["web_search_calls_used"] = cfg.get("web_search_calls_used", 0)
     # Budget caps

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-23T16:47:02.144160Z'
-git_sha: 3b1c5b5c1a5740abd1c7b4e9151863613fc88314
+generated_at: '2025-08-23T17:31:06.867904Z'
+git_sha: b6780740e1cd1ade90c8c0b6c97b0290bbac6ed6
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -109,14 +109,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/router.py
+- path: orchestrators/__init__.py
   role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/spec_builder.py
+- path: orchestrators/router.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -130,14 +130,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/qa_router.py
+- path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/__init__.py
+- path: orchestrators/qa_router.py
   role: Orchestrator
   responsibilities: []
   inputs: []

--- a/tests/test_evidence_normalization.py
+++ b/tests/test_evidence_normalization.py
@@ -19,9 +19,11 @@ def test_pair_sequence():
 def test_irregular_shapes():
     payload = [("a", 1, 2)]
     out = _normalize_evidence_payload(payload)
-    assert "data" in out
+    assert out["_data"] == payload
+    assert "_note" in out
 
 
 def test_scalar_value():
     payload = "hello"
-    assert _normalize_evidence_payload(payload) == {"value": "hello"}
+    out = _normalize_evidence_payload(payload)
+    assert out["_data"] == "hello"

--- a/tests/test_live_search.py
+++ b/tests/test_live_search.py
@@ -19,6 +19,9 @@ def test_live_search_triggered(monkeypatch):
     importlib.reload(ff)
     importlib.reload(ba)
     importlib.reload(ip_agent)
+    from core.retrieval import budget as rbudget
+
+    rbudget.RETRIEVAL_BUDGET = rbudget.RetrievalBudget(3)
 
     def fake_search_and_summarize(query, k, max_tokens):
         return "summary", [Source(title="T1", url="u1")]
@@ -49,6 +52,11 @@ def test_no_live_search_with_rag(monkeypatch):
     importlib.reload(ff)
     importlib.reload(ba)
     importlib.reload(ip_agent)
+    for mod in (ff, ba, ip_agent):
+        monkeypatch.setattr(mod, "VECTOR_INDEX_PRESENT", True, raising=False)
+    from core.retrieval import budget as rbudget
+
+    rbudget.RETRIEVAL_BUDGET = rbudget.RetrievalBudget(3)
     called = {"search": False}
 
     def fake_search_and_summarize(query, k, max_tokens):
@@ -85,6 +93,9 @@ def test_live_search_disabled(monkeypatch):
     importlib.reload(ff)
     importlib.reload(ba)
     importlib.reload(ip_agent)
+    from core.retrieval import budget as rbudget
+
+    rbudget.RETRIEVAL_BUDGET = rbudget.RetrievalBudget(3)
     called = {"search": False}
 
     def fake_search_and_summarize(query, k, max_tokens):

--- a/tests/test_live_search_decoupled.py
+++ b/tests/test_live_search_decoupled.py
@@ -12,6 +12,9 @@ def test_live_search_without_index():
         "live_search_backend": "openai",
         "live_search_summary_tokens": 32,
     }
+    from core.retrieval import budget as rbudget
+
+    rbudget.RETRIEVAL_BUDGET = rbudget.RetrievalBudget(3)
     with patch(
         "dr_rd.retrieval.live_search.OpenAIWebSearchClient.search_and_summarize",
         return_value=("web", [Source("t", "u")]),
@@ -33,6 +36,9 @@ def test_live_search_when_rag_empty():
         "live_search_backend": "openai",
         "live_search_summary_tokens": 32,
     }
+    from core.retrieval import budget as rbudget
+
+    rbudget.RETRIEVAL_BUDGET = rbudget.RetrievalBudget(3)
     with patch(
         "dr_rd.retrieval.live_search.OpenAIWebSearchClient.search_and_summarize",
         return_value=("web", [Source("t", "u")]),

--- a/tests/test_orchestrator_normalize_payload.py
+++ b/tests/test_orchestrator_normalize_payload.py
@@ -1,0 +1,17 @@
+from core.orchestrator import _normalize_evidence_payload
+
+
+def test_normalize_payload_variants():
+    assert _normalize_evidence_payload({"a": 1}) == {"a": 1}
+
+    assert _normalize_evidence_payload([("a", 1), ("b", 2)]) == {"a": 1, "b": 2}
+
+    assert _normalize_evidence_payload([{"a": 1}, {"b": 2}]) == {"a": 1, "b": 2}
+
+    triple = [("a", 1, 2)]
+    res = _normalize_evidence_payload(triple)
+    assert res["_data"] == triple and "_note" in res
+
+    scalar = 42
+    res = _normalize_evidence_payload(scalar)
+    assert res["_data"] == scalar

--- a/tests/test_planner_with_context.py
+++ b/tests/test_planner_with_context.py
@@ -42,7 +42,7 @@ def test_planner_web_injection(monkeypatch):
         rag_snippets=[],
         web_summary="web",  # type: ignore[arg-type]
         sources=[],
-        meta={"rag_hits": 0, "web_used": True, "backend": "openai", "reason": "rag_empty"},
+        meta={"rag_hits": 0, "web_used": True, "backend": "openai", "reason": "no_results"},
     )
     captured = {}
     with patch("core.agents.planner_agent.collect_context", return_value=bundle), patch(

--- a/tests/test_retrieval_fallback_no_index.py
+++ b/tests/test_retrieval_fallback_no_index.py
@@ -33,7 +33,7 @@ def test_web_fallback_no_index(monkeypatch):
     meta = bundle.meta
     assert dummy.called == 1
     assert meta["web_used"] is True
-    assert meta["reason"] == "no_vector_index"
+    assert meta["reason"] == "fallback_no_vector"
     assert meta["backend"] == "openai"
     assert meta["sources"] == 2
     assert rbudget.RETRIEVAL_BUDGET.used == 1

--- a/tests/test_retrieval_fallback_rag_empty.py
+++ b/tests/test_retrieval_fallback_rag_empty.py
@@ -40,7 +40,7 @@ def test_web_fallback_rag_empty(monkeypatch):
     assert dummy.called == 1
     assert meta["rag_hits"] == 0
     assert meta["web_used"] is True
-    assert meta["reason"] == "rag_empty"
+    assert meta["reason"] == "no_results"
     assert meta["backend"] == "openai"
     assert meta["sources"] == 1
     assert rbudget.RETRIEVAL_BUDGET.used == 1

--- a/tests/test_retrieval_fallback_web_only.py
+++ b/tests/test_retrieval_fallback_web_only.py
@@ -1,0 +1,67 @@
+import logging
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import config.feature_flags as ff
+from core.agents import planner_agent
+from core.retrieval.budget import RetrievalBudget
+from dr_rd.retrieval import pipeline
+from dr_rd.retrieval.live_search import Source
+
+
+class DummyClient:
+    def __init__(self):
+        self.called = 0
+
+    def search_and_summarize(self, query, k, max_tokens):
+        self.called += 1
+        return "s1\ns2", [
+            Source(title="t1", url="u1"),
+            Source(title="t2", url="u2"),
+            Source(title="t3", url="u3"),
+        ]
+
+
+def test_planner_web_fallback(monkeypatch, caplog):
+    # Configure flags for web-only retrieval
+    for mod in (ff, planner_agent):
+        monkeypatch.setattr(mod, "VECTOR_INDEX_PRESENT", False, raising=False)
+        monkeypatch.setattr(mod, "ENABLE_LIVE_SEARCH", True, raising=False)
+        monkeypatch.setattr(mod, "LIVE_SEARCH_BACKEND", "openai", raising=False)
+        monkeypatch.setattr(mod, "RAG_ENABLED", True, raising=False)
+        monkeypatch.setattr(mod, "RAG_TOPK", 5, raising=False)
+
+    from core.retrieval import budget as rbudget
+
+    rbudget.RETRIEVAL_BUDGET = RetrievalBudget(1)
+
+    dummy = DummyClient()
+    monkeypatch.setattr(pipeline, "get_live_client", lambda _b: dummy)
+
+    def fake_llm_call(_a, _b, _c, messages, **_kw):
+        return SimpleNamespace(
+            output_text="{}",
+            choices=[
+                SimpleNamespace(
+                    finish_reason="stop",
+                    usage=SimpleNamespace(
+                        prompt_tokens=0, completion_tokens=0, total_tokens=0
+                    ),
+                )
+            ],
+        )
+
+    with caplog.at_level(logging.INFO):
+        with patch("core.agents.planner_agent.llm_call", fake_llm_call), patch(
+            "core.agents.planner_agent.extract_planner_payload", return_value={}
+        ):
+            planner_agent.run_planner("idea", "model")
+
+    assert dummy.called == 1
+    assert rbudget.RETRIEVAL_BUDGET.used == 1
+    assert any(
+        "RetrievalTrace agent=Planner" in r.message
+        and "web_used=true" in r.message
+        and "reason=fallback_no_vector" in r.message
+        for r in caplog.records
+    )

--- a/tests/test_retrieval_web_only.py
+++ b/tests/test_retrieval_web_only.py
@@ -29,6 +29,9 @@ def _set_web_only_flags(monkeypatch):
         monkeypatch.setattr(mod, "LIVE_SEARCH_MAX_CALLS", 3, raising=False)
         monkeypatch.setattr(mod, "LIVE_SEARCH_SUMMARY_TOKENS", 256, raising=False)
         monkeypatch.setattr(mod, "VECTOR_INDEX_PRESENT", False, raising=False)
+    from core.retrieval import budget as rbudget
+
+    rbudget.RETRIEVAL_BUDGET = rbudget.RetrievalBudget(3)
 
 
 def test_planner_web_only(monkeypatch, caplog):
@@ -51,7 +54,7 @@ def test_planner_web_only(monkeypatch, caplog):
         and "rag_hits=0" in r.message
         and "web_used=true" in r.message
         and "backend=openai" in r.message
-        and "reason=no_vector_index" in r.message
+        and "reason=fallback_no_vector" in r.message
         for r in caplog.records
     )
     user_content = next(m["content"] for m in captured["messages"] if m["role"] == "user")
@@ -85,7 +88,7 @@ def test_executor_web_only(monkeypatch, caplog):
         and "rag_hits=0" in r.message
         and "web_used=true" in r.message
         and "backend=openai" in r.message
-        and "reason=no_vector_index" in r.message
+        and "reason=fallback_no_vector" in r.message
         for r in caplog.records
     )
     user_content = next(m["content"] for m in captured["messages"] if m["role"] == "user")


### PR DESCRIPTION
## Summary
- Fallback to live web search when vector index is absent or returns no results, with clear RetrievalTrace reasons
- Normalize web-search call caps via `get_web_search_call_cap` and expose chosen cap in ResolvedConfig
- Harden evidence payload normalization for non-dict inputs
- Document web-search fallback behavior and budget cap resolution

## Testing
- `pytest tests/test_retrieval_fallback_web_only.py tests/test_orchestrator_normalize_payload.py tests/test_retrieval_fallback_no_index.py tests/test_retrieval_fallback_rag_empty.py tests/test_retrieval_budget_normalization.py tests/test_retrieval_decoupled.py tests/test_agents_retrieval.py tests/test_retrieval_web_only.py tests/test_planner_with_context.py tests/test_live_search_decoupled.py tests/test_live_search.py tests/test_evidence_normalization.py -q`
- `python scripts/generate_repo_map.py`

------
https://chatgpt.com/codex/tasks/task_e_68a9f8dbeadc832cba008d898462fcea