### PR TITLE
feat: add evaluation agent and quality loop

### DIFF
--- a/config/feature_flags.py
+++ b/config/feature_flags.py
@@ -32,6 +32,15 @@ VECTOR_INDEX_PATH: str = ""
 VECTOR_INDEX_SOURCE: str = "none"
 VECTOR_INDEX_REASON: str = ""
 
+EVALUATION_ENABLED = _flag("EVALUATION_ENABLED")
+EVALUATION_MAX_ROUNDS: int = int(os.getenv("EVALUATION_MAX_ROUNDS", "1"))
+EVALUATION_HUMAN_REVIEW = _flag("EVALUATION_HUMAN_REVIEW")
+EVALUATION_USE_LLM_RUBRIC = _flag("EVALUATION_USE_LLM_RUBRIC")
+EVAL_WEIGHTS = json.loads(
+    os.getenv("EVAL_WEIGHTS", '{"clarity":0.3,"completeness":0.5,"grounding":0.2}')
+)
+EVAL_MIN_OVERALL: float = float(os.getenv("EVAL_MIN_OVERALL", "0.65"))
+
 # Default evaluator weights and threshold. ``EVALUATOR_WEIGHTS`` can be
 # overridden via an environment variable containing a JSON object.
 EVALUATOR_WEIGHTS = json.loads(
@@ -76,6 +85,12 @@ def get_env_defaults() -> dict:
         "SIM_OPTIMIZER_ENABLED": SIM_OPTIMIZER_ENABLED,
         "SIM_OPTIMIZER_STRATEGY": SIM_OPTIMIZER_STRATEGY,
         "SIM_OPTIMIZER_MAX_EVALS": SIM_OPTIMIZER_MAX_EVALS,
+        "EVALUATION_ENABLED": EVALUATION_ENABLED,
+        "EVALUATION_MAX_ROUNDS": EVALUATION_MAX_ROUNDS,
+        "EVALUATION_HUMAN_REVIEW": EVALUATION_HUMAN_REVIEW,
+        "EVALUATION_USE_LLM_RUBRIC": EVALUATION_USE_LLM_RUBRIC,
+        "EVAL_MIN_OVERALL": EVAL_MIN_OVERALL,
+        "EVAL_WEIGHTS": EVAL_WEIGHTS,
     }
 
 
@@ -85,6 +100,8 @@ def apply_overrides(cfg: dict) -> None:
     global RAG_ENABLED, RAG_TOPK, ENABLE_LIVE_SEARCH
     global LIVE_SEARCH_BACKEND, LIVE_SEARCH_MAX_CALLS, LIVE_SEARCH_SUMMARY_TOKENS
     global FAISS_BOOTSTRAP_MODE, VECTOR_INDEX_PATH, FAISS_INDEX_URI, ENABLE_IMAGES
+    global EVALUATION_ENABLED, EVALUATION_MAX_ROUNDS, EVALUATION_HUMAN_REVIEW
+    global EVALUATION_USE_LLM_RUBRIC, EVAL_MIN_OVERALL, EVAL_WEIGHTS
     if "rag_enabled" in cfg:
         RAG_ENABLED = bool(cfg.get("rag_enabled"))
     if "rag_top_k" in cfg:
@@ -107,6 +124,21 @@ def apply_overrides(cfg: dict) -> None:
         FAISS_INDEX_URI = str(cfg.get("faiss_index_uri") or FAISS_INDEX_URI)
     if "enable_images" in cfg:
         ENABLE_IMAGES = bool(cfg.get("enable_images"))
+    if "evaluation_enabled" in cfg:
+        EVALUATION_ENABLED = bool(cfg.get("evaluation_enabled"))
+    if "evaluation_max_rounds" in cfg:
+        EVALUATION_MAX_ROUNDS = int(cfg.get("evaluation_max_rounds", EVALUATION_MAX_ROUNDS))
+    if "evaluation_human_review" in cfg:
+        EVALUATION_HUMAN_REVIEW = bool(cfg.get("evaluation_human_review"))
+    if "evaluation_use_llm_rubric" in cfg:
+        EVALUATION_USE_LLM_RUBRIC = bool(cfg.get("evaluation_use_llm_rubric"))
+    if "evaluation_min_overall" in cfg:
+        EVAL_MIN_OVERALL = float(cfg.get("evaluation_min_overall", EVAL_MIN_OVERALL))
+    if "evaluation_weights" in cfg:
+        try:
+            EVAL_WEIGHTS = dict(cfg.get("evaluation_weights", EVAL_WEIGHTS))
+        except Exception:
+            pass
 
 
 def apply_mode_overrides(cfg: dict) -> None:

--- a/core/agents/evaluation_agent.py
+++ b/core/agents/evaluation_agent.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import re
+from typing import Dict, List, Any, Optional
+
+import config.feature_flags as ff
+from utils.logging import logger
+
+try:
+    from evaluation import llm_rubric
+except Exception:  # pragma: no cover - optional
+    llm_rubric = None  # type: ignore
+
+
+class EvaluationAgent:
+    """Lightweight heuristic evaluator for agent outputs."""
+
+    name = "Evaluation"
+
+    def __init__(self, model: str | None = None):
+        self.model = model or ""
+
+    # ------------------------------------------------------------------
+    def _has_placeholder(self, text: str) -> bool:
+        return bool(re.search(r"(?i)\b(TBD|TODO|\?\?\?|placeholder)\b", text))
+
+    def _score_clarity(self, texts: List[str]) -> float:
+        if any(self._has_placeholder(t) for t in texts):
+            return 0.2
+        return 1.0
+
+    def _score_completeness(self, answers: Dict[str, str], payloads: Dict[str, dict]) -> float:
+        if not answers:
+            return 0.0
+        penalties = 0.0
+        total_roles = len(answers)
+        for role, ans in answers.items():
+            if not ans.strip():
+                penalties += 1.0
+                continue
+            if self._has_placeholder(ans):
+                penalties += 0.5
+            payload = payloads.get(role) or {}
+            for key in ("findings", "risks", "next_steps"):
+                if key in payload and not payload.get(key):
+                    penalties += 0.2
+        score = max(0.0, 1.0 - penalties / max(1, total_roles))
+        return min(1.0, score)
+
+    def _score_grounding(self, answers: Dict[str, str], payloads: Dict[str, dict], context: Dict[str, Any]) -> float:
+        rag = bool(context.get("rag_enabled")) or bool(context.get("live_search_enabled"))
+        if not rag:
+            return 1.0
+        cites = 0
+        for role, ans in answers.items():
+            if re.search(r"\[(?:\d+|[a-z])\]", ans) or "according to" in ans.lower():
+                cites += 1
+            payload = payloads.get(role) or {}
+            cites += len(payload.get("citations", []) or [])
+            if re.search(r"https?://", ans):
+                cites += 1
+        if cites == 0:
+            return 0.0
+        return 1.0 if cites >= 2 else 0.5
+
+    # ------------------------------------------------------------------
+    def run(
+        self,
+        idea: str,
+        answers_by_role: Dict[str, str],
+        payload_by_role: Dict[str, dict],
+        context: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        context = context or {}
+        texts = list(answers_by_role.values())
+        clarity = self._score_clarity(texts)
+        completeness = self._score_completeness(answers_by_role, payload_by_role)
+        grounding = self._score_grounding(answers_by_role, payload_by_role, context)
+        weights = ff.EVAL_WEIGHTS
+        overall = (
+            clarity * weights.get("clarity", 0.0)
+            + completeness * weights.get("completeness", 0.0)
+            + grounding * weights.get("grounding", 0.0)
+        )
+        overall = round(overall, 4)
+
+        if ff.EVALUATION_USE_LLM_RUBRIC and llm_rubric is not None:
+            try:
+                text = "\n\n".join(texts)
+                rubric = "Clarity, Completeness, Grounding"
+                overall = llm_rubric.score_with_rubric(text, rubric)
+            except Exception as e:  # pragma: no cover
+                logger.warning("LLM rubric scoring failed: %s", e)
+
+        insufficient = overall < ff.EVAL_MIN_OVERALL
+        findings: List[str] = []
+        followups: List[Dict[str, str]] = []
+        if insufficient:
+            if clarity < 0.7:
+                followups.append(
+                    {
+                        "role": "Research Scientist",
+                        "title": "Improve clarity",
+                        "description": "Polish language and remove placeholders.",
+                    }
+                )
+                findings.append("low clarity")
+            if completeness < 0.7:
+                followups.append(
+                    {
+                        "role": "Planner",
+                        "title": "Patch Plan for Gaps",
+                        "description": "Add tasks addressing missing findings or sections.",
+                    }
+                )
+                findings.append("incomplete outputs")
+            if grounding < 0.7:
+                followups.append(
+                    {
+                        "role": "Research Scientist",
+                        "title": "Add citations",
+                        "description": "Provide at least two diverse citations.",
+                    }
+                )
+                findings.append("weak grounding")
+        followups = followups[:3]
+
+        metrics = {"tokens_in": 0, "tokens_out": 0, "cost_usd": 0.0}
+        for payload in payload_by_role.values():
+            if isinstance(payload, dict):
+                metrics["tokens_in"] += int(payload.get("tokens_in", 0) or 0)
+                metrics["tokens_out"] += int(payload.get("tokens_out", 0) or 0)
+                try:
+                    metrics["cost_usd"] += float(payload.get("cost", 0.0) or 0.0)
+                except Exception:
+                    pass
+
+        return {
+            "score": {
+                "clarity": clarity,
+                "completeness": completeness,
+                "grounding": grounding,
+                "overall": overall,
+            },
+            "insufficient": insufficient,
+            "findings": findings,
+            "followups": followups,
+            "notes": "heuristic",
+            "metrics": metrics,
+        }
+

--- a/core/agents/unified_registry.py
+++ b/core/agents/unified_registry.py
@@ -21,6 +21,7 @@ from core.agents.chief_scientist_agent import ChiefScientistAgent
 from core.agents.regulatory_specialist_agent import RegulatorySpecialistAgent
 from core.agents.invoke import resolve_invoker
 from core.llm import select_model
+from core.agents.evaluation_agent import EvaluationAgent
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +43,7 @@ AGENT_REGISTRY: Dict[str, Type[BaseAgent]] = {
     "Reflection": ReflectionAgent,
     "Chief Scientist": ChiefScientistAgent,
     "Regulatory Specialist": RegulatorySpecialistAgent,
+    "Evaluation": EvaluationAgent,
 }
 
 # Backwards compatibility alias

--- a/core/observability/trace.py
+++ b/core/observability/trace.py
@@ -12,7 +12,16 @@ def _now() -> str:
 
 
 class TraceEvent(BaseModel):
-    type: Literal["route", "call", "retry", "validate", "save_evidence", "complete"]
+    type: Literal[
+        "route",
+        "call",
+        "retry",
+        "validate",
+        "save_evidence",
+        "complete",
+        "evaluation",
+        "spawn_followup",
+    ]
     ts: str = Field(default_factory=_now)
     meta: Dict[str, Any] = Field(default_factory=dict)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,7 +3,7 @@
 - agents: UI-only wrappers (PlannerAgent, SynthesizerAgent) and any view helpers.
 - legacy agents directory: deprecated shim removed after migration to core.agents.
 
-The app builds agents via core/agents/unified_registry.build_agents_unified(...). The orchestrator executes a single "Planner → Router/Registry → Executor → Synthesizer" pipeline regardless of profile. Runtime knobs are exposed as feature-flag toggles rather than separate modes.
+The app builds agents via core/agents/unified_registry.build_agents_unified(...). The orchestrator executes a single "Planner → Router/Registry → Executor → Evaluation → Synthesizer" pipeline regardless of profile. Runtime knobs are exposed as feature-flag toggles rather than separate modes. The Evaluation stage scores clarity, completeness, and grounding of agent outputs and may spawn follow‑up tasks before synthesis.
 
 ## Runtime toggles and cost tracking
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -36,7 +36,10 @@ The Streamlit app exposes runtime controls in the sidebar while running in the
 single **Standard** profile. Retrieval features (RAG and Live Search) can be
 toggled and adjusted on demand; changes are pushed into runtime flags via
 `config.feature_flags.apply_overrides()`. The sidebar also includes a numeric
-target budget and optional stage weight inputs. There is no “Test” or “Deep”
+target budget and optional stage weight inputs. A separate **Quality & Evaluation**
+expander enables an internal evaluator that can request follow‑up tasks. Users
+may toggle evaluation, set the maximum refinement rounds, and require manual
+approval of follow‑ups. There is no “Test” or “Deep”
 mode selector; similar behaviour is achieved by lowering the budget or choosing
 cheaper models in configuration.
 
@@ -77,6 +80,11 @@ ENABLE_LIVE_SEARCH=true|false
 LIVE_SEARCH_BACKEND=openai|serpapi
 ENABLE_IMAGES=true|false
 SERPAPI_KEY=your_key
+EVALUATION_ENABLED=true|false
+EVALUATION_MAX_ROUNDS=0..2
+EVALUATION_HUMAN_REVIEW=true|false
+EVAL_MIN_OVERALL=0.0..1.0
+EVALUATION_USE_LLM_RUBRIC=true|false
 ```
 
 ## Feature flags

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -1,7 +1,7 @@
 # Repository Map
 
 ## Overview & Flow Diagram
-User idea → Planner → Router/Registry → Executor → Summarization → Synthesizer → UI
+User idea → Planner → Router/Registry → Executor → Evaluation → Synthesizer → UI
 
 ## Entry Points & Run Modes
 
@@ -31,6 +31,7 @@ Deprecated aliases: test, deep
 | Reflection | `core/agents/reflection_agent.py` | JSON |
 | Chief Scientist | `core/agents/chief_scientist_agent.py` | JSON |
 | Regulatory Specialist | `core/agents/regulatory_specialist_agent.py` | JSON |
+| Evaluation | `core/agents/evaluation_agent.py` | JSON |
 
 
 ## Orchestrator & Executor Responsibilities
@@ -50,4 +51,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-25T22:54:51.646146Z from commit 65bd9c0_
+_Last generated at 2025-08-25T23:27:11.560811Z from commit 6eca588_

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,13 +1,12 @@
 version: 1
-generated_at: '2025-08-25T22:54:51.646146Z'
-git_sha: 65bd9c02778147f50dfc5b0015e8358e8ef82068
+generated_at: '2025-08-25T23:27:11.560811Z'
+git_sha: 6eca588ecee83e6c66e3cf1806dec67a63868a5b
 entry_points:
 - name: streamlit_app
   path: app.py
 - name: package_init
   path: app/__init__.py:main
-architecture: "Planner \u2192 Router/Registry \u2192 Executor \u2192 Summarization\
-  \ \u2192 Synthesizer"
+architecture: "Planner \u2192 Router/Registry \u2192 Executor \u2192 Evaluation \u2192 Synthesizer"
 runtime_modes:
   standard:
     target_cost_usd: 2.5
@@ -141,14 +140,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/plan_utils.py
-  role: Orchestrator
+- path: core/agents/evaluation_agent.py
+  role: Agent[Evaluation]
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/qa_router.py
+- path: orchestrators/app_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -162,13 +161,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
@@ -176,14 +168,21 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
-  role: Summarization
+- path: orchestrators/qa_router.py
+  role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/__init__.py
+- path: orchestrators/plan_utils.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -197,7 +196,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/schemas.py
+- path: core/summarization/__init__.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -233,6 +239,7 @@ agent_registry:
   Reflection: core/agents/reflection_agent.py
   Chief Scientist: core/agents/chief_scientist_agent.py
   Regulatory Specialist: core/agents/regulatory_specialist_agent.py
+  Evaluation: core/agents/evaluation_agent.py
 config_files:
 - path: config/modes.yaml
   required_keys:

--- a/tests/test_evaluation_agent.py
+++ b/tests/test_evaluation_agent.py
@@ -1,0 +1,146 @@
+import sys
+from unittest.mock import patch
+
+import config.feature_flags as ff
+from core.agents.evaluation_agent import EvaluationAgent
+from core.orchestrator import execute_plan
+
+
+def make_streamlit():
+    class ST:
+        def __init__(self):
+            self.session_state = {}
+    return ST()
+
+
+def test_evaluation_agent_sufficient():
+    agent = EvaluationAgent()
+    answers = {"Research Scientist": "Clear text with citation [1]."}
+    payloads = {"Research Scientist": {"citations": ["a"], "findings": "done"}}
+    context = {"rag_enabled": True}
+    res = agent.run("idea", answers, payloads, context)
+    assert res["insufficient"] is False
+    assert res["followups"] == []
+
+
+def test_evaluation_agent_followups():
+    agent = EvaluationAgent()
+    answers = {"Research Scientist": "TBD"}
+    payloads = {"Research Scientist": {}}
+    context = {"rag_enabled": True}
+    res = agent.run("idea", answers, payloads, context)
+    assert res["insufficient"] is True
+    assert 0 < len(res["followups"]) <= 3
+
+
+@patch("core.orchestrator.route_task")
+@patch("core.orchestrator._invoke_agent")
+def test_evaluation_loop_guard(mock_invoke, mock_route, monkeypatch):
+    st = make_streamlit()
+    monkeypatch.setitem(sys.modules, "streamlit", st)
+    monkeypatch.setattr("core.orchestrator.st", st)
+    ff.EVALUATION_ENABLED = True
+    ff.EVALUATION_HUMAN_REVIEW = False
+    ff.EVALUATION_MAX_ROUNDS = 1
+    class DummyAgent:
+        def __init__(self, model):
+            pass
+
+    def fake_route(task, ui_model):
+        return (
+            task.get("role", "Research Scientist"),
+            DummyAgent,
+            "m1",
+            task,
+        )
+
+    mock_route.side_effect = fake_route
+    call_log = []
+
+    def fake_invoke(agent, idea, task, model=None):
+        call_log.append(task.get("title"))
+        return "ok"
+
+    mock_invoke.side_effect = fake_invoke
+
+    iter_results = iter(
+        [
+            {
+                "score": {},
+                "insufficient": True,
+                "findings": ["gap"],
+                "followups": [{"role": "Research Scientist", "title": "F1", "description": "d"}],
+                "notes": "",
+                "metrics": {},
+            },
+            {
+                "score": {},
+                "insufficient": True,
+                "findings": ["gap"],
+                "followups": [{"role": "Research Scientist", "title": "F2", "description": "d"}],
+                "notes": "",
+                "metrics": {},
+            },
+        ]
+    )
+
+    monkeypatch.setattr(
+        EvaluationAgent,
+        "run",
+        lambda self, idea, ans, payload, context=None: next(iter_results),
+    )
+
+    tasks = [{"role": "Research Scientist", "title": "t1", "description": "d1"}]
+    execute_plan("idea", tasks, agents={})
+    assert "t1" in call_log
+    assert "F1" in call_log
+    assert "F2" not in call_log
+
+
+@patch("core.orchestrator.route_task")
+@patch("core.orchestrator._invoke_agent")
+def test_evaluation_human_review(mock_invoke, mock_route, monkeypatch):
+    st = make_streamlit()
+    monkeypatch.setitem(sys.modules, "streamlit", st)
+    monkeypatch.setattr("core.orchestrator.st", st)
+    ff.EVALUATION_ENABLED = True
+    ff.EVALUATION_HUMAN_REVIEW = True
+    ff.EVALUATION_MAX_ROUNDS = 1
+    class DummyAgent:
+        def __init__(self, model):
+            pass
+
+    def fake_route(task, ui_model):
+        return (
+            task.get("role", "Research Scientist"),
+            DummyAgent,
+            "m1",
+            task,
+        )
+
+    mock_route.side_effect = fake_route
+
+    call_log = []
+
+    def fake_invoke(agent, idea, task, model=None):
+        call_log.append(task.get("title"))
+        return "ok"
+
+    mock_invoke.side_effect = fake_invoke
+    monkeypatch.setattr(
+        EvaluationAgent,
+        "run",
+        lambda self, idea, ans, payload, context=None: {
+            "score": {},
+            "insufficient": True,
+            "findings": ["gap"],
+            "followups": [{"role": "Research Scientist", "title": "F1", "description": "d"}],
+            "notes": "",
+            "metrics": {},
+        },
+    )
+    tasks = [{"role": "Research Scientist", "title": "t1", "description": "d1"}]
+    execute_plan("idea", tasks, agents={})
+    assert st.session_state.get("awaiting_approval") is True
+    assert st.session_state.get("pending_followups")[0]["title"] == "F1"
+    assert all(title == "t1" for title in call_log)


### PR DESCRIPTION
## Summary
- add heuristic EvaluationAgent scoring clarity/completeness/grounding and proposing follow‑ups
- wire evaluation loop with feature flags and optional human review
- expose quality controls in UI and document new evaluation stage

## Testing
- `pytest tests/test_evaluation_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68acefccbd30832c855cec7f2ad37930