### PR TITLE
fix: remove redundant pandas import

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1518,8 +1518,6 @@ def main():
                                     st.warning(f"Could not create repo: {info}")
         # --- end App Builder ---
 
-        import pandas as pd
-
         by_stage = METER.by_stage()
         df = pd.DataFrame(
             [


### PR DESCRIPTION
## Summary
- remove late pandas import to avoid UnboundLocalError in PoC report table

## Testing
- `pre-commit run --files app/__init__.py` *(fails: flake8 reports existing style issues)*
- `pytest` *(fails: multiple tests fail in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9b9e24a0832cab3f051ea1ce8e06