### PR TITLE
feat: robust web fallback and evidence normalization

### DIFF
--- a/core/observability/evidence.py
+++ b/core/observability/evidence.py
@@ -16,7 +16,7 @@ class EvidenceItem(BaseModel):
     evidence: str = ""
     sources: List[str] = Field(default_factory=list)
     quotes: List[str] = Field(default_factory=list)
-    confidence: float = 0.0   # 0..1
+    confidence: float = 0.0  # 0..1
     tokens_in: int = 0
     tokens_out: int = 0
     cost_usd: float = 0.0
@@ -71,9 +71,9 @@ class EvidenceSet(BaseModel):
 
     def add(self, **kwargs) -> None:
         claim = kwargs.get("claim")
-        if not isinstance(claim, str):
+        if claim is not None and not isinstance(claim, str):
             try:
-                kwargs["claim"] = json.dumps(claim, ensure_ascii=False)[:2000]
+                kwargs["claim"] = json.dumps(claim, ensure_ascii=False)
             except Exception:
                 kwargs["claim"] = str(claim)
         self.items.append(EvidenceItem(project_id=self.project_id, **kwargs))

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -13,14 +13,15 @@ The system reads per-mode settings from `config/modes.yaml`. Retrieval flows in 
 
 When `live_search_enabled` is true, the system automatically performs a live web
 search if the vector index is absent or a RAG lookup returns zero hits. The
-resulting summary is injected into prompts under `# Web Search Results`, subject
-to the web-search budget cap.
+resulting snippets are injected into prompts under `# Web Search Results`,
+subject to the web-search budget cap.
 
 `RetrievalTrace.reason` may be:
 
-- `web_only` – no vector index, web search only.
-- `rag_empty_web_fallback` – vector index queried but returned zero hits.
+- `no_vector_index_fallback` – no vector index, web search only.
+- `rag_zero_hits` – vector index queried but returned zero hits.
 - `budget_exhausted` – web search skipped due to budget.
+- `disabled` – web search disabled when needed.
 
 Evidence payloads collected during execution are normalized so that:
 
@@ -92,7 +93,7 @@ FAISS_INDEX_DIR=.faiss_index
 Expected logs:
 
 - `FAISSLoad path=.faiss_index result=skip reason=bootstrap_skip`
-- `RetrievalTrace … rag_hits=0 web_used=true backend=<openai|serpapi> reason=web_only`
+- `RetrievalTrace … rag_hits=0 web_used=true backend=<openai|serpapi> reason=no_vector_index_fallback`
 
 To re-enable FAISS later set:
 

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -43,4 +43,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-23T18:36:36.569676Z from commit c2c94ab_
+_Last generated at 2025-08-23T20:10:57.272765Z from commit 6902f99_

--- a/dr_rd/retrieval/context.py
+++ b/dr_rd/retrieval/context.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List
+
+from core.llm_client import BUDGET
+from core.retrieval import budget as rbudget
+from core.retrieval.budget import get_web_search_call_cap
+from dr_rd.retrieval.live_search import get_live_client
+from dr_rd.retrieval.vector_store import Retriever
+from utils.search_tools import search_google
+
+
+def _format_results(results: List[Dict[str, Any]]) -> List[Dict[str, str]]:
+    out: List[Dict[str, str]] = []
+    for r in results:
+        out.append(
+            {
+                "title": str(r.get("title", "")),
+                "url": str(r.get("link") or r.get("url") or ""),
+                "snippet": str(r.get("snippet", "")),
+            }
+        )
+    return out
+
+
+def fetch_context(
+    cfg: Dict[str, Any], query: str, agent_name: str, task_id: str | None
+) -> Dict[str, Any]:
+    """Retrieve vector and/or web context for a query."""
+
+    retriever: Retriever | None = cfg.get("retriever")
+    rag_enabled = bool(cfg.get("rag_enabled")) and bool(cfg.get("vector_index_present"))
+    rag_top_k = int(cfg.get("rag_top_k", 5))
+
+    rag_snips: List[str] = []
+    rag_hits = 0
+    if rag_enabled and retriever is not None:
+        try:
+            hits = retriever.query(query, rag_top_k)
+        except Exception:
+            hits = []
+        rag_hits = len(hits)
+        rag_snips = [getattr(h, "text", str(h)) for h in hits]
+        if BUDGET and rag_hits:
+            BUDGET.retrieval_calls += 1
+            BUDGET.retrieval_tokens += sum(len(s.split()) for s in rag_snips)
+
+    vector_present = bool(cfg.get("vector_index_present"))
+    reason = "ok"
+    if not vector_present:
+        reason = "no_vector_index_fallback"
+    elif rag_hits == 0:
+        reason = "rag_zero_hits"
+
+    need_web = (not vector_present) or rag_hits == 0
+
+    max_calls = get_web_search_call_cap(cfg)
+    cfg.setdefault("web_search_max_calls", max_calls)
+    used = int(cfg.get("web_search_calls_used", 0))
+    budget_obj = rbudget.RETRIEVAL_BUDGET
+    budget_allows = used < max_calls and (budget_obj.allow() if budget_obj else True)
+
+    web_results: List[Dict[str, str]] = []
+    web_used = False
+    backend = "none"
+
+    if need_web:
+        if cfg.get("live_search_enabled") and budget_allows:
+            backend = str(cfg.get("live_search_backend", "openai"))
+            try:
+                if backend == "serpapi":
+                    raw = search_google(agent_name, "", query, k=rag_top_k)
+                    web_results = _format_results(raw)
+                else:
+                    client = get_live_client(backend)
+                    _summary, srcs = client.search_and_summarize(
+                        query, rag_top_k, cfg.get("live_search_summary_tokens", 256)
+                    )
+                    web_results = [
+                        {"title": s.title, "url": s.url or "", "snippet": ""} for s in srcs
+                    ]
+                web_used = True
+                cfg["web_search_calls_used"] = used + 1
+                if budget_obj:
+                    budget_obj.consume()
+                if BUDGET:
+                    BUDGET.web_search_calls += 1
+            except Exception:
+                pass
+        else:
+            if not cfg.get("live_search_enabled"):
+                reason = "disabled"
+            elif not budget_allows:
+                reason = "budget_exhausted"
+
+    trace = {
+        "rag_hits": rag_hits,
+        "web_used": web_used,
+        "backend": backend if web_used else "none",
+        "sources": len(web_results),
+        "reason": reason,
+    }
+
+    return {"rag_snippets": rag_snips, "web_results": web_results, "trace": trace}

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-23T18:36:36.569676Z'
-git_sha: c2c94ab2a21a779937f0e03c77a2aae6572f523b
+generated_at: '2025-08-23T20:10:57.272765Z'
+git_sha: 6902f99454d2a4e791f056215ec1b35227158612
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -102,7 +102,28 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
+- path: orchestrators/__init__.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/plan_utils.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
 - path: orchestrators/qa_router.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -117,27 +138,6 @@ modules:
   invoked_by: []
   invokes: []
 - path: orchestrators/router.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/plan_utils.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/__init__.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []

--- a/tests/test_evidence_payload_normalization.py
+++ b/tests/test_evidence_payload_normalization.py
@@ -1,0 +1,21 @@
+import json
+
+from core.orchestrator import _normalize_evidence_payload
+
+
+def test_payload_normalization_shapes():
+    cases = [
+        {"claim": 123},
+        [{"a": 1}, {"claim": {"x": 2}}],
+        [("a", 1), ("claim", 3)],
+        [("a", 1, 2), ("claim", 4, 5)],
+        "plain text",
+        None,
+    ]
+    outs = [_normalize_evidence_payload(c) for c in cases]
+    assert outs[0]["claim"] == "123"
+    assert outs[1]["claim"] == json.dumps({"x": 2})
+    assert outs[2]["claim"] == "3"
+    assert "items" in outs[3]
+    assert outs[4]["text"] == "plain text"
+    assert outs[5] == {}

--- a/tests/test_planner_with_context.py
+++ b/tests/test_planner_with_context.py
@@ -1,7 +1,6 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from dr_rd.retrieval.pipeline import ContextBundle
 from core.agents.planner_agent import run_planner
 
 
@@ -23,30 +22,42 @@ def _fake_llm(messages):
 
 
 def test_planner_rag_injection(monkeypatch):
-    bundle = ContextBundle(
-        rag_snippets=["fact"],
-        web_summary=None,
-        sources=[],
-        meta={"rag_hits": 1, "web_used": False, "backend": "none", "reason": "ok"},
-    )
+    ctx = {
+        "rag_snippets": ["fact"],
+        "web_results": [],
+        "trace": {
+            "rag_hits": 1,
+            "web_used": False,
+            "backend": "none",
+            "sources": 0,
+            "reason": "ok",
+        },
+    }
     captured = {}
-    with patch("core.agents.planner_agent.collect_context", return_value=bundle), patch(
-        "core.agents.planner_agent.llm_call", lambda *a, **k: _fake_llm(captured.setdefault("messages", a[3]))
+    with patch("core.agents.planner_agent.fetch_context", return_value=ctx), patch(
+        "core.agents.planner_agent.llm_call",
+        lambda *a, **k: _fake_llm(captured.setdefault("messages", a[3])),
     ), patch("core.agents.planner_agent.extract_planner_payload", return_value={}):
         run_planner("idea", "model")
     assert "RAG Knowledge" in captured["messages"][1]["content"]
 
 
 def test_planner_web_injection(monkeypatch):
-    bundle = ContextBundle(
-        rag_snippets=[],
-        web_summary="web",  # type: ignore[arg-type]
-        sources=[],
-        meta={"rag_hits": 0, "web_used": True, "backend": "openai", "reason": "rag_empty_web_fallback"},
-    )
+    ctx = {
+        "rag_snippets": [],
+        "web_results": [{"title": "t", "url": "u", "snippet": "s"}],
+        "trace": {
+            "rag_hits": 0,
+            "web_used": True,
+            "backend": "openai",
+            "sources": 1,
+            "reason": "rag_zero_hits",
+        },
+    }
     captured = {}
-    with patch("core.agents.planner_agent.collect_context", return_value=bundle), patch(
-        "core.agents.planner_agent.llm_call", lambda *a, **k: _fake_llm(captured.setdefault("messages", a[3]))
+    with patch("core.agents.planner_agent.fetch_context", return_value=ctx), patch(
+        "core.agents.planner_agent.llm_call",
+        lambda *a, **k: _fake_llm(captured.setdefault("messages", a[3])),
     ), patch("core.agents.planner_agent.extract_planner_payload", return_value={}):
         run_planner("idea", "model")
     assert "Web Search Results" in captured["messages"][1]["content"]

--- a/tests/test_retrieval_budget_caps.py
+++ b/tests/test_retrieval_budget_caps.py
@@ -44,7 +44,7 @@ def test_retrieval_budget_consumption(monkeypatch, caplog):
             return "summary", [Source(title="t", url="u")]
 
     dummy = DummyClient()
-    monkeypatch.setattr(pipeline, "get_live_client", lambda b: dummy)
+    monkeypatch.setattr("dr_rd.retrieval.context.get_live_client", lambda b: dummy)
 
     with caplog.at_level(logging.INFO):
         bundle = pipeline.collect_context("idea", "task", cfg)
@@ -54,8 +54,6 @@ def test_retrieval_budget_consumption(monkeypatch, caplog):
             rbudget.RETRIEVAL_BUDGET.max_calls,
         )
     assert bundle.meta["web_used"] is True
-    assert bundle.meta["reason"] == "web_only"
+    assert bundle.meta["reason"] == "no_vector_index_fallback"
     assert rbudget.RETRIEVAL_BUDGET.used == 1
-    assert any(
-        f"RetrievalBudget web_search_calls=1/{cap}" in r.message for r in caplog.records
-    )
+    assert any(f"RetrievalBudget web_search_calls=1/{cap}" in r.message for r in caplog.records)

--- a/tests/test_retrieval_decoupled.py
+++ b/tests/test_retrieval_decoupled.py
@@ -35,7 +35,7 @@ def _cfg():
 
 def test_no_retriever_triggers_web(monkeypatch):
     dummy = DummyClient()
-    monkeypatch.setattr(pipeline, "get_live_client", lambda b: dummy)
+    monkeypatch.setattr("dr_rd.retrieval.context.get_live_client", lambda b: dummy)
     cfg = _cfg()
     cfg["vector_index_present"] = False
     from core.retrieval import budget as rbudget
@@ -43,13 +43,13 @@ def test_no_retriever_triggers_web(monkeypatch):
     rbudget.RETRIEVAL_BUDGET = rbudget.RetrievalBudget(5)
     bundle = pipeline.collect_context("idea", "task", cfg, retriever=None)
     assert dummy.called == 1
-    assert bundle.meta["reason"] == "web_only"
+    assert bundle.meta["reason"] == "no_vector_index_fallback"
     assert bundle.web_summary == "sum"
 
 
 def test_empty_rag_triggers_web(monkeypatch):
     dummy = DummyClient()
-    monkeypatch.setattr(pipeline, "get_live_client", lambda b: dummy)
+    monkeypatch.setattr("dr_rd.retrieval.context.get_live_client", lambda b: dummy)
     retriever = DummyRetriever([])
     cfg = _cfg()
     cfg["vector_index_present"] = True
@@ -58,7 +58,7 @@ def test_empty_rag_triggers_web(monkeypatch):
     rbudget.RETRIEVAL_BUDGET = rbudget.RetrievalBudget(5)
     bundle = pipeline.collect_context("i", "t", cfg, retriever=retriever)
     assert dummy.called == 1
-    assert bundle.meta["reason"] == "rag_empty_web_fallback"
+    assert bundle.meta["reason"] == "rag_zero_hits"
 
 
 def test_budget_skip(monkeypatch):
@@ -68,9 +68,9 @@ def test_budget_skip(monkeypatch):
         retrieval_tokens=0,
         skipped_due_to_budget=0,
     )
-    monkeypatch.setattr(pipeline, "BUDGET", dummy_budget)
+    monkeypatch.setattr("dr_rd.retrieval.context.BUDGET", dummy_budget)
     dummy = DummyClient()
-    monkeypatch.setattr(pipeline, "get_live_client", lambda b: dummy)
+    monkeypatch.setattr("dr_rd.retrieval.context.get_live_client", lambda b: dummy)
     cfg = _cfg()
     from core.retrieval import budget as rbudget
 

--- a/tests/test_retrieval_fallback_no_index.py
+++ b/tests/test_retrieval_fallback_no_index.py
@@ -27,13 +27,13 @@ def test_web_fallback_no_index(monkeypatch):
 
     rbudget.RETRIEVAL_BUDGET = RetrievalBudget(3)
     dummy = DummyClient()
-    monkeypatch.setattr(pipeline, "get_live_client", lambda b: dummy)
+    monkeypatch.setattr("dr_rd.retrieval.context.get_live_client", lambda b: dummy)
 
     bundle = pipeline.collect_context("idea", "task", cfg)
     meta = bundle.meta
     assert dummy.called == 1
     assert meta["web_used"] is True
-    assert meta["reason"] == "web_only"
+    assert meta["reason"] == "no_vector_index_fallback"
     assert meta["backend"] == "openai"
     assert meta["sources"] == 2
     assert rbudget.RETRIEVAL_BUDGET.used == 1

--- a/tests/test_retrieval_fallback_rag_empty.py
+++ b/tests/test_retrieval_fallback_rag_empty.py
@@ -32,7 +32,7 @@ def test_web_fallback_rag_empty(monkeypatch):
 
     rbudget.RETRIEVAL_BUDGET = RetrievalBudget(2)
     dummy = DummyClient()
-    monkeypatch.setattr(pipeline, "get_live_client", lambda b: dummy)
+    monkeypatch.setattr("dr_rd.retrieval.context.get_live_client", lambda b: dummy)
 
     retriever = EmptyRetriever()
     bundle = pipeline.collect_context("idea", "task", cfg, retriever=retriever)
@@ -40,7 +40,7 @@ def test_web_fallback_rag_empty(monkeypatch):
     assert dummy.called == 1
     assert meta["rag_hits"] == 0
     assert meta["web_used"] is True
-    assert meta["reason"] == "rag_empty_web_fallback"
+    assert meta["reason"] == "rag_zero_hits"
     assert meta["backend"] == "openai"
     assert meta["sources"] == 1
     assert rbudget.RETRIEVAL_BUDGET.used == 1

--- a/tests/test_retrieval_fallback_web_only.py
+++ b/tests/test_retrieval_fallback_web_only.py
@@ -36,7 +36,7 @@ def test_planner_web_fallback(monkeypatch, caplog):
     rbudget.RETRIEVAL_BUDGET = RetrievalBudget(1)
 
     dummy = DummyClient()
-    monkeypatch.setattr(pipeline, "get_live_client", lambda _b: dummy)
+    monkeypatch.setattr("dr_rd.retrieval.context.get_live_client", lambda _b: dummy)
 
     def fake_llm_call(_a, _b, _c, messages, **_kw):
         return SimpleNamespace(
@@ -44,9 +44,7 @@ def test_planner_web_fallback(monkeypatch, caplog):
             choices=[
                 SimpleNamespace(
                     finish_reason="stop",
-                    usage=SimpleNamespace(
-                        prompt_tokens=0, completion_tokens=0, total_tokens=0
-                    ),
+                    usage=SimpleNamespace(prompt_tokens=0, completion_tokens=0, total_tokens=0),
                 )
             ],
         )
@@ -62,6 +60,6 @@ def test_planner_web_fallback(monkeypatch, caplog):
     assert any(
         "RetrievalTrace agent=Planner" in r.message
         and "web_used=true" in r.message
-        and "reason=web_only" in r.message
+        and "reason=no_vector_index_fallback" in r.message
         for r in caplog.records
     )

--- a/tests/test_retrieval_web_fallback.py
+++ b/tests/test_retrieval_web_fallback.py
@@ -1,0 +1,33 @@
+from core.retrieval.budget import RetrievalBudget
+from dr_rd.retrieval.context import fetch_context
+
+
+def test_web_fallback_no_vector(monkeypatch):
+    cfg = {
+        "vector_index_present": False,
+        "rag_enabled": True,
+        "rag_top_k": 5,
+        "live_search_enabled": True,
+        "live_search_backend": "serpapi",
+        "web_search_max_calls": 2,
+        "web_search_calls_used": 0,
+    }
+    from core.retrieval import budget as rbudget
+
+    rbudget.RETRIEVAL_BUDGET = RetrievalBudget(3)
+
+    def fake_search(role, idea, q, k=5):
+        return [
+            {"title": "t1", "link": "u1", "snippet": "s1"},
+            {"title": "t2", "link": "u2", "snippet": "s2"},
+        ]
+
+    monkeypatch.setattr("dr_rd.retrieval.context.search_google", fake_search)
+    out = fetch_context(cfg, "q", "A", "T1")
+    trace = out["trace"]
+    assert trace["web_used"] is True
+    assert trace["backend"] == "serpapi"
+    assert trace["reason"] == "no_vector_index_fallback"
+    assert len(out["web_results"]) == 2
+    assert cfg["web_search_calls_used"] == 1
+    assert rbudget.RETRIEVAL_BUDGET.used == 1


### PR DESCRIPTION
## Summary
- centralize retrieval with `fetch_context` to fall back to web search when FAISS is absent
- unify planner and agents on the new helper and log detailed `RetrievalTrace`
- harden evidence payload normalization so `claim` is always a string

## Testing
- `ruff check dr_rd/retrieval/context.py core/agents/base_agent.py core/agents/planner_agent.py core/orchestrator.py core/observability/evidence.py tests/test_agents_retrieval.py tests/test_live_search_fallback.py tests/test_planner_with_context.py tests/test_retrieval_decoupled.py tests/test_retrieval_fallback_no_index.py tests/test_retrieval_fallback_rag_empty.py tests/test_retrieval_budget_caps.py tests/test_retrieval_web_only.py tests/test_retrieval_fallback_web_only.py tests/test_live_search_decoupled.py tests/test_retrieval_web_fallback.py tests/test_evidence_payload_normalization.py`
- `black dr_rd/retrieval/context.py core/agents/base_agent.py core/agents/planner_agent.py core/orchestrator.py core/observability/evidence.py tests/test_agents_retrieval.py tests/test_live_search_fallback.py tests/test_planner_with_context.py tests/test_retrieval_decoupled.py tests/test_retrieval_fallback_no_index.py tests/test_retrieval_fallback_rag_empty.py tests/test_retrieval_budget_caps.py tests/test_retrieval_web_only.py tests/test_retrieval_fallback_web_only.py tests/test_live_search_decoupled.py tests/test_retrieval_web_fallback.py tests/test_evidence_payload_normalization.py`
- `pytest tests/test_retrieval_web_fallback.py tests/test_evidence_payload_normalization.py -q`
- `python scripts/generate_repo_map.py`

------
https://chatgpt.com/codex/tasks/task_e_68aa1e50fff4832cb0523f368be74840