### PR TITLE
Implement callable interface for ResearchScientistAgent

### DIFF
--- a/core/agents/research_scientist_agent.py
+++ b/core/agents/research_scientist_agent.py
@@ -37,3 +37,8 @@ class ResearchScientistAgent(LLMRoleAgent):
             except Exception:
                 pass
         return result
+
+    def __call__(self, *, task: dict, model: str | None = None, meta: dict | None = None) -> str:
+        """Invoke the agent with the standard dispatcher signature."""
+        idea = task.get("idea", "")
+        return self.act(idea, task, model=model)


### PR DESCRIPTION
## Summary
- add `__call__` method to `ResearchScientistAgent` so it can be invoked via the agent dispatcher

## Testing
- `pytest`
- `pytest tests/test_app_ui.py::test_empty_idea_shows_info -q` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'experimental_rerun')*


------
https://chatgpt.com/codex/tasks/task_e_68ad09d44300832c881d3df3cc0e2fa5