### PR TITLE
Feature flags (Step 3/10): mode-agnostic apply_overrides(), deprecate apply_mode_overrides, unify image flag

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -775,7 +775,7 @@ def main():
         image_toggle_fn = getattr(
             sidebar, "toggle", getattr(sidebar, "checkbox", lambda *a, **k: False)
         )
-        default_images_on = not ff.DISABLE_IMAGES_BY_DEFAULT.get(selected_mode, True)
+        default_images_on = ff.ENABLE_IMAGES
         st.session_state["disable_images"] = not image_toggle_fn(
             "Generate images",
             value=default_images_on,

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -9,7 +9,7 @@ The system reads per-mode settings from `config/modes.yaml`. Retrieval flows in 
 - `web_search_max_calls` (legacy `live_search_max_calls`): maximum live-search
   queries per run.
 - `live_search_summary_tokens`: cap for web-summary tokens.
-- `enable_images`: allow image generation (default `false` for `test` and `deep`).
+- `enable_images`: allow image generation (default `false`).
 
 ## Runtime profile
 
@@ -49,6 +49,26 @@ LIVE_SEARCH_BACKEND=openai|serpapi
 ENABLE_IMAGES=true|false
 SERPAPI_KEY=your_key
 ```
+
+## Feature flags
+
+Environment variables remain the baseline source of truth. The active runtime
+profile (`standard` from `modes.yaml`) may override selected flags at startup via
+`apply_overrides(cfg)`. The legacy function name `apply_mode_overrides` is
+deprecated and will be removed; code should migrate to `apply_overrides`.
+
+Config keys that can be overridden:
+
+- `rag_enabled`
+- `rag_top_k`
+- `live_search_enabled`
+- `live_search_backend`
+- `live_search_max_calls`
+- `live_search_summary_tokens`
+- `faiss_bootstrap_mode`
+- `faiss_index_local_dir`
+- `faiss_index_uri`
+- `enable_images`
 
 ### Budget cap normalization
 

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -44,4 +44,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-25T19:13:53.425528Z from commit f72b748_
+_Last generated at 2025-08-25T19:24:22.747942Z from commit 03d111d_

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-25T19:13:53.425528Z'
-git_sha: f72b74871349e6ca48f2abc5d3ae8eeb9918d926
+generated_at: '2025-08-25T19:24:22.747942Z'
+git_sha: 03d111d73ae5701ba8ccc7ccbd7c6eefd6f950dd
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -82,34 +82,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/__init__.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/qa_router.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/router.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/plan_utils.py
   role: Orchestrator
   responsibilities: []
@@ -124,8 +96,29 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
-  role: Summarization
+- path: orchestrators/qa_router.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/__init__.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/router.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/app_builder.py
+  role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
@@ -138,7 +131,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/__init__.py
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -146,6 +139,13 @@ modules:
   invoked_by: []
   invokes: []
 - path: core/summarization/integrator.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/utils/image_visuals.py
+++ b/utils/image_visuals.py
@@ -9,7 +9,7 @@ import streamlit as st
 from openai import OpenAI
 from PIL import Image
 
-from config.feature_flags import DISABLE_IMAGES_BY_DEFAULT
+from config.feature_flags import ENABLE_IMAGES
 from .storage_gcs import upload_bytes_to_gcs
 
 
@@ -52,8 +52,7 @@ def make_visuals_for_project(
 ) -> list[dict]:
     """Generate schematic and render images for a project."""
 
-    mode = st.session_state.get("MODE", "deep")
-    if st.session_state.get("disable_images", DISABLE_IMAGES_BY_DEFAULT.get(mode, True)):
+    if st.session_state.get("disable_images", not ENABLE_IMAGES):
         return []
 
     brief = idea or ""


### PR DESCRIPTION
## Summary
- add `apply_overrides` for config-driven feature flag overrides and deprecate `apply_mode_overrides`
- consolidate image flag to `ENABLE_IMAGES` and drop per-mode map
- document new feature flag behavior and regenerate repo map

## Testing
- `python -m py_compile config/feature_flags.py app/__init__.py utils/image_visuals.py`
- `pytest` *(fails: APIConnectionError, assertion errors)*
- `python scripts/generate_repo_map.py`

------
https://chatgpt.com/codex/tasks/task_e_68acb77bb684832c84ae225f6005f7d9