### PR TITLE
Consolidate profiles (Step 2/10): unify mode_profiles to standard with legacy aliases and TEST_MODE shim

### DIFF
--- a/config/mode_profiles.py
+++ b/config/mode_profiles.py
@@ -1,32 +1,62 @@
 from copy import deepcopy
+import logging
 
 PROFILES = {
-    "deep": {
+    "standard": {
         "ENABLE_LIVE_SEARCH": True,
         "PARALLEL_EXEC_ENABLED": True,
-        "TOT_PLANNING_ENABLED": True, "TOT_K": 4, "TOT_BEAM": 3, "TOT_MAX_DEPTH": 3,
-        "EVALUATORS_ENABLED": True, "EVALUATOR_MIN_OVERALL": 0.70,
-        "REFLECTION_ENABLED": True, "REFLECTION_PATIENCE": 1,
-        "RAG_ENABLED": True, "RAG_TOPK": 8,
-        "SIM_OPTIMIZER_ENABLED": True, "SIM_OPTIMIZER_STRATEGY": "random", "SIM_OPTIMIZER_MAX_EVALS": 30,
+        "TOT_PLANNING_ENABLED": True,
+        "TOT_K": 4,
+        "TOT_BEAM": 3,
+        "TOT_MAX_DEPTH": 3,
+        "EVALUATORS_ENABLED": True,
+        "EVALUATOR_MIN_OVERALL": 0.70,
+        "REFLECTION_ENABLED": True,
+        "REFLECTION_PATIENCE": 1,
+        "RAG_ENABLED": True,
+        "RAG_TOPK": 8,
+        "SIM_OPTIMIZER_ENABLED": True,
+        "SIM_OPTIMIZER_STRATEGY": "random",
+        "SIM_OPTIMIZER_MAX_EVALS": 30,
         "IMAGES_SIZE": "256x256",
-    },
+    }
 }
-PROFILES["test"] = deepcopy(PROFILES["deep"])
-PROFILES["test"]["TEST_MODE"] = True
+PROFILES["deep"] = PROFILES["standard"]
+PROFILES["test"] = PROFILES["standard"]
 
-# UI presets baked into the two modes. The app reads these to hide knobs.
 UI_PRESETS = {
-    "deep":     {"simulate_enabled": True,  "design_depth": "High",   "refinement_rounds": 3, "rerun_sims_each_round": True,  "estimator": {"exec_tokens": 90000, "help_prob": 0.50}},
+    "standard": {
+        "simulate_enabled": True,
+        "design_depth": "High",
+        "refinement_rounds": 3,
+        "rerun_sims_each_round": True,
+        "estimator": {"exec_tokens": 90000, "help_prob": 0.50},
+    }
 }
-UI_PRESETS["test"] = UI_PRESETS["deep"]
+UI_PRESETS["deep"] = UI_PRESETS["standard"]
+UI_PRESETS["test"] = UI_PRESETS["standard"]
 
 
 def apply_profile(env_defaults: dict, mode: str, overrides: dict | None = None) -> dict:
+    """Merge defaults with the selected profile and overrides.
+
+    Legacy modes ``deep`` and ``test`` map to ``standard``; they are deprecated and will be
+    removed in a future release. For compatibility, ``mode='test'`` also injects
+    ``TEST_MODE=True``. This shim will be removed in a later step.
+    """
+    orig_mode = (mode or "standard").strip().lower()
+    canonical_mode = "standard" if orig_mode in {"deep", "test"} else orig_mode
+    if orig_mode in {"deep", "test"}:
+        logging.warning("Mode '%s' is deprecated; using 'standard' profile.", orig_mode)
+
     out = deepcopy(env_defaults)
-    profile = PROFILES.get(mode.lower().strip(), {})
+    profile = PROFILES.get(canonical_mode, {})
     out.update(profile)
+
+    if orig_mode == "test":
+        out["TEST_MODE"] = True
+
     if overrides:
         out.update({k: v for k, v in overrides.items() if v is not None})
-    return out
 
+    return out

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -44,4 +44,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-25T19:05:12.676314Z from commit 8beda76_
+_Last generated at 2025-08-25T19:13:53.425528Z from commit f72b748_

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-25T19:05:12.676314Z'
-git_sha: 8beda769ee788c11011583a41b965eea28fdb6c7
+generated_at: '2025-08-25T19:13:53.425528Z'
+git_sha: f72b74871349e6ca48f2abc5d3ae8eeb9918d926
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -82,13 +82,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/qa_router.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/app_builder.py
   role: Orchestrator
   responsibilities: []
@@ -103,14 +96,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/router.py
+- path: orchestrators/qa_router.py
   role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/spec_builder.py
+- path: orchestrators/router.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -124,6 +117,13 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
+- path: orchestrators/spec_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
 - path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
@@ -131,14 +131,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/__init__.py
+- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/schemas.py
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []


### PR DESCRIPTION
## Summary
- unify runtime mode configuration under a single `standard` profile and expose `deep`/`test` as temporary aliases
- keep UI presets in sync with the `standard` profile while warning on legacy modes
- map legacy modes inside `apply_profile`, logging deprecations and injecting `TEST_MODE` for `mode="test"`

## Testing
- `pre-commit run --files config/mode_profiles.py repo_map.yaml docs/REPO_MAP.md`
- `pytest tests/test_agent_model_selection.py::test_per_agent_override -q` *(fails: assert used_r == "gpt-4.1-mini")*


------
https://chatgpt.com/codex/tasks/task_e_68acb56589d0832c8949de2198cbe87c