### PR TITLE
feat: unify routing with research fallback and add reflection self-check

### DIFF
--- a/core/agents/hrm_agent.py
+++ b/core/agents/hrm_agent.py
@@ -2,7 +2,8 @@ from core.agents.base_agent import LLMRoleAgent
 
 ROLE_PROMPT = (
     "You are an HR Manager specializing in R&D projects. "
-    "Identify the expert roles needed for the following idea."
+    "Identify the expert roles needed for the following idea. "
+    "Conclude with a JSON summary using keys: role, task, findings, risks, next_steps, sources."
 )
 
 class HRMAgent(LLMRoleAgent):

--- a/core/agents/materials_engineer_agent.py
+++ b/core/agents/materials_engineer_agent.py
@@ -2,7 +2,8 @@ from core.agents.base_agent import LLMRoleAgent
 
 ROLE_PROMPT = (
     "You are a Materials Engineer specialized in material selection and engineering feasibility. "
-    "Evaluate material choices and manufacturing considerations."
+    "Evaluate material choices and manufacturing considerations. "
+    "Conclude with a JSON summary using keys: role, task, findings, risks, next_steps, sources."
 )
 
 class MaterialsEngineerAgent(LLMRoleAgent):

--- a/core/agents/reflection_agent.py
+++ b/core/agents/reflection_agent.py
@@ -2,7 +2,7 @@ from core.agents.base_agent import LLMRoleAgent
 
 ROLE_PROMPT = (
     "You are a Reflection agent analyzing the team's outputs. "
-    "Determine if follow-up tasks are required."
+    "Determine if follow-up tasks are required. Respond with either a JSON array of follow-up task strings or the exact string 'no further tasks'."
 )
 
 class ReflectionAgent(LLMRoleAgent):

--- a/core/agents/registry.py
+++ b/core/agents/registry.py
@@ -17,6 +17,9 @@ from .ip_analyst_agent import IPAnalystAgent
 from .planner_agent import PlannerAgent
 from .synthesizer_agent import SynthesizerAgent
 from .mechanical_systems_lead_agent import MechanicalSystemsLeadAgent
+from .hrm_agent import HRMAgent
+from .materials_engineer_agent import MaterialsEngineerAgent
+from .reflection_agent import ReflectionAgent
 from .invoke import resolve_invoker
 from config.agent_models import AGENT_MODEL_MAP
 from core.llm import select_model
@@ -37,6 +40,9 @@ AGENTS: Dict[str, Type[BaseAgent]] = {
     "Planner": PlannerAgent,
     "Synthesizer": SynthesizerAgent,
     "Mechanical Systems Lead": MechanicalSystemsLeadAgent,
+    "HRM": HRMAgent,
+    "Materials Engineer": MaterialsEngineerAgent,
+    "Reflection": ReflectionAgent,
 }
 
 # Backwards compatibility alias
@@ -48,7 +54,7 @@ CACHE: Dict[str, object] = {}
 def get_agent(name: str) -> object:
     """Return a cached agent instance by canonical ``name``.
 
-    Unknown names fall back to ``Synthesizer``.
+    Unknown names fall back to ``Research Scientist``.
     """
 
     if name in CACHE:
@@ -56,9 +62,9 @@ def get_agent(name: str) -> object:
 
     cls = AGENTS.get(name)
     if cls is None:
-        logger.info("Unknown agent %r; using Synthesizer", name)
-        cls = AGENTS["Synthesizer"]
-        name = "Synthesizer"
+        logger.info("Unknown agent %r; using Research Scientist", name)
+        cls = AGENTS["Research Scientist"]
+        name = "Research Scientist"
 
     inst = cls(select_model("agent", agent_name=name))
     CACHE[name] = inst

--- a/core/agents/research_scientist_agent.py
+++ b/core/agents/research_scientist_agent.py
@@ -5,7 +5,8 @@ class ResearchScientistAgent(LLMRoleAgent):
     def act(self, idea, task=None, **kwargs) -> str:
         if isinstance(task, dict):
             system_prompt = (
-                "You are the Research Scientist. Provide specific, non-generic analysis with concrete details."
+                "You are the Research Scientist. Provide specific, non-generic analysis with concrete details. "
+                "Conclude with a JSON summary using keys: role, task, findings, risks, next_steps, sources."
             )
             user_prompt = (
                 f"Project Idea:\n{idea}\n\n"

--- a/core/roles.py
+++ b/core/roles.py
@@ -24,6 +24,10 @@ CANON = {
     "ip analyst": "IP Analyst",
     "intellectual property": "IP Analyst",
     "ip": "IP Analyst",
+    "hrm": "HRM",
+    "human resources": "HRM",
+    "materials engineer": "Materials Engineer",
+    "reflection": "Reflection",
 }
 
 # Additional explicit role remappings to stop Synthesizer fallbacks. The keys
@@ -43,6 +47,11 @@ CANONICAL = {
     "Quality Assurance": "Regulatory",
     # Materials research is handled by the Mechanical Systems Lead today.
     "Materials Scientist": "Mechanical Systems Lead",
+    # Quality assurance and consistency review maps to Reflection agent.
+    "QA": "Reflection",
+    "Quality Assurance": "Reflection",
+    # HR related planning maps to HRM agent
+    "Human Resources": "HRM",
 }
 
 logger = logging.getLogger(__name__)
@@ -73,4 +82,14 @@ def canonicalize(role: str | None) -> str | None:
 
 
 def canonical_roles() -> Set[str]:
-    return {"CTO", "Research Scientist", "Regulatory", "Finance", "Marketing Analyst", "IP Analyst"}
+    return {
+        "CTO",
+        "Research Scientist",
+        "Regulatory",
+        "Finance",
+        "Marketing Analyst",
+        "IP Analyst",
+        "HRM",
+        "Materials Engineer",
+        "Reflection",
+    }

--- a/core/router.py
+++ b/core/router.py
@@ -28,11 +28,27 @@ KEYWORDS: Dict[str, str] = {
     "iso": "Regulatory",
     "budget": "Finance",
     "architecture": "CTO",
+    # Expanded coverage
+    "quantum": "Research Scientist",
+    "physics": "Research Scientist",
+    "physicist": "Research Scientist",
+    "materials": "Materials Engineer",
+    "manufacturing": "Materials Engineer",
+    "prototype": "Materials Engineer",
+    "hr": "HRM",
+    "human resources": "HRM",
+    "hiring": "HRM",
+    "org design": "HRM",
+    "qa": "Reflection",
+    "quality assurance": "Reflection",
+    "consistency review": "Reflection",
+    "postmortem": "Reflection",
 }
 
 # Common role aliases to canonical registry roles
 ALIASES: Dict[str, str] = {
     "manufacturing technician": "Research Scientist",
+    "quantum physicist": "Research Scientist",
 }
 
 
@@ -88,11 +104,11 @@ def choose_agent_for_task(
             model = select_model("agent", ui_model, agent_name=role)
             return role, AGENT_REGISTRY[role], model
 
-    # 3) Fallback to Synthesizer with info log
+    # 3) Fallback to Research Scientist with info log
     if planned_role:
-        logger.info("Fallback routing %r → Synthesizer", planned_role)
-    model = select_model("agent", ui_model, agent_name="Synthesizer")
-    return "Synthesizer", AGENT_REGISTRY["Synthesizer"], model
+        logger.info("Fallback routing %r → Research Scientist", planned_role)
+    model = select_model("agent", ui_model, agent_name="Research Scientist")
+    return "Research Scientist", AGENT_REGISTRY["Research Scientist"], model
 
 
 def route_task(
@@ -112,15 +128,15 @@ def dispatch(task: Dict[str, str], ui_model: str | None = None):
     """Dispatch ``task`` to the appropriate agent instance.
 
     The task's ``role`` is normalised via ``ALIASES`` and ``ROLE_SYNONYMS``
-    before lookup.  Unknown roles fall back to ``Synthesizer``.  If the resolved
-    agent lacks a callable interface, a single warning is logged and the task is
-    rerouted to ``Synthesizer``.
+    before lookup.  Unknown roles fall back to ``Research Scientist``.  If the
+    resolved agent lacks a callable interface, a single warning is logged and the
+    task is rerouted to ``Research Scientist``.
     """
 
     role = canonicalize(_alias(task.get("role")))
     if role:
         role = ROLE_SYNONYMS.get(role, role)
-    canonical = role if role in AGENT_REGISTRY else "Synthesizer"
+    canonical = role if role in AGENT_REGISTRY else "Research Scientist"
 
     model = select_model("agent", ui_model, agent_name=canonical)
     meta = {"purpose": "agent", "agent": canonical, "role": task.get("role")}
@@ -128,11 +144,11 @@ def dispatch(task: Dict[str, str], ui_model: str | None = None):
     try:
         return invoke_agent(agent, task=task, model=model, meta=meta)
     except TypeError as e:
-        if canonical != "Synthesizer":
+        if canonical != "Research Scientist":
             logger.warning("Uncallable agent %s: %s", canonical, e)
-            fb = get_agent("Synthesizer")
-            fb_model = select_model("agent", ui_model, agent_name="Synthesizer")
-            fb_meta = {**meta, "agent": "Synthesizer", "fallback_from": canonical}
+            fb = get_agent("Research Scientist")
+            fb_model = select_model("agent", ui_model, agent_name="Research Scientist")
+            fb_meta = {**meta, "agent": "Research Scientist", "fallback_from": canonical}
             return invoke_agent(fb, task=task, model=fb_model, meta=fb_meta)
         raise
 

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -43,4 +43,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-25T02:50:06.796824Z from commit 435f9a9_
+_Last generated at 2025-08-25T06:02:34.222187Z from commit 24a7d45_

--- a/prompts/prompts.py
+++ b/prompts/prompts.py
@@ -2,6 +2,7 @@
 
 PLANNER_SYSTEM_PROMPT = (
     "You are a Project Planner AI. Decompose the idea into role-specific tasks. "
+    "Prefer assigning tasks to these roles where appropriate: CTO, Research Scientist, Regulatory, Finance, Marketing Analyst, IP Analyst, HRM, Materials Engineer, Reflection, Synthesizer. "
     'Output ONLY JSON matching this schema: {"tasks":[{"id":"T01","role":"Role","title":"Task title","summary":"Short"}]}.'
 )
 
@@ -41,7 +42,10 @@ SYNTHESIZER_BUILD_GUIDE_TEMPLATE = (
     "Agent Contributions:\n{contributions}"
 )
 
-CTO_SYSTEM_PROMPT = "You are the CTO. Assess feasibility, architecture, and risks. Return clear, structured guidance."
+CTO_SYSTEM_PROMPT = (
+    "You are the CTO. Assess feasibility, architecture, and risks. "
+    "Return clear, structured guidance and conclude with a JSON summary using keys: role, task, findings, risks, next_steps, sources."
+)
 
 CTO_USER_PROMPT_TEMPLATE = (
     "Project Idea:\n{idea}\n\n" "Task Title:\n{title}\n\n" "Task Description:\n{description}"
@@ -56,7 +60,7 @@ REGULATORY_SYSTEM_PROMPT = (
 REGULATORY_USER_PROMPT_TEMPLATE = (
     "Project Idea: {idea}\n"
     "As the Regulatory expert, your task is {task}. Provide a thorough analysis of regulatory requirements and compliance steps in Markdown format, including any certifications or standards needed, and mapping of system components to regulations. "
-    "Include justification for each compliance recommendation (e.g., why a certain standard applies). Conclude with a JSON checklist of regulatory steps and compliance requirements."
+    "Include justification for each compliance recommendation (e.g., why a certain standard applies). Conclude with a JSON summary using keys: role, task, findings, risks, next_steps, sources."
 )
 
 MARKETING_SYSTEM_PROMPT = "You are a marketing analyst with expertise in market research, customer segmentation, competitive landscapes and go-to-market strategies."
@@ -68,7 +72,10 @@ MARKETING_USER_PROMPT_TEMPLATE = (
 
 FINANCE_SYSTEM_PROMPT = "You evaluate budgets, BOM costs and financial risks."
 
-FINANCE_USER_PROMPT_TEMPLATE = "Project Idea: {idea}\n" "As the Finance lead, your task is {task}."
+FINANCE_USER_PROMPT_TEMPLATE = (
+    "Project Idea: {idea}\n"
+    "As the Finance lead, your task is {task}. Conclude with a JSON summary using keys: role, task, findings, risks, next_steps, sources."
+)
 
 IP_ANALYST_SYSTEM_PROMPT = "You are an intellectual-property analyst skilled at prior-art searches, novelty assessment, patentability, and freedom-to-operate risk."
 
@@ -86,5 +93,25 @@ PATENT_SYSTEM_PROMPT = (
 PATENT_USER_PROMPT_TEMPLATE = (
     "Project Idea: {idea}\n"
     "As the Patent expert, your task is {task}. Provide an analysis in Markdown format of patentability, including any existing patents (with relevant patent figures or diagrams if applicable) and an IP strategy. "
-    "Include reasoning behind each recommendation (e.g., why certain features are patentable or not). Conclude with a JSON list of potential patent ideas or relevant patent references."
+    "Include reasoning behind each recommendation (e.g., why certain features are patentable or not). Conclude with a JSON summary using keys: role, task, findings, risks, next_steps, sources."
+)
+
+RESEARCH_SCIENTIST_SYSTEM_PROMPT = (
+    "You are the Research Scientist. Provide specific, non-generic analysis with concrete details. "
+    "Conclude with a JSON summary using keys: role, task, findings, risks, next_steps, sources."
+)
+
+HRM_SYSTEM_PROMPT = (
+    "You are an HR Manager specializing in R&D projects. Identify the expert roles needed for the following idea. "
+    "Conclude with a JSON summary using keys: role, task, findings, risks, next_steps, sources."
+)
+
+MATERIALS_ENGINEER_SYSTEM_PROMPT = (
+    "You are a Materials Engineer specialized in material selection and engineering feasibility. "
+    "Conclude with a JSON summary using keys: role, task, findings, risks, next_steps, sources."
+)
+
+REFLECTION_SYSTEM_PROMPT = (
+    "You are a Reflection agent analyzing the team's outputs. Determine if follow-up tasks are required. "
+    "Respond with either a JSON array of follow-up task strings or the exact string 'no further tasks'."
 )

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-25T02:50:06.796824Z'
-git_sha: 435f9a9b3108cff54736e006047512ad92f88790
+generated_at: '2025-08-25T06:02:34.222187Z'
+git_sha: 24a7d45433868a35aff282f2dd63e9e2d64cec85
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -103,7 +103,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/router.py
+- path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -117,7 +117,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
+- path: orchestrators/router.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -131,7 +131,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/spec_builder.py
+- path: orchestrators/app_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -145,14 +145,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
-  role: Summarization
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: core/summarization/schemas.py
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -166,7 +159,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
+- path: core/summarization/schemas.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/integrator.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_reflection_pass.py
+++ b/tests/test_reflection_pass.py
@@ -1,0 +1,52 @@
+import json
+from core import orchestrator, router
+
+def test_reflection_adds_followups(monkeypatch):
+    # Enable reflection
+    import config.feature_flags as ff
+    monkeypatch.setattr(ff, "REFLECTION_ENABLED", True)
+
+    class Dummy:
+        def __init__(self, model):
+            self.model = model
+
+    registry = {"Research Scientist": Dummy, "Reflection": Dummy, "HRM": Dummy}
+    monkeypatch.setattr(router, "AGENT_REGISTRY", registry)
+    monkeypatch.setattr(orchestrator, "AGENT_REGISTRY", registry)
+    monkeypatch.setattr(router, "select_model", lambda purpose, ui_model, agent_name=None: "m")
+    monkeypatch.setattr(orchestrator, "select_model", lambda *a, **k: "m")
+
+    def fake_invoke(agent, idea, task, model=None):
+        role = task.get("role")
+        if role == "Research Scientist":
+            return json.dumps(
+                {
+                    "role": "Research Scientist",
+                    "task": task.get("title"),
+                    "findings": [],
+                    "risks": [],
+                    "next_steps": [],
+                    "sources": [],
+                }
+            )
+        if role == "Reflection":
+            return json.dumps(["[HRM]: assess hiring needs"])
+        if role == "HRM":
+            return json.dumps(
+                {
+                    "role": "HRM",
+                    "task": task.get("title"),
+                    "findings": [],
+                    "risks": [],
+                    "next_steps": [],
+                    "sources": [],
+                }
+            )
+        return "{}"
+
+    monkeypatch.setattr(orchestrator, "_invoke_agent", fake_invoke)
+
+    tasks = [{"role": "Research Scientist", "title": "Initial", "description": ""}]
+    out = orchestrator.execute_plan("idea", tasks, save_evidence=False, save_decision_log=False)
+    assert "Research Scientist" in out
+    assert "HRM" in out

--- a/tests/test_router_fallback.py
+++ b/tests/test_router_fallback.py
@@ -7,28 +7,26 @@ class NoCall:
     pass
 
 
-class Synth:
+class RS:
     def run(self, *, task=None, model=None, meta=None):
-        return "synth"
+        return "rs"
 
 
 def test_router_fallback(monkeypatch, caplog):
-    monkeypatch.setattr(router, "AGENT_REGISTRY", {"Bad": object, "Synthesizer": object})
+    monkeypatch.setattr(router, "AGENT_REGISTRY", {"Bad": object, "Research Scientist": object})
 
     def fake_get_agent(name):
-        return NoCall() if name == "Bad" else Synth()
+        return NoCall() if name == "Bad" else RS()
 
     monkeypatch.setattr(router, "get_agent", fake_get_agent)
     monkeypatch.setattr(
-        router,
-        "select_model",
-        lambda purpose, ui_model, agent_name=None: "m",
+        router, "select_model", lambda purpose, ui_model, agent_name=None: "m"
     )
 
     task = {"role": "Bad", "title": "x"}
     with caplog.at_level(logging.WARNING):
         result = router.dispatch(task)
-    assert result == "synth"
+    assert result == "rs"
     warnings = [r for r in caplog.records if r.levelname == "WARNING"]
     assert len(warnings) == 1
     assert "Bad" in warnings[0].message

--- a/tests/test_router_synonyms.py
+++ b/tests/test_router_synonyms.py
@@ -9,8 +9,15 @@ def test_synonym_mapping():
     assert role == "Regulatory"
 
 
-def test_fallback_to_synthesizer(caplog):
+def test_fallback_to_research_scientist(caplog):
     caplog.set_level(logging.INFO)
     role, _, _ = choose_agent_for_task("Unknown", "", "")
-    assert role == "Synthesizer"
+    assert role == "Research Scientist"
     assert any("Fallback routing" in r.message for r in caplog.records)
+
+
+def test_keyword_expansion():
+    assert choose_agent_for_task(None, "Quantum computing", "")[0] == "Research Scientist"
+    assert choose_agent_for_task(None, "", "materials selection")[0] == "Materials Engineer"
+    assert choose_agent_for_task(None, "", "hiring plan")[0] == "HRM"
+    assert choose_agent_for_task(None, "QA review", "")[0] == "Reflection"

--- a/tests/test_self_check.py
+++ b/tests/test_self_check.py
@@ -1,0 +1,35 @@
+import json
+from core.evaluation.self_check import validate_and_retry
+
+
+def test_self_check_retry_success():
+    calls = {"count": 0}
+
+    def retry_fn(reminder: str) -> str:
+        calls["count"] += 1
+        return json.dumps(
+            {
+                "role": "Research Scientist",
+                "task": "t",
+                "findings": [],
+                "risks": [],
+                "next_steps": [],
+                "sources": [],
+            }
+        )
+
+    bad_output = "No JSON here"
+    fixed, meta = validate_and_retry("Research Scientist", {"title": "t"}, bad_output, retry_fn)
+    assert json.loads(fixed)["role"] == "Research Scientist"
+    assert meta == {"retried": True, "valid_json": True}
+    assert calls["count"] == 1
+
+
+def test_self_check_retry_failure():
+    def retry_fn(reminder: str) -> str:
+        return "still bad"
+
+    bad_output = "No JSON here"
+    fixed, meta = validate_and_retry("Research Scientist", {"title": "t"}, bad_output, retry_fn)
+    assert fixed == bad_output
+    assert meta == {"retried": True, "valid_json": False}


### PR DESCRIPTION
## Summary
- route unknown or keyword-mapped tasks through a single router that falls back to Research Scientist and covers HRM, Materials Engineer, and Reflection
- register new HRM, Materials Engineer, and Reflection agents and enforce uniform JSON with self-check + retry and a reflection follow-up pass
- extend planner and specialist prompts to prefer the supported role roster and emit the standard JSON contract

## Testing
- `pytest tests/test_router_synonyms.py tests/test_router_fallback.py tests/test_self_check.py tests/test_reflection_pass.py`
- `python scripts/generate_repo_map.py`

------
https://chatgpt.com/codex/tasks/task_e_68abfb0ce030832c813e38570959b983