### PR TITLE
Config loader (Step 5/10): unify to standard profile, remove cheap test injection, adopt apply_overrides()

### DIFF
--- a/app/config_loader.py
+++ b/app/config_loader.py
@@ -1,4 +1,9 @@
-"""Helpers to load mode and pricing configuration and create a CostTracker."""
+"""Load runtime configuration profiles and create a :class:`CostTracker`.
+
+``load_profile()`` is the canonical entry point for loading the single
+"Standard" profile. ``load_mode()`` is retained as a deprecated alias for one
+release to avoid breaking imports.
+"""
 
 import logging
 import os
@@ -6,39 +11,45 @@ from pathlib import Path
 
 import yaml
 
-from config.feature_flags import apply_mode_overrides
-from config.model_routing import TEST_MODEL_ID, _cheap_default
+from config.feature_flags import apply_overrides
 from core.budget import CostTracker
 
 CONFIG_DIR = Path(__file__).resolve().parent.parent / "config"
 
 
-def load_mode(mode: str) -> tuple[dict, CostTracker]:
+def load_profile(mode: str | None = None) -> tuple[dict, CostTracker]:
+    """Load the ``standard`` profile and return its config and budget tracker.
+
+    Legacy mode names (``test`` and ``deep``) map to ``standard`` with a
+    deprecation warning. Any unknown or missing mode also falls back to
+    ``standard`` with a warning.
+    """
+
     modes_path = CONFIG_DIR / "modes.yaml"
     prices_path = Path(os.getenv("PRICES_PATH", CONFIG_DIR / "prices.yaml"))
 
     with open(modes_path) as fh:
         modes = yaml.safe_load(fh) or {}
-    if mode not in modes:
-        logging.warning("Requested mode '%s' not found. Falling back to 'test'.", mode)
-    mode_cfg = modes.get(mode, modes.get("test", {}))
+
+    requested = mode
+    if mode in {"test", "deep"}:
+        logging.warning("Mode '%s' is deprecated and maps to 'standard'.", mode)
+        mode = "standard"
+    if not mode or mode not in modes:
+        logging.warning("Requested mode '%s' not found. Falling back to 'standard'.", requested)
+        mode = "standard"
+
+    mode_cfg = modes.get(mode, {})
     weights = mode_cfg.get("stage_weights")
     if isinstance(weights, dict):
         total = sum(weights.values())
         if abs(total - 1.0) > 0.05 and total > 0:
-            logging.warning("stage_weights for mode %s sum to %.3f; normalizing", mode, total)
+            logging.warning("stage_weights for profile %s sum to %.3f; normalizing", mode, total)
             mode_cfg["stage_weights"] = {k: v / total for k, v in weights.items()}
 
     with open(prices_path) as fh:
         prices = yaml.safe_load(fh) or {}
 
-    if mode == "test":
-        models = mode_cfg.get("models")
-        if not (
-            isinstance(models, dict) and all(stage in models for stage in ["plan", "exec", "synth"])
-        ):
-            cheap = TEST_MODEL_ID or _cheap_default(prices.get("models", {}))
-            mode_cfg["models"] = {s: cheap for s in ["plan", "exec", "synth"]}
     # FAISS defaults and env overrides
     mode_cfg.setdefault("faiss_index_local_dir", ".faiss_index")
     mode_cfg.setdefault("faiss_bootstrap_mode", "download")
@@ -53,5 +64,12 @@ def load_mode(mode: str) -> tuple[dict, CostTracker]:
         mode_cfg["faiss_bootstrap_mode"] = env_boot
 
     budget = CostTracker(mode_cfg, prices)
-    apply_mode_overrides(mode_cfg)
+    apply_overrides(mode_cfg)
     return mode_cfg, budget
+
+
+def load_mode(mode: str) -> tuple[dict, CostTracker]:
+    """Deprecated alias for :func:`load_profile`."""
+
+    logging.warning("app.config_loader.load_mode() is deprecated; use load_profile().")
+    return load_profile(mode)

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -11,9 +11,18 @@ The system reads per-mode settings from `config/modes.yaml`. Retrieval flows in 
 - `live_search_summary_tokens`: cap for web-summary tokens.
 - `enable_images`: allow image generation (default `false`).
 
+## Loader
+
+`load_profile("standard")` is the canonical entry point for loading runtime
+configuration. `load_mode()` is deprecated and forwards to `load_profile()` for
+one release.
+
 ## Runtime profile
 
-`standard` is the only supported runtime profile going forward. `test` and `deep` are temporary aliases to `standard` and will be removed in an upcoming release. Behavioural knobs are controlled by feature flags and toggles (details to follow).
+`standard` is the only supported runtime profile going forward. Legacy
+`test` and `deep` selections map to `standard` and emit a deprecation warning.
+Behavioural knobs are controlled by feature flags and toggles (details to
+follow).
 
 ## Model routing
 
@@ -58,8 +67,8 @@ SERPAPI_KEY=your_key
 
 Environment variables remain the baseline source of truth. The active runtime
 profile (`standard` from `modes.yaml`) may override selected flags at startup via
-`apply_overrides(cfg)`. The legacy function name `apply_mode_overrides` is
-deprecated and will be removed; code should migrate to `apply_overrides`.
+`config.feature_flags.apply_overrides(cfg)`. The legacy name
+`apply_mode_overrides` is deprecated and will be removed.
 
 Config keys that can be overridden:
 

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -44,4 +44,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-25T19:31:31.363960Z from commit e0dcc28_
+_Last generated at 2025-08-25T19:35:27.644852Z from commit 89eb696_

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-25T19:31:31.363960Z'
-git_sha: e0dcc28725f447a7503fbfe307c64f6f24468fe5
+generated_at: '2025-08-25T19:35:27.644852Z'
+git_sha: 89eb6960eb7cda135e1524a84c94a4a72b57694b
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -89,6 +89,13 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
+- path: orchestrators/__init__.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
 - path: orchestrators/qa_router.py
   role: Orchestrator
   responsibilities: []
@@ -103,6 +110,13 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
+- path: orchestrators/spec_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
 - path: orchestrators/app_builder.py
   role: Orchestrator
   responsibilities: []
@@ -110,15 +124,8 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/__init__.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/spec_builder.py
-  role: Orchestrator
+- path: core/summarization/__init__.py
+  role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
@@ -139,13 +146,6 @@ modules:
   invoked_by: []
   invokes: []
 - path: core/summarization/schemas.py
-  role: Summarization
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []


### PR DESCRIPTION
## Summary
- Add canonical `load_profile()` loader that defaults to the single `standard` profile and maps legacy `test`/`deep` modes with deprecation warnings
- Remove legacy cheap model injection and switch to `config.feature_flags.apply_overrides()`
- Keep `load_mode()` as a temporary alias and document new loader and profile behavior

## Testing
- `pre-commit run --files app/config_loader.py docs/CONFIG.md repo_map.yaml docs/REPO_MAP.md` (bandit skipped)
- `pytest -q` *(fails: tests/test_llm_route.py::test_responses_route, tests/test_llm_route.py::test_responses_drops_temperature, tests/test_mode_caps.py::test_fallback_and_summarize, tests/test_mode_env.py::test_env_selects_deep, tests/test_mode_env.py::test_env_invalid_warns, tests/test_orchestrator_loop.py::test_orchestrator_iterative_loop_executes_all_roles, tests/test_planner_agent.py::test_planner_agent_uses_response_format, tests/test_planner_agent.py::test_planner_agent_handles_truncated_json, tests/test_planner_output.py::test_planner_output_validity, tests/test_profile_model.py::test_pro_profile_uses_gpt5, tests/test_rag_prompt.py::test_rag_included_when_enabled, tests/test_rag_prompt.py::test_rag_snippet_not_truncated, tests/test_registry.py::test_agent_mapping_research, tests/test_registry.py::test_agent_mapping_default, tests/test_router.py::test_unresolved_role_logs, tests/test_router_no_drop.py::test_default_role, tests/test_smoke.py::test_run_smoke, tests/test_synthesizer.py::test_compose_final_proposal, tests/test_vector_index_skip_flag.py::test_vector_index_skip_flag)*

------
https://chatgpt.com/codex/tasks/task_e_68acbaa54f68832cbe018ddf55246cbe