### PR TITLE
Ensure plan node assigns task IDs

### DIFF
--- a/core/graph/nodes.py
+++ b/core/graph/nodes.py
@@ -14,6 +14,8 @@ def plan_node(state: GraphState, ui_model: str | None = None) -> GraphState:
 
     constraint_text = "\n".join(state.constraints or [])
     tasks = generate_plan(state.idea, constraint_text, state.risk_posture, ui_model=ui_model)
+    for idx, t in enumerate(tasks, 1):
+        t.setdefault("id", f"T{idx:02d}")
     state.tasks = [GraphTask(**t) for t in tasks]
     state.cursor = 0
     node_end(state, "plan")


### PR DESCRIPTION
## Summary
- Assign sequential IDs to planner tasks in `plan_node` when missing
- Prevent `GraphTask` validation errors caused by missing `id`

## Testing
- `pytest tests/test_langgraph_minimal.py::test_graph_runs_with_tool_request -q` *(fails: AssertionError: nodes order mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68ad07349308832c8fbfdc023fcd3d8c