### PR TITLE
feat: enable openai web search

### DIFF
--- a/core/agents/base_agent.py
+++ b/core/agents/base_agent.py
@@ -188,6 +188,7 @@ class BaseAgent:
                 {"role": "system", "content": self.system_message},
                 {"role": "user", "content": prompt},
             ],
+            enable_web_search=ENABLE_LIVE_SEARCH,
         )
         resp = result["raw"]
         usage = getattr(resp, "usage", None)

--- a/core/agents/ip_analyst_agent.py
+++ b/core/agents/ip_analyst_agent.py
@@ -26,12 +26,14 @@ class IPAnalystAgent(BaseAgent):
         prompt = self.user_prompt_template.format(idea=idea, task=task)
         prompt = self._augment_prompt(prompt, idea, task, "")
         sel = pick_model(CallHints(stage="exec"))
+        enable_web = bool(context.get("live_search_enabled", False)) if context else False
         result = call_openai(
             model=sel["model"],
             messages=[
                 {"role": "system", "content": self.system_message},
                 {"role": "user", "content": prompt},
             ],
+            enable_web_search=enable_web,
             **sel["params"],
         )
         resp = result["raw"]

--- a/core/agents/marketing_agent.py
+++ b/core/agents/marketing_agent.py
@@ -41,12 +41,14 @@ class MarketingAgent(BaseAgent):
                 pass
 
         sel = pick_model(CallHints(stage="exec"))
+        enable_web = bool(context.get("live_search_enabled", False)) if context else False
         result = call_openai(
             model=sel["model"],
             messages=[
                 {"role": "system", "content": self.system_message},
                 {"role": "user", "content": prompt},
             ],
+            enable_web_search=enable_web,
             **sel["params"],
         )
         resp = result["raw"]

--- a/core/agents/planner_agent.py
+++ b/core/agents/planner_agent.py
@@ -68,6 +68,7 @@ def _repair_to_json(raw_txt: str, model: str) -> str:
         messages=repair_msgs,
         temperature=0.0,
         response_format={"type": "json_object"},
+        enable_web_search=False,
     )
     return result["text"] or "{}"
 
@@ -160,7 +161,7 @@ def run_planner(
         if not use_chat:
             logger.info("Planner seed provided but Responses API is in use; seed will be ignored.")
 
-    resp = llm_call(None, model, "plan", messages, **params)
+    resp = llm_call(None, model, "plan", messages, enable_web_search=ENABLE_LIVE_SEARCH, **params)
     finish = None
     if getattr(resp, "choices", None):
         finish = getattr(resp.choices[0], "finish_reason", None)
@@ -259,6 +260,7 @@ class PlannerAgent:
             messages=messages,
             temperature=0.2,
             response_format={"type": "json_object"},
+            enable_web_search=ENABLE_LIVE_SEARCH,
         )
         raw = result["text"] or "{}"
         try:

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -11,6 +11,13 @@ The system reads per-mode settings from `config/modes.yaml`. Retrieval flows in 
 - `live_search_summary_tokens`: cap for web-summary tokens.
 - `enable_images`: allow image generation (default `false` for `test` and `deep`).
 
+**Model defaults with OpenAI web search**
+
+When `LIVE_SEARCH_BACKEND=openai`, the default model is `gpt-4o-mini` so that the
+`web_search_preview` tool is supported without extra configuration. If you force
+another model via env or mode config, the client will emit a warning and
+temporarily override to `gpt-4o-mini` for calls that request web search.
+
 When `live_search_enabled` is true, the system automatically performs a live web
 search if the vector index is absent or a RAG lookup returns zero hits. The
 resulting snippets are injected into prompts under `# Web Search Results`,

--- a/tests/test_openai_web_search_injection.py
+++ b/tests/test_openai_web_search_injection.py
@@ -1,0 +1,61 @@
+import os
+import types
+from typing import Any, Dict
+
+import pytest
+
+import core.llm_client as llm
+
+
+class _StubResponses:
+    def __init__(self, sink: Dict[str, Any]):
+        self._sink = sink
+
+    def create(self, **kwargs):
+        self._sink.update(kwargs)
+        return types.SimpleNamespace(id="resp_123", output=[])
+
+
+class _StubClient:
+    def __init__(self, sink: Dict[str, Any]):
+        self.responses = _StubResponses(sink)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for k in ["ENABLE_LIVE_SEARCH", "LIVE_SEARCH_BACKEND", "OPENAI_API_KEY"]:
+        monkeypatch.delenv(k, raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    yield
+
+
+def test_injects_web_search_tool_and_overrides_model(monkeypatch, caplog):
+    monkeypatch.setenv("ENABLE_LIVE_SEARCH", "true")
+    monkeypatch.setenv("LIVE_SEARCH_BACKEND", "openai")
+    sink: Dict[str, Any] = {}
+    monkeypatch.setattr(llm, "client", _StubClient(sink))
+
+    with caplog.at_level("WARNING"):
+        llm.call_openai(
+            model="gpt-4.1-mini",
+            messages=[{"role": "user", "content": "who is the ceo of openai?"}],
+            api="Responses",
+        )
+
+    assert sink["model"] == "gpt-4o-mini"
+    assert sink["tools"] == [{"type": "web_search_preview"}]
+    assert any("Overriding to 'gpt-4o-mini'" in rec.message for rec in caplog.records)
+
+
+def test_does_not_inject_when_disabled(monkeypatch):
+    sink: Dict[str, Any] = {}
+    monkeypatch.setattr(llm, "client", _StubClient(sink))
+
+    llm.call_openai(
+        model="gpt-4.1-mini",
+        messages=[{"role": "user", "content": "hello"}],
+        api="Responses",
+    )
+
+    assert "tools" not in sink or sink["tools"] is None
+


### PR DESCRIPTION
## Summary
- inject OpenAI `web_search_preview` tooling with model guardrails
- default to `gpt-4o-mini` when OpenAI search backend requested
- propagate web search flag through agents and planner
- document OpenAI web search model defaults
- add tests for OpenAI web search tool injection

## Testing
- `pytest -q`
- `pytest tests/test_openai_web_search_injection.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aab057f9e8832c91afbf7553587a04