### PR TITLE
Handle list payloads in coverage

### DIFF
--- a/core/observability/coverage.py
+++ b/core/observability/coverage.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import List, Dict, Any
+from typing import Any, Dict, List
 
 logger = logging.getLogger(__name__)
 
@@ -41,11 +41,7 @@ def _to_text(v: Any) -> str:
                 val = _to_text(v[key])
                 if val:
                     return val
-        parts = [
-            _to_text(value)
-            for value in v.values()
-            if value is not None and _to_text(value)
-        ]
+        parts = [_to_text(value) for value in v.values() if value is not None and _to_text(value)]
         if parts:
             return " ".join(parts)
         return json.dumps(v, ensure_ascii=False, separators=(",", ":"))
@@ -56,20 +52,34 @@ def build_coverage(project_id: str, role_to_findings: Dict[str, dict]) -> List[D
     rows = []
     for role, payload in role_to_findings.items():
         dims = {d: False for d in DIMENSIONS}
-        findings_raw = payload.get("findings")
-        task_raw = payload.get("task")
+        if isinstance(payload, dict):
+            findings_raw = payload.get("findings")
+            task_raw = payload.get("task")
+        else:
+            findings_raw = payload
+            task_raw = ""
         txt = _to_text(findings_raw) + " " + _to_text(task_raw)
         if any(isinstance(x, (list, tuple, dict)) for x in [findings_raw, task_raw]):
             logger.info("coverage: coerced structured fields for role=%s", role)
         t = txt.lower()
         dims["Feasibility"] = any(k in t for k in ["feasible", "feasibility", "risk", "resource"])
         dims["Novelty"] = any(k in t for k in ["novel", "original", "prior art", "new"])
-        dims["Compliance"] = any(k in t for k in ["regulatory", "compliance", "fda", "iso", "safety"])
+        dims["Compliance"] = any(
+            k in t for k in ["regulatory", "compliance", "fda", "iso", "safety"]
+        )
         dims["Cost"] = any(k in t for k in ["cost", "budget", "capex", "opex", "bom"])
-        dims["IP"] = any(k in t for k in ["patent", "prior art", "claims", "freedom to operate", "ip"])
-        dims["Market"] = any(k in t for k in ["market", "customer", "adoption", "pricing", "competitor"])
-        dims["Architecture"] = any(k in t for k in ["architecture", "interface", "security", "scalability", "system"])
-        dims["Materials"] = any(k in t for k in ["material", "alloy", "polymer", "composite", "fatigue", "tensile"])
+        dims["IP"] = any(
+            k in t for k in ["patent", "prior art", "claims", "freedom to operate", "ip"]
+        )
+        dims["Market"] = any(
+            k in t for k in ["market", "customer", "adoption", "pricing", "competitor"]
+        )
+        dims["Architecture"] = any(
+            k in t for k in ["architecture", "interface", "security", "scalability", "system"]
+        )
+        dims["Materials"] = any(
+            k in t for k in ["material", "alloy", "polymer", "composite", "fatigue", "tensile"]
+        )
         row = {"project_id": project_id, "role": role}
         row.update(dims)
         rows.append(row)

--- a/tests/test_coverage_map.py
+++ b/tests/test_coverage_map.py
@@ -15,3 +15,13 @@ def test_build_coverage():
     assert r1["Feasibility"] and r1["Cost"] and r1["Compliance"]
     r2 = {r["role"]: r for r in rows}["Engineer"]
     assert r2["Materials"] and r2["Novelty"]
+
+
+def test_build_coverage_list_payload():
+    role_to_findings = {
+        "Researcher": ["novel architecture using composite materials"],
+    }
+    rows = build_coverage("p2", role_to_findings)
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["Novelty"] and r["Architecture"] and r["Materials"]


### PR DESCRIPTION
## Summary
- avoid attribute errors in coverage analysis when agent outputs are lists
- test coverage builder with top-level list payloads

## Testing
- `pre-commit run --hook-stage manual --files core/observability/coverage.py tests/test_coverage_map.py`
- `pytest tests/test_coverage_map.py tests/test_coverage_text_coercion.py`

------
https://chatgpt.com/codex/tasks/task_e_68aa5d4ab8d8832cad7c0f3e3993f396