### PR TITLE
feat: add structured agent trace and UI

### DIFF
--- a/app/agent_trace_ui.py
+++ b/app/agent_trace_ui.py
@@ -1,15 +1,10 @@
-"""Helper functions to render a rich Agent Trace in Streamlit.
-
-This module encapsulates the UI for displaying per-agent execution traces,
-including a timeline, per-role inspection tabs, token/cost telemetry and
-download/export controls. Keeping this logic separate helps maintain a thin
-Streamlit entrypoint while providing users with deep insight into how the
-pipeline executed their R&D request.
-"""
+"""Helper functions to render Agent Trace views in Streamlit."""
 
 from __future__ import annotations
 
 import json
+import os
+from pathlib import Path
 from typing import Any, Dict, List, Sequence
 
 import pandas as pd  # type: ignore
@@ -17,24 +12,7 @@ import streamlit as st  # type: ignore
 
 
 def _format_summary(text: str, max_chars: int = 200) -> str:
-    """Return a shortened summary of the given text for display.
-
-    We take the first non-empty line and truncate to a maximum number of
-    characters. Newlines are preserved in the raw view. If the text is
-    longer than ``max_chars`` we append an ellipsis.
-
-    Parameters
-    ----------
-    text : str
-        The full string from which to build a summary.
-    max_chars : int, default 200
-        Maximum number of characters to include in the summary.
-
-    Returns
-    -------
-    str
-        A one-line summary suitable for brief display.
-    """
+    """Return a shortened summary of the given text for display."""
     if not text:
         return ""
     for line in text.splitlines():
@@ -44,98 +22,130 @@ def _format_summary(text: str, max_chars: int = 200) -> str:
     return text[: max_chars] + ("…" if len(text) > max_chars else "")
 
 
+def render_live_status(live_status: Dict[str, Dict[str, Any]]) -> None:
+    """Show per-task live progress and token counters."""
+    if not live_status:
+        return
+    st.subheader("Live Status")
+    for tid, info in live_status.items():
+        st.markdown(f"**{info.get('role', '')} – {info.get('title', '')}**")
+        st.progress(float(info.get("progress", 0.0)))
+        cols = st.columns(3)
+        cols[0].metric("Tokens in", f"{info.get('tokens_in', 0):,}")
+        cols[1].metric("Tokens out", f"{info.get('tokens_out', 0):,}")
+        cols[2].metric("Cost", f"${info.get('cost_usd', 0.0):.4f}")
+
+
 def render_agent_trace(agent_trace: Sequence[Dict[str, Any]], answers: Dict[str, str]) -> None:
-    """Render the agent trace UI.
-
-    This function produces a timeline-style breakdown of each task executed by
-    the agents, along with per-role inspection tabs and download controls. It
-    should be called from within a Streamlit context (e.g. after executing
-    ``execute_plan``) to display the trace to the user.
-
-    Parameters
-    ----------
-    agent_trace : sequence of dict
-        Each dict should at least contain keys ``agent`` (role name), ``title``
-        (task title), ``tokens_in``, ``tokens_out``, ``quotes``, ``citations``,
-        ``cost``, ``raw_json`` and ``finding``.
-    answers : dict
-        Mapping from role name to the concatenated outputs for that role. Used
-        for populating the per-role inspection tabs.
-    """
-    # Guard against missing or empty data
+    """Render the agent execution timeline and raw outputs."""
     if not agent_trace:
         return
-    # Outer expander groups all trace information. An emoji hints at the
-    # diagnostics available without taking too much vertical space by default.
     with st.expander("📌 Agent Trace & Inspection", expanded=False):
         total_steps = len(agent_trace)
-        # Render each step in order with a progress indicator and summary.
         for idx, item in enumerate(agent_trace, 1):
-            agent = item.get("agent", "") or ""
-            title = item.get("title", "") or ""
+            agent = item.get("role") or item.get("agent") or ""
+            title = item.get("title", "")
             st.markdown(f"**Step {idx}/{total_steps}: {agent} – {title}**")
-            # Progress bar shows progress through the overall plan
             st.progress(min(float(idx) / float(total_steps), 1.0))
-            # Token and citation metrics displayed in columns
             cols = st.columns(4)
             cols[0].metric("Tokens in", f"{item.get('tokens_in', 0):,}")
             cols[1].metric("Tokens out", f"{item.get('tokens_out', 0):,}")
             cols[2].metric("Quotes", f"{len(item.get('quotes', []) or [])}")
             cols[3].metric("Citations", f"{len(item.get('citations', []) or [])}")
-            # Cost, if present, shown as a caption
-            cost = item.get("cost", 0.0) or 0.0
+            cost = float(item.get("cost_usd", item.get("cost", 0.0)) or 0.0)
             st.caption(f"**Cost:** ${cost:,.4f}")
-            # Show a brief summary of the finding
             summary = _format_summary(item.get("finding", "") or "")
             if summary:
                 st.markdown(f"**Summary:** {summary}")
-            # Expanders for raw JSON and full output
             with st.expander("🔍 Raw JSON", expanded=False):
                 st.json(item.get("raw_json", {}))
             with st.expander("📄 Full Output", expanded=False):
                 st.write(item.get("finding", "") or "")
 
-        # Per-role tabs allow users to inspect the aggregated output for each agent
-        unique_roles = sorted({item.get("agent", "") for item in agent_trace if item.get("agent")})
-        if unique_roles:
-            tab_objs = st.tabs(unique_roles)
-            for i, role in enumerate(unique_roles):
-                with tab_objs[i]:
-                    st.subheader(role)
-                    role_output = answers.get(role, "")
-                    if role_output:
-                        st.markdown(role_output)
-                    else:
-                        st.info("No output recorded for this role.")
 
-        # Horizontal divider before export controls
-        st.divider()
-        col_json, col_csv = st.columns(2)
-        # JSON export: pretty-print the agent trace
-        trace_json = json.dumps(list(agent_trace), indent=2, ensure_ascii=False)
-        col_json.download_button(
-            label="💾 Download Trace (JSON)",
-            data=trace_json,
-            file_name="agent_trace.json",
+def render_role_summaries(answers: Dict[str, str]) -> None:
+    """Display per-role outputs with raw view toggles."""
+    if not answers:
+        return
+    roles = list(answers.keys())
+    tabs = st.tabs(roles)
+    for i, role in enumerate(roles):
+        with tabs[i]:
+            summary = _format_summary(answers.get(role, ""))
+            if summary:
+                st.markdown(summary)
+            with st.expander("View raw", expanded=False):
+                st.write(answers.get(role, ""))
+
+
+def render_exports(project_id: str, agent_trace: Sequence[Dict[str, Any]]) -> None:
+    """Expose trace/report downloads and shareable links."""
+    if not agent_trace:
+        return
+    st.subheader("Exports")
+    col_json, col_csv = st.columns(2)
+    trace_json = json.dumps(list(agent_trace), indent=2, ensure_ascii=False)
+    col_json.download_button(
+        "💾 Download Trace (JSON)",
+        data=trace_json,
+        file_name="agent_trace.json",
+        mime="application/json",
+    )
+    try:
+        flat_rows: List[Dict[str, Any]] = []
+        for item in agent_trace:
+            row: Dict[str, Any] = {}
+            for k, v in item.items():
+                if k in ("quotes", "citations", "raw_json", "events"):
+                    row[k] = json.dumps(v, ensure_ascii=False)
+                else:
+                    row[k] = v
+            flat_rows.append(row)
+        df = pd.DataFrame(flat_rows)
+        col_csv.download_button(
+            "📄 Download Trace (CSV)",
+            data=df.to_csv(index=False),
+            file_name="agent_trace.csv",
+            mime="text/csv",
+        )
+    except Exception:
+        col_csv.caption("CSV export unavailable for this trace.")
+    evidence_path = Path("audits") / project_id / "evidence.json"
+    coverage_path = Path("audits") / project_id / "coverage.csv"
+    if evidence_path.exists():
+        st.download_button(
+            "Evidence JSON",
+            data=evidence_path.read_bytes(),
+            file_name="evidence.json",
             mime="application/json",
         )
-        # CSV export: flatten nested structures before conversion
-        try:
-            flat_rows: List[Dict[str, Any]] = []
-            for item in agent_trace:
-                row: Dict[str, Any] = {}
-                for k, v in item.items():
-                    if k in ("quotes", "citations", "raw_json"):
-                        row[k] = json.dumps(v, ensure_ascii=False)
-                    else:
-                        row[k] = v
-                flat_rows.append(row)
-            df = pd.DataFrame(flat_rows)
-            col_csv.download_button(
-                label="📄 Download Trace (CSV)",
-                data=df.to_csv(index=False),
-                file_name="agent_trace.csv",
-                mime="text/csv",
+    if coverage_path.exists():
+        st.download_button(
+            "Coverage CSV",
+            data=coverage_path.read_bytes(),
+            file_name="coverage.csv",
+            mime="text/csv",
+        )
+    paths = st.session_state.get("final_paths", {})
+    if paths.get("report"):
+        st.download_button(
+            "Download final report (MD)",
+            data=open(paths["report"], "rb"),
+            file_name="final_report.md",
+        )
+    if paths.get("bundle"):
+        st.download_button(
+            "Download bundle (ZIP)",
+            data=open(paths["bundle"], "rb"),
+            file_name="final_bundle.zip",
+        )
+    if project_id:
+        st.markdown("---")
+        share_path = f"rd_projects/{project_id}"
+        st.text("Shareable Project Link")
+        st.code(share_path, language=None)
+        console_base = os.getenv("CONSOLE_BASE_URL", "").strip()
+        if console_base:
+            st.markdown(
+                f"[Open in Console]({console_base.rstrip('/')}/{project_id})"
             )
-        except Exception:
-            col_csv.caption("CSV export unavailable for this trace.")

--- a/core/observability/__init__.py
+++ b/core/observability/__init__.py
@@ -1,2 +1,13 @@
 from .evidence import EvidenceItem, EvidenceSet
 from .coverage import build_coverage, DIMENSIONS
+from .trace import AgentTraceCollector, AgentTraceItem, TraceEvent
+
+__all__ = [
+    "EvidenceItem",
+    "EvidenceSet",
+    "build_coverage",
+    "DIMENSIONS",
+    "AgentTraceCollector",
+    "AgentTraceItem",
+    "TraceEvent",
+]

--- a/core/observability/trace.py
+++ b/core/observability/trace.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+def _now() -> str:
+    """Return current UTC timestamp in ISO format with trailing Z."""
+    return datetime.utcnow().isoformat() + "Z"
+
+
+class TraceEvent(BaseModel):
+    type: Literal["route", "call", "retry", "validate", "save_evidence", "complete"]
+    ts: str = Field(default_factory=_now)
+    meta: Dict[str, Any] = Field(default_factory=dict)
+
+
+class AgentTraceItem(BaseModel):
+    project_id: str
+    task_id: str
+    step_no: int
+    role: str
+    title: str = ""
+    model: str = ""
+    tokens_in: int = 0
+    tokens_out: int = 0
+    cost_usd: float = 0.0
+    quotes: List[Any] = Field(default_factory=list)
+    citations: List[Any] = Field(default_factory=list)
+    finding: str = ""
+    raw_json: Dict[str, Any] = Field(default_factory=dict)
+    events: List[TraceEvent] = Field(default_factory=list)
+    ts_start: str = Field(default_factory=_now)
+    ts_end: Optional[str] = None
+
+
+class AgentTraceCollector:
+    """Collect AgentTraceItem entries during plan execution."""
+
+    def __init__(self, project_id: str):
+        self.project_id = project_id
+        self.items: List[AgentTraceItem] = []
+
+    def start_item(self, task: Dict[str, Any], role: str, model: str) -> int:
+        item = AgentTraceItem(
+            project_id=self.project_id,
+            task_id=task.get("id", ""),
+            step_no=len(self.items) + 1,
+            role=role,
+            title=task.get("title", ""),
+            model=model,
+        )
+        self.items.append(item)
+        return len(self.items) - 1
+
+    def append_event(self, handle: int, type: str, meta: Dict[str, Any]) -> None:
+        self.items[handle].events.append(TraceEvent(type=type, meta=meta))
+
+    def finalize_item(
+        self,
+        handle: int,
+        finding: str,
+        raw_json: Dict[str, Any],
+        tokens_in: int,
+        tokens_out: int,
+        cost: float,
+        quotes: List[Any],
+        citations: List[Any],
+        ts_end: Optional[str] = None,
+    ) -> None:
+        item = self.items[handle]
+        item.finding = finding
+        item.raw_json = raw_json
+        item.tokens_in = tokens_in
+        item.tokens_out = tokens_out
+        item.cost_usd = cost
+        item.quotes = quotes
+        item.citations = citations
+        item.ts_end = ts_end or _now()
+        self.append_event(handle, "complete", {})
+
+    def as_dicts(self) -> List[Dict[str, Any]]:
+        return [i.model_dump() for i in self.items]

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -31,7 +31,6 @@ Deprecated aliases: test, deep
 | Reflection | `core/agents/reflection_agent.py` | JSON |
 | Chief Scientist | `core/agents/chief_scientist_agent.py` | JSON |
 | Regulatory Specialist | `core/agents/regulatory_specialist_agent.py` | JSON |
-| UI Helpers | `app/agent_trace_ui.py` | JSON |
 
 
 ## Orchestrator & Executor Responsibilities
@@ -51,4 +50,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-25T22:00:21.202618Z from commit c57a33b_
+_Last generated at 2025-08-25T22:54:51.646146Z from commit 65bd9c0_

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-25T22:00:21.202618Z'
-git_sha: c57a33bd9fde9ae2f67d1fa5d72c149d75b81e95
+generated_at: '2025-08-25T22:54:51.646146Z'
+git_sha: 65bd9c02778147f50dfc5b0015e8358e8ef82068
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -141,28 +141,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/__init__.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/plan_utils.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -176,7 +155,28 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
+- path: orchestrators/__init__.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/app_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/spec_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -190,7 +190,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
+- path: core/summarization/integrator.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_agent_trace_ui_smoke.py
+++ b/tests/test_agent_trace_ui_smoke.py
@@ -1,0 +1,48 @@
+import streamlit as st
+
+from app.agent_trace_ui import (
+    render_agent_trace,
+    render_live_status,
+    render_role_summaries,
+    render_exports,
+)
+
+
+def test_agent_trace_ui_smoke(tmp_path):
+    st.session_state.clear()
+    live_status = {
+        "T01": {
+            "done": True,
+            "progress": 1.0,
+            "tokens_in": 1,
+            "tokens_out": 2,
+            "cost_usd": 0.1,
+            "model": "gpt",
+            "role": "CTO",
+            "title": "Test",
+        }
+    }
+    trace = [
+        {
+            "project_id": "p",
+            "task_id": "T01",
+            "step_no": 1,
+            "role": "CTO",
+            "title": "Test",
+            "model": "gpt",
+            "tokens_in": 1,
+            "tokens_out": 2,
+            "cost_usd": 0.1,
+            "quotes": [],
+            "citations": [],
+            "finding": "done",
+            "raw_json": {},
+            "events": [],
+            "ts_start": "",
+            "ts_end": "",
+        }
+    ]
+    render_live_status(live_status)
+    render_agent_trace(trace, {})
+    render_role_summaries({"CTO": "output"})
+    render_exports("proj", trace)

--- a/tests/test_trace_capture.py
+++ b/tests/test_trace_capture.py
@@ -1,0 +1,44 @@
+import json
+
+import streamlit as st
+
+from core.orchestrator import execute_plan
+
+
+class DummyAgent:
+    def __init__(self, model: str | None = None):
+        pass
+
+    def run(self, idea: str, task: dict, model: str | None = None) -> str:
+        payload = {
+            "role": task.get("role", ""),
+            "task": task.get("title", ""),
+            "findings": "done",
+            "risks": [],
+            "next_steps": [],
+            "sources": [],
+            "tokens_in": 1,
+            "tokens_out": 2,
+            "cost": 0.0031,
+            "quotes": ["evidence"],
+            "citations": [],
+        }
+        return "```json\n" + json.dumps(payload) + "\n```"
+
+
+def test_trace_capture(monkeypatch):
+    st.session_state.clear()
+
+    def fake_choose(role, title, desc, ui_model=None):
+        return role or "CTO", DummyAgent, "gpt-4o-mini"
+
+    monkeypatch.setattr("core.router.choose_agent_for_task", fake_choose)
+
+    tasks = [{"id": "T01", "role": "CTO", "title": "Test", "description": "do"}]
+    execute_plan("idea", tasks, agents={})
+
+    trace = st.session_state.get("agent_trace")
+    assert trace and trace[0]["role"] == "CTO"
+    assert trace[0]["model"] == "gpt-4o-mini"
+    assert trace[0]["tokens_in"] == 1
+    assert trace[0]["events"][0]["type"] == "route"


### PR DESCRIPTION
## Summary
- capture detailed agent events via new `AgentTraceCollector` and persist project traces
- expose live status, trace timeline, exports, and role summaries in Streamlit UI
- reference saved trace from Firestore for collaboration and sharing

## Testing
- `pytest tests/test_trace_capture.py tests/test_agent_trace_ui_smoke.py -q`
- `python scripts/generate_repo_map.py`

------
https://chatgpt.com/codex/tasks/task_e_68ace7735518832c8eb70b6c875efed6