### PR TITLE
fix: ensure web search fallback uses live config

### DIFF
--- a/core/agents/base_agent.py
+++ b/core/agents/base_agent.py
@@ -9,15 +9,13 @@ import streamlit as st
 from utils.logging import logger
 
 from config.feature_flags import (
-    ENABLE_LIVE_SEARCH,
-    LIVE_SEARCH_BACKEND,
-    LIVE_SEARCH_MAX_CALLS,
     LIVE_SEARCH_SUMMARY_TOKENS,
     RAG_ENABLED,
     RAG_TOPK,
     VECTOR_INDEX_PATH,
     VECTOR_INDEX_PRESENT,
 )
+import config.feature_flags as ff
 from core.llm import complete
 from core.llm_client import call_openai, log_usage
 from core.prompt_utils import coerce_user_content
@@ -107,12 +105,12 @@ class BaseAgent:
         cfg = {
             "rag_enabled": RAG_ENABLED and vector_available,
             "rag_top_k": RAG_TOPK,
-            "live_search_enabled": ENABLE_LIVE_SEARCH,
-            "live_search_backend": LIVE_SEARCH_BACKEND,
+            "live_search_enabled": ff.ENABLE_LIVE_SEARCH,
+            "live_search_backend": ff.LIVE_SEARCH_BACKEND,
             "live_search_summary_tokens": LIVE_SEARCH_SUMMARY_TOKENS,
             "vector_index_present": vector_available,
             "retriever": self.retriever,
-            "live_search_max_calls": LIVE_SEARCH_MAX_CALLS,
+            "live_search_max_calls": ff.LIVE_SEARCH_MAX_CALLS,
         }
         ctx = fetch_context(cfg, f"{idea}\n{task}".strip(), self.name, task_id)
         trace = ctx["trace"]
@@ -188,7 +186,7 @@ class BaseAgent:
                 {"role": "system", "content": self.system_message},
                 {"role": "user", "content": prompt},
             ],
-            enable_web_search=ENABLE_LIVE_SEARCH,
+            enable_web_search=ff.ENABLE_LIVE_SEARCH,
         )
         resp = result["raw"]
         usage = getattr(resp, "usage", None)

--- a/core/agents/planner_agent.py
+++ b/core/agents/planner_agent.py
@@ -10,14 +10,12 @@ from typing import List, Optional
 from pydantic import BaseModel, Field
 
 from config.feature_flags import (
-    ENABLE_LIVE_SEARCH,
-    LIVE_SEARCH_BACKEND,
-    LIVE_SEARCH_MAX_CALLS,
     LIVE_SEARCH_SUMMARY_TOKENS,
     RAG_ENABLED,
     RAG_TOPK,
     VECTOR_INDEX_PRESENT,
 )
+import config.feature_flags as ff
 from core.llm_client import (
     _strip_code_fences,
     call_openai,
@@ -110,11 +108,11 @@ def run_planner(
     cfg = {
         "rag_enabled": RAG_ENABLED and vector_available,
         "rag_top_k": RAG_TOPK,
-        "live_search_enabled": ENABLE_LIVE_SEARCH,
-        "live_search_backend": LIVE_SEARCH_BACKEND,
+        "live_search_enabled": ff.ENABLE_LIVE_SEARCH,
+        "live_search_backend": ff.LIVE_SEARCH_BACKEND,
         "live_search_summary_tokens": LIVE_SEARCH_SUMMARY_TOKENS,
         "vector_index_present": vector_available,
-        "live_search_max_calls": LIVE_SEARCH_MAX_CALLS,
+        "live_search_max_calls": ff.LIVE_SEARCH_MAX_CALLS,
     }
     ctx = fetch_context(cfg, idea, "Planner", "plan")
     trace = ctx["trace"]
@@ -161,7 +159,7 @@ def run_planner(
         if not use_chat:
             logger.info("Planner seed provided but Responses API is in use; seed will be ignored.")
 
-    resp = llm_call(None, model, "plan", messages, enable_web_search=ENABLE_LIVE_SEARCH, **params)
+    resp = llm_call(None, model, "plan", messages, enable_web_search=ff.ENABLE_LIVE_SEARCH, **params)
     finish = None
     if getattr(resp, "choices", None):
         finish = getattr(resp.choices[0], "finish_reason", None)
@@ -260,7 +258,7 @@ class PlannerAgent:
             messages=messages,
             temperature=0.2,
             response_format={"type": "json_object"},
-            enable_web_search=ENABLE_LIVE_SEARCH,
+            enable_web_search=ff.ENABLE_LIVE_SEARCH,
         )
         raw = result["text"] or "{}"
         try:

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -43,4 +43,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-23T21:21:38.927561Z from commit cf8ffb3_
+_Last generated at 2025-08-24T07:16:22.258739Z from commit c6ed7e5_

--- a/dr_rd/retrieval/live_search.py
+++ b/dr_rd/retrieval/live_search.py
@@ -80,10 +80,16 @@ class OpenAIWebSearchClient:
         k: int | None = None,
         max_tokens: int | None = None,
         max_sources: int = 5,
+        *,
+        tools: list[dict] | None = None,
+        tool_choice: str | None = None,
     ) -> Any:
         if k is not None:
             max_sources = k
         try:
+            kwargs: dict = {"tools": tools or [{"type": "web_search"}]}
+            if tool_choice is not None:
+                kwargs["tool_choice"] = tool_choice
             rsp = call_openai(
                 model=self.model,
                 messages=[
@@ -96,7 +102,7 @@ class OpenAIWebSearchClient:
                         "content": f"Search the web and summarize reliably with sources: {query}",
                     },
                 ],
-                tools=[{"type": "web_search"}],
+                **kwargs,
             )
         except Exception as e:  # pragma: no cover - network failures
             if _is_openai_web_search_unavailable(e):

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-23T21:21:38.927561Z'
-git_sha: cf8ffb3c4490c6f9e1706bdadc1a09af153be0dd
+generated_at: '2025-08-24T07:16:22.258739Z'
+git_sha: c6ed7e58af96c30518f93cdad87b41b18501a99e
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -12,9 +12,9 @@ runtime_modes:
     target_cost_usd: 2.5
     enforce_caps: false
     models:
-      plan: gpt-4-turbo
-      exec: gpt-4-turbo
-      synth: gpt-4-turbo
+      plan: gpt-4o-mini
+      exec: gpt-4o-mini
+      synth: gpt-4o-mini
     k_search: 6
     max_loops: 5
     stage_weights:
@@ -35,9 +35,9 @@ runtime_modes:
     target_cost_usd: 2.5
     enforce_caps: false
     models:
-      plan: gpt-5
-      exec: gpt-5
-      synth: gpt-5
+      plan: gpt-4o-mini
+      exec: gpt-4o-mini
+      synth: gpt-4o-mini
     k_search: 6
     max_loops: 5
     stage_weights:
@@ -102,21 +102,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/plan_utils.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/spec_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/router.py
+- path: orchestrators/app_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -130,6 +116,13 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
+- path: orchestrators/router.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
 - path: orchestrators/qa_router.py
   role: Orchestrator
   responsibilities: []
@@ -137,7 +130,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
+- path: orchestrators/spec_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/plan_utils.py
   role: Orchestrator
   responsibilities: []
   inputs: []

--- a/tests/test_retrieval_web_fallback.py
+++ b/tests/test_retrieval_web_fallback.py
@@ -1,5 +1,6 @@
 from core.retrieval.budget import RetrievalBudget
 from dr_rd.retrieval.context import fetch_context
+from dr_rd.retrieval.live_search import OpenAIWebSearchUnavailable
 
 
 def test_web_fallback_no_vector(monkeypatch):
@@ -22,12 +23,19 @@ def test_web_fallback_no_vector(monkeypatch):
             {"title": "t2", "link": "u2", "snippet": "s2"},
         ]
 
+    def boom(self, *args, **kwargs):
+        raise OpenAIWebSearchUnavailable("no tool")
+
+    monkeypatch.setenv("SERPAPI_KEY", "dummy")
+    monkeypatch.setattr(
+        "dr_rd.retrieval.context.OpenAIWebSearchClient.search_and_summarize", boom
+    )
     monkeypatch.setattr("dr_rd.retrieval.context.search_google", fake_search)
     out = fetch_context(cfg, "q", "A", "T1")
     trace = out["trace"]
     assert trace["web_used"] is True
     assert trace["backend"] == "serpapi"
-    assert trace["reason"] == "web_only_mode"
+    assert trace["reason"] == "live_search_error"
     assert len(out["web_results"]) == 2
     assert cfg["web_search_calls_used"] == 1
     assert rbudget.RETRIEVAL_BUDGET.used == 1


### PR DESCRIPTION
## Summary
- use runtime feature flags for live search in agents
- force OpenAI web search with SerpAPI fallback when FAISS disabled
- expand logging and add tests for live search fallback

## Testing
- `pytest tests/test_live_search_fallback.py -q`
- `pytest tests/test_retrieval_web_fallback.py -q`
- `pytest -q` *(fails: ProxyError from OpenAI API)*

------
https://chatgpt.com/codex/tasks/task_e_68aaba7bd24c832c8aa9badea4161b5c