### PR TITLE
Fix summary formatting for dict answers

### DIFF
--- a/app/agent_trace_ui.py
+++ b/app/agent_trace_ui.py
@@ -11,10 +11,23 @@ import pandas as pd  # type: ignore
 import streamlit as st  # type: ignore
 
 
-def _format_summary(text: str, max_chars: int = 200) -> str:
-    """Return a shortened summary of the given text for display."""
+def _format_summary(text: Any, max_chars: int = 200) -> str:
+    """Return a shortened summary of the given text for display.
+
+    ``answers`` values may be either plain strings or structured dictionaries
+    (e.g., with a ``content`` field).  This helper now defensively handles both
+    cases by extracting a representative string before truncating.
+    """
     if not text:
         return ""
+
+    if isinstance(text, dict):
+        # Prefer an explicit content/summary field if available; otherwise
+        # fall back to a JSON representation so something meaningful is shown.
+        text = text.get("content") or text.get("summary") or json.dumps(text, ensure_ascii=False)
+    elif not isinstance(text, str):
+        text = str(text)
+
     for line in text.splitlines():
         stripped = line.strip()
         if stripped:

--- a/tests/test_agent_trace_ui_summary.py
+++ b/tests/test_agent_trace_ui_summary.py
@@ -1,0 +1,7 @@
+from app.agent_trace_ui import _format_summary
+
+
+def test_format_summary_handles_dict():
+    payload = {"content": "First line\nSecond line"}
+    result = _format_summary(payload)
+    assert result == "First line"


### PR DESCRIPTION
## Summary
- make agent trace summary renderer robust to dictionary values by extracting content and falling back to JSON
- add regression test covering dict-based answers

## Testing
- `pytest tests/test_agent_trace_ui_summary.py::test_format_summary_handles_dict -q`
- `pytest tests/test_app_ui.py::test_empty_idea_shows_info -q` (fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'expander')

------
https://chatgpt.com/codex/tasks/task_e_68ad0d772428832c9a8a589f1628f72d