### PR TITLE
fix: handle non-string outputs in self_check

### DIFF
--- a/core/evaluation/self_check.py
+++ b/core/evaluation/self_check.py
@@ -37,7 +37,13 @@ def validate_and_retry(
     retried = False
     valid = False
 
+    # ``raw_text`` may be a dict if the agent returns structured data.
+    if not isinstance(raw_text, str):
+        raw_text = json.dumps(raw_text)
+
     def _check(text: str) -> bool:
+        if not isinstance(text, str):
+            text = json.dumps(text)
         block = extract_json_block(text)
         candidate = block if block is not None else text
         try:
@@ -58,8 +64,13 @@ def validate_and_retry(
         except Exception as e:  # pragma: no cover - retry best effort
             logger.warning("Retry failed for %s: %s", agent_name, e)
             second = raw_text
+        if not isinstance(second, str):
+            second = json.dumps(second)
         if _check(second):
             raw_text = second
             valid = True
-    logger.info("self_check=%s", {"retried": retried, "valid_json": valid, "role": agent_name, "task": task.get('title')})
+    logger.info(
+        "self_check=%s",
+        {"retried": retried, "valid_json": valid, "role": agent_name, "task": task.get("title")},
+    )
     return raw_text, {"retried": retried, "valid_json": valid}

--- a/tests/test_self_check.py
+++ b/tests/test_self_check.py
@@ -1,4 +1,5 @@
 import json
+
 from core.evaluation.self_check import validate_and_retry
 
 
@@ -33,3 +34,24 @@ def test_self_check_retry_failure():
     fixed, meta = validate_and_retry("Research Scientist", {"title": "t"}, bad_output, retry_fn)
     assert fixed == bad_output
     assert meta == {"retried": True, "valid_json": False}
+
+
+def test_self_check_retry_dict_output():
+    calls = {"count": 0}
+
+    def retry_fn(reminder: str):
+        calls["count"] += 1
+        return {
+            "role": "Research Scientist",
+            "task": "t",
+            "findings": [],
+            "risks": [],
+            "next_steps": [],
+            "sources": [],
+        }
+
+    bad_output = "No JSON here"
+    fixed, meta = validate_and_retry("Research Scientist", {"title": "t"}, bad_output, retry_fn)
+    assert json.loads(fixed)["role"] == "Research Scientist"
+    assert meta == {"retried": True, "valid_json": True}
+    assert calls["count"] == 1


### PR DESCRIPTION
## Summary
- handle dict outputs by converting to JSON strings during self_check validation
- add regression test for dict-based retry output

## Testing
- `pytest tests/test_self_check.py`
- `pre-commit run --files core/evaluation/self_check.py tests/test_self_check.py`

------
https://chatgpt.com/codex/tasks/task_e_68acce559a4c832ca115de890db13fe3