### PR TITLE
Unify runtime profiles (Step 1/10): add `standard` profile; alias `test`/`deep`

### DIFF
--- a/config/modes.yaml
+++ b/config/modes.yaml
@@ -1,4 +1,4 @@
-test:
+standard: &standard
   target_cost_usd: 2.50
   enforce_caps: false
   models: { plan: gpt-4o-mini, exec: gpt-4o-mini, synth: gpt-4o-mini }
@@ -15,21 +15,7 @@ test:
   faiss_bootstrap_mode: skip
   faiss_index_uri: ""
   enable_images: false
-deep:
-  target_cost_usd: 2.50
-  enforce_caps: false
-  models: { plan: gpt-4o-mini, exec: gpt-4o-mini, synth: gpt-4o-mini }
-  k_search: 6
-  max_loops: 5
-  stage_weights: { plan: 0.20, exec: 0.50, synth: 0.30 }
-  rag_enabled: true
-  rag_top_k: 5
-  live_search_enabled: true
-  live_search_backend: openai
-  live_search_max_calls: 3
-  live_search_summary_tokens: 256
-  faiss_index_local_dir: .faiss_index
-  faiss_bootstrap_mode: skip
-  faiss_index_uri: ""
-  enable_images: false
+
+test: *standard  # DEPRECATED: alias to 'standard'; will be removed next release
+deep: *standard  # DEPRECATED: alias to 'standard'; will be removed next release
 # redaction time

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -11,6 +11,10 @@ The system reads per-mode settings from `config/modes.yaml`. Retrieval flows in 
 - `live_search_summary_tokens`: cap for web-summary tokens.
 - `enable_images`: allow image generation (default `false` for `test` and `deep`).
 
+## Runtime profile
+
+`standard` is the only supported runtime profile going forward. `test` and `deep` are temporary aliases to `standard` and will be removed in an upcoming release. Behavioural knobs are controlled by feature flags and toggles (details to follow).
+
 **Model defaults with OpenAI web search**
 
 When `LIVE_SEARCH_BACKEND=openai`, the default model is `gpt-4o-mini` so that the

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -11,6 +11,7 @@ User idea → Planner → Router/Registry → Executor → Summarization → Syn
 
 
 ### Runtime Modes
+- **standard**: target cost USD 2.5
 - **test**: target cost USD 2.5
 - **deep**: target cost USD 2.5
 
@@ -43,4 +44,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-25T06:02:34.222187Z from commit 24a7d45_
+_Last generated at 2025-08-25T19:05:12.676314Z from commit 8beda76_

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-25T06:02:34.222187Z'
-git_sha: 24a7d45433868a35aff282f2dd63e9e2d64cec85
+generated_at: '2025-08-25T19:05:12.676314Z'
+git_sha: 8beda769ee788c11011583a41b965eea28fdb6c7
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -9,7 +9,7 @@ entry_points:
 architecture: "Planner \u2192 Router/Registry \u2192 Executor \u2192 Summarization\
   \ \u2192 Synthesizer"
 runtime_modes:
-  test:
+  standard: &id001
     target_cost_usd: 2.5
     enforce_caps: false
     models:
@@ -32,29 +32,8 @@ runtime_modes:
     faiss_bootstrap_mode: skip
     faiss_index_uri: ''
     enable_images: false
-  deep:
-    target_cost_usd: 2.5
-    enforce_caps: false
-    models:
-      plan: gpt-4o-mini
-      exec: gpt-4o-mini
-      synth: gpt-4o-mini
-    k_search: 6
-    max_loops: 5
-    stage_weights:
-      plan: 0.2
-      exec: 0.5
-      synth: 0.3
-    rag_enabled: true
-    rag_top_k: 5
-    live_search_enabled: true
-    live_search_backend: openai
-    live_search_max_calls: 3
-    live_search_summary_tokens: 256
-    faiss_index_local_dir: .faiss_index
-    faiss_bootstrap_mode: skip
-    faiss_index_uri: ''
-    enable_images: false
+  test: *id001
+  deep: *id001
 env_flags:
 - DRRD_MODE
 - RAG_ENABLED
@@ -103,7 +82,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/spec_builder.py
+- path: orchestrators/qa_router.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/app_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -124,21 +110,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
+- path: orchestrators/spec_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
 - path: orchestrators/plan_utils.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/app_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/qa_router.py
   role: Orchestrator
   responsibilities: []
   inputs: []


### PR DESCRIPTION
## Summary
- introduce canonical `standard` runtime profile and deprecate `test`/`deep` aliases
- document runtime profile changes and note pending removal of legacy aliases
- regenerate repository map

## Testing
- `python - <<'PY'
from app.config_loader import load_mode
keys = ['target_cost_usd','enforce_caps','models','k_search','max_loops','stage_weights','rag_enabled','rag_top_k','live_search_enabled','live_search_backend','live_search_max_calls','live_search_summary_tokens','faiss_index_local_dir','faiss_bootstrap_mode','faiss_index_uri','enable_images']
for m in ['standard','test','deep']:
    cfg,_=load_mode(m)
    vals={k:cfg.get(k) for k in keys}
    print(m, vals)
PY`
- `pytest -q` *(fails: openai.APIConnectionError, assertion mismatches, KeyError 'source')*
- `python scripts/generate_repo_map.py`


------
https://chatgpt.com/codex/tasks/task_e_68acb3486630832c85d47e262eeb6ef2