### PR TITLE
Model router (Step 6/10): remove TEST_MODE branch; unify to Standard routing only

### DIFF
--- a/core/model_router.py
+++ b/core/model_router.py
@@ -1,9 +1,6 @@
 from config.model_routing import (
     DEFAULTS,
     CallHints,
-    TEST_MODEL_ID,
-    PRICE_TABLE,
-    _cheap_default,
 )
 import streamlit as st
 from core.llm import select_model
@@ -43,27 +40,6 @@ def pick_model(h: CallHints) -> dict:
         elif h.stage == "synth":
             sel["model"] = stage_map.get("synth", sel["model"])
 
-    flags = st.session_state.get("final_flags", {}) if "st" in globals() else {}
-    if flags.get("TEST_MODE"):
-        override = {
-            "plan": flags.get("MODEL_PLANNER"),
-            "exec": flags.get("MODEL_EXEC"),
-            "synth": flags.get("MODEL_SYNTH"),
-        }.get(h.stage)
-        if override:
-            sel["model"] = override
-        else:
-            default_model = (
-                st.session_state.get("MODE_CFG", {})
-                .get("models", {})
-                .get(h.stage)
-                or TEST_MODEL_ID
-                or _cheap_default(PRICE_TABLE)
-            )
-            sel["model"] = default_model
-        params = sel.get("params", {})
-        params["temperature"] = min(0.3, params.get("temperature", 0.3))
-        sel["params"] = params
     return sel
 
 

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -44,4 +44,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-25T19:35:27.644852Z from commit 89eb696_
+_Last generated at 2025-08-25T19:42:38.476399Z from commit bb68d55_

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-25T19:35:27.644852Z'
-git_sha: 89eb6960eb7cda135e1524a84c94a4a72b57694b
+generated_at: '2025-08-25T19:42:38.476399Z'
+git_sha: bb68d55e65dd8e2160940405904f1fe44ea3c742
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -82,20 +82,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/plan_utils.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/__init__.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/qa_router.py
   role: Orchestrator
   responsibilities: []
@@ -110,7 +96,21 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
+- path: orchestrators/plan_utils.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
 - path: orchestrators/spec_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/__init__.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -124,14 +124,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/__init__.py
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
+- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -145,7 +145,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/schemas.py
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_core_model_router.py
+++ b/tests/test_core_model_router.py
@@ -1,0 +1,22 @@
+import streamlit as st
+from core.model_router import pick_model, CallHints
+
+
+def test_stage_override_via_mode_cfg():
+    st.session_state.clear()
+    st.session_state["MODE_CFG"] = {"models": {"plan": "cfg-model"}}
+    sel = pick_model(CallHints(stage="plan"))
+    assert sel["model"] == "cfg-model"
+
+
+def test_test_mode_has_no_effect():
+    st.session_state.clear()
+    h = CallHints(stage="exec")
+    sel_base = pick_model(h)
+    st.session_state["final_flags"] = {"TEST_MODE": True}
+    sel_test = pick_model(h)
+    assert sel_test == sel_base
+    assert "temperature" not in sel_test["params"]
+    st.session_state["final_flags"]["TEST_MODE"] = False
+    sel_again = pick_model(h)
+    assert sel_again == sel_base


### PR DESCRIPTION
## Summary
- drop TEST_MODE-dependent logic in `pick_model` so routing only follows standard profile and optional `MODE_CFG` overrides
- add tests verifying MODE_CFG stage overrides and that TEST_MODE flag no longer alters model or temperature
- regenerate `repo_map.yaml` and `docs/REPO_MAP.md`

## Testing
- `pytest tests/test_core_model_router.py`
- `pytest tests/test_model_router_mode_deprecation.py`
- `pytest tests/test_images_flag.py`
- `pytest` *(fails: AssertionError, missing env/test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68acbc2bfca8832c8a26e46b8ef7fd56