### PR TITLE
Feature: Prompt Registry & Prompt Factory (v1) + Retrieval Policies (non migrating)

### DIFF
--- a/core/prompting_bridge.py
+++ b/core/prompting_bridge.py
@@ -1,0 +1,10 @@
+"""Future bridge for prompt subsystem.
+
+This module illustrates how an agent could request a prompt:
+
+    from dr_rd.prompting import PromptFactory, registry
+    factory = PromptFactory(registry)
+    prompt = factory.build_prompt({"role": "Planner", "task": "<task>", "inputs": {"task": "<task>"}})
+
+No runtime behavior change; not imported elsewhere yet.
+"""

--- a/docs/PROMPT_STANDARDS.md
+++ b/docs/PROMPT_STANDARDS.md
@@ -1,0 +1,41 @@
+# Prompt Standards
+
+## Template Fields & Versioning
+- **id** and **version** identify a prompt template. Combined they form a unique key such as `planner.v1`.
+- **role** and **task_key** select the template for a caller.
+- **system** and **user_template** provide the base messages used by the model. `user_template` is formatted with runtime `inputs`.
+- **io_schema_ref** points to a JSON schema contract the model must follow.
+- **retrieval_policy** controls how aggressively the model should fetch external context.
+- **evaluation_hooks**, **safety_notes**, **provider_hints**, **examples_ref** are optional metadata.
+
+Registering a new version requires an explicit call to `PromptRegistry.register`. The latest registered version wins.
+
+## Retrieval Policies
+- `NONE`: no retrieval; `top_k=0`, no sources.
+- `LIGHT`: small number of sources (`top_k=5`), conservative budget.
+- `AGGRESSIVE`: broad search (`top_k=10`), generous budget.
+
+Retrieval instructions are included only when either `config.feature_flags.RAG_ENABLED` or `ENABLE_LIVE_SEARCH` is true. The factory maps policies to `{top_k, source_types, budget_hint}` and adds citation requirements when retrieval is active.
+
+## JSON Guardrails & Citations
+All prompts remind the model:
+> "You must reply only with a JSON object matching the schema: <io_schema_ref>."
+
+When retrieval is enabled, prompts also require inline numbered citations and a final `sources` list.
+
+## Using the PromptFactory
+Agents request prompts through `PromptFactory.build_prompt` providing:
+`{"role", "task", "inputs", "io_schema_ref", "retrieval_policy", ...}`.
+
+`build_prompt` resolves a template, injects guardrails and retrieval instructions, and returns:
+```
+{
+  "system": "...",
+  "user": "...",
+  "io_schema_ref": "...",
+  "retrieval": {...},
+  "llm_hints": {...},
+  "evaluation_hooks": [...]
+}
+```
+Future agents should reference `io_schema_ref` and use `PromptFactory` instead of hardcoded prompts.

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -51,4 +51,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-28T20:11:14.953045Z from commit 4240f5e_
+_Last generated at 2025-08-28T20:29:14.493707Z from commit 9e7fb17_

--- a/dr_rd/prompting/__init__.py
+++ b/dr_rd/prompting/__init__.py
@@ -1,0 +1,23 @@
+"""Prompting subsystem for DR-RD."""
+
+from .prompt_registry import (
+    PromptRegistry,
+    PromptTemplate,
+    RetrievalPolicy,
+    RETRIEVAL_NONE,
+    RETRIEVAL_LIGHT,
+    RETRIEVAL_AGGRESSIVE,
+    registry,
+)
+from .prompt_factory import PromptFactory
+
+__all__ = [
+    "PromptRegistry",
+    "PromptTemplate",
+    "RetrievalPolicy",
+    "PromptFactory",
+    "RETRIEVAL_NONE",
+    "RETRIEVAL_LIGHT",
+    "RETRIEVAL_AGGRESSIVE",
+    "registry",
+]

--- a/dr_rd/prompting/prompt_factory.py
+++ b/dr_rd/prompting/prompt_factory.py
@@ -1,0 +1,86 @@
+"""Prompt factory that composes prompts from templates."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from .prompt_registry import (
+    PromptRegistry,
+    RetrievalPolicy,
+    RETRIEVAL_POLICY_META,
+    registry as default_registry,
+)
+
+
+class PromptFactory:
+    """Build prompts from templates and runtime spec."""
+
+    def __init__(self, registry: Optional[PromptRegistry] = None) -> None:
+        self.registry = registry or default_registry
+
+    def build_prompt(self, spec: Dict[str, Any]) -> Dict[str, Any]:
+        role = spec.get("role")
+        task_key = spec.get("task_key")
+        inputs = spec.get("inputs") or {}
+        template = self.registry.get(role, task_key)
+
+        if template:
+            io_schema_ref = spec.get("io_schema_ref") or template.io_schema_ref
+            retrieval_policy = spec.get("retrieval_policy") or template.retrieval_policy
+            evaluation_hooks = spec.get("evaluation_hooks") or template.evaluation_hooks
+            provider_hints = template.provider_hints or {}
+            system = template.system
+            user_prompt = template.user_template.format(**inputs)
+        else:
+            io_schema_ref = spec.get("io_schema_ref") or "unknown"
+            retrieval_policy = spec.get("retrieval_policy") or RetrievalPolicy.NONE
+            evaluation_hooks = spec.get("evaluation_hooks")
+            provider_hints = {}
+            system = f"You are {role}."
+            user_prompt = spec.get("task", "")
+
+        evaluation_hooks = evaluation_hooks or ["self_check_minimal"]
+
+        guardrail = (
+            f" You must reply only with a JSON object matching the schema: {io_schema_ref}."
+        )
+        system = system.strip() + guardrail
+
+        from config import feature_flags
+
+        retrieval_enabled = bool(
+            getattr(feature_flags, "RAG_ENABLED", False)
+            or getattr(feature_flags, "ENABLE_LIVE_SEARCH", False)
+        )
+
+        meta = RETRIEVAL_POLICY_META.get(
+            retrieval_policy, RETRIEVAL_POLICY_META[RetrievalPolicy.NONE]
+        )
+
+        retrieval_dict = {
+            "policy": retrieval_policy.name,
+            "top_k": meta["top_k"],
+            "source_types": meta["source_types"],
+            "budget_hint": meta["budget_hint"],
+            "enabled": retrieval_enabled,
+        }
+
+        if retrieval_enabled and retrieval_policy != RetrievalPolicy.NONE:
+            retrieval_text = (
+                f" Retrieval policy {retrieval_policy.name}: use up to {meta['top_k']} items from "
+                f"{', '.join(meta['source_types'])}; budget {meta['budget_hint']}."
+                " Provide inline numbered citations and a final sources list."
+            )
+            system += retrieval_text
+
+        llm_hints = {"provider": "auto", "json_strict": True, "tool_use": "prefer"}
+        llm_hints.update(provider_hints)
+
+        return {
+            "system": system.strip(),
+            "user": user_prompt.strip(),
+            "io_schema_ref": io_schema_ref,
+            "retrieval": retrieval_dict,
+            "llm_hints": llm_hints,
+            "evaluation_hooks": evaluation_hooks,
+        }

--- a/dr_rd/prompting/prompt_registry.py
+++ b/dr_rd/prompting/prompt_registry.py
@@ -1,0 +1,140 @@
+"""Prompt templates and registry."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from enum import Enum
+from typing import Dict, List, Optional, Tuple
+
+
+@dataclass
+class PromptTemplate:
+    """Represents a prompt template and associated metadata."""
+
+    id: str
+    version: str
+    role: str
+    task_key: Optional[str]
+    system: str
+    user_template: str
+    io_schema_ref: str
+    retrieval_policy: "RetrievalPolicy"
+    evaluation_hooks: Optional[List[str]] = None
+    safety_notes: Optional[str] = None
+    provider_hints: Optional[Dict] = None
+    examples_ref: Optional[str] = None
+
+
+class RetrievalPolicy(Enum):
+    """Defines retrieval aggressiveness."""
+
+    NONE = "NONE"
+    LIGHT = "LIGHT"
+    AGGRESSIVE = "AGGRESSIVE"
+
+
+RETRIEVAL_POLICY_META = {
+    RetrievalPolicy.NONE: {"top_k": 0, "source_types": [], "budget_hint": "none"},
+    RetrievalPolicy.LIGHT: {
+        "top_k": 5,
+        "source_types": ["web", "local"],
+        "budget_hint": "conservative",
+    },
+    RetrievalPolicy.AGGRESSIVE: {
+        "top_k": 10,
+        "source_types": ["web", "academic", "local"],
+        "budget_hint": "generous",
+    },
+}
+
+RETRIEVAL_NONE = RetrievalPolicy.NONE
+RETRIEVAL_LIGHT = RetrievalPolicy.LIGHT
+RETRIEVAL_AGGRESSIVE = RetrievalPolicy.AGGRESSIVE
+
+
+class PromptRegistry:
+    """Registry for prompt templates."""
+
+    def __init__(self) -> None:
+        self._templates: Dict[Tuple[str, Optional[str]], PromptTemplate] = {}
+
+    def register(self, template: PromptTemplate) -> None:
+        """Register or overwrite a prompt template."""
+
+        key = (template.role, template.task_key)
+        self._templates[key] = template
+
+    def get(self, role: str, task_key: Optional[str] = None) -> Optional[PromptTemplate]:
+        """Retrieve a template by role and optional task key."""
+
+        return self._templates.get((role, task_key)) or self._templates.get((role, None))
+
+    def list(self, role: Optional[str] = None) -> List[PromptTemplate]:
+        """List registered templates, optionally filtered by role."""
+
+        if role is None:
+            return list(self._templates.values())
+        return [tpl for (r, _), tpl in self._templates.items() if r == role]
+
+    def as_dict(self) -> Dict:
+        """Return a serialisable representation for debugging."""
+
+        result: Dict = {}
+        for (role, task_key), tpl in self._templates.items():
+            result.setdefault(role, {})[task_key or "default"] = asdict(tpl)
+        return result
+
+
+# Global registry seeded with initial templates ---------------------------------
+registry = PromptRegistry()
+
+registry.register(
+    PromptTemplate(
+        id="planner",
+        version="v1",
+        role="Planner",
+        task_key=None,
+        system="You are the planning agent responsible for drafting project plans.",
+        user_template="Develop a plan for the following goal: {task}",
+        io_schema_ref="dr_rd/schemas/planner_v1.json",
+        retrieval_policy=RetrievalPolicy.LIGHT,
+        provider_hints={
+            "openai": {"json_mode": True, "tool_choice": "auto"},
+            "anthropic": {"tool_choice": "auto"},
+        },
+    )
+)
+
+registry.register(
+    PromptTemplate(
+        id="research",
+        version="v1",
+        role="Research Scientist",
+        task_key=None,
+        system="You are a research scientist uncovering facts and evidence.",
+        user_template="Investigate the following question: {task}",
+        io_schema_ref="dr_rd/schemas/research_v1.json",
+        retrieval_policy=RetrievalPolicy.AGGRESSIVE,
+        provider_hints={
+            "openai": {"json_mode": True, "tool_choice": "auto"},
+            "anthropic": {"tool_choice": "auto"},
+        },
+    )
+)
+
+registry.register(
+    PromptTemplate(
+        id="synthesizer",
+        version="v1",
+        role="Synthesizer",
+        task_key=None,
+        system="You synthesize plans and findings into coherent summaries.",
+        user_template="Summarize the following materials: {task}",
+        io_schema_ref="dr_rd/schemas/synthesizer_v1.json",
+        retrieval_policy=RetrievalPolicy.NONE,
+        provider_hints={
+            "openai": {"json_mode": True, "tool_choice": "auto"},
+            "anthropic": {"tool_choice": "auto"},
+        },
+    )
+)

--- a/dr_rd/schemas/planner_v1.json
+++ b/dr_rd/schemas/planner_v1.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Planner V1",
+  "type": "object",
+  "properties": {
+    "plan_id": {"type": "string"},
+    "tasks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "title": {"type": "string"},
+          "desc": {"type": "string"},
+          "role_hint": {"type": "string"}
+        },
+        "required": ["title", "desc"],
+        "additionalProperties": false
+      }
+    },
+    "constraints": {"type": "string"},
+    "assumptions": {"type": "string"},
+    "metrics": {"type": "string"},
+    "next_steps": {"type": "string"}
+  },
+  "required": ["plan_id", "tasks"],
+  "additionalProperties": false
+}

--- a/dr_rd/schemas/research_v1.json
+++ b/dr_rd/schemas/research_v1.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Research V1",
+  "type": "object",
+  "properties": {
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "claim": {"type": "string"},
+          "evidence": {"type": "string"},
+          "citations": {"type": "array", "items": {"type": "string"}}
+        },
+        "required": ["claim", "evidence"],
+        "additionalProperties": false
+      }
+    },
+    "gaps": {"type": "string"},
+    "risks": {"type": "string"},
+    "next_steps": {"type": "string"},
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string"},
+          "title": {"type": "string"},
+          "url": {"type": "string"}
+        },
+        "required": ["id", "title"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["findings", "sources"],
+  "additionalProperties": false
+}

--- a/dr_rd/schemas/synthesizer_v1.json
+++ b/dr_rd/schemas/synthesizer_v1.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Synthesizer V1",
+  "type": "object",
+  "properties": {
+    "summary": {"type": "string"},
+    "key_points": {"type": "array", "items": {"type": "string"}},
+    "contradictions": {"type": "array", "items": {"type": "string"}},
+    "confidence": {"type": "number"},
+    "sources": {"type": "array", "items": {"type": "string"}}
+  },
+  "required": ["summary", "key_points"],
+  "additionalProperties": false
+}

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-28T20:11:14.953045Z'
-git_sha: 4240f5e7b47a8e8be43c529ae2a1624b26b63bdb
+generated_at: '2025-08-28T20:29:14.493707Z'
+git_sha: 9e7fb171c0902fddee4791ffe81bfecdcb4ef73a
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -149,14 +149,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/qa_router.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/spec_builder.py
+- path: orchestrators/app_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -170,7 +163,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
+- path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -184,8 +177,8 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/__init__.py
-  role: Summarization
+- path: orchestrators/qa_router.py
+  role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
@@ -199,6 +192,13 @@ modules:
   invoked_by: []
   invokes: []
 - path: core/summarization/integrator.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_prompt_registry.py
+++ b/tests/test_prompt_registry.py
@@ -1,0 +1,50 @@
+import pytest
+
+from dr_rd.prompting import PromptRegistry, PromptTemplate, RetrievalPolicy
+
+
+def test_register_get_list():
+    registry = PromptRegistry()
+    tpl = PromptTemplate(
+        id="demo",
+        version="v1",
+        role="Demo",
+        task_key=None,
+        system="sys",
+        user_template="user",
+        io_schema_ref="schema.json",
+        retrieval_policy=RetrievalPolicy.NONE,
+    )
+    registry.register(tpl)
+    assert registry.get("Demo") == tpl
+    assert registry.list("Demo") == [tpl]
+    assert registry.list() == [tpl]
+
+
+def test_version_overwrite():
+    registry = PromptRegistry()
+    tpl1 = PromptTemplate(
+        id="demo",
+        version="v1",
+        role="Demo",
+        task_key=None,
+        system="s1",
+        user_template="u1",
+        io_schema_ref="schema.json",
+        retrieval_policy=RetrievalPolicy.NONE,
+    )
+    tpl2 = PromptTemplate(
+        id="demo",
+        version="v2",
+        role="Demo",
+        task_key=None,
+        system="s2",
+        user_template="u2",
+        io_schema_ref="schema.json",
+        retrieval_policy=RetrievalPolicy.NONE,
+    )
+    registry.register(tpl1)
+    registry.register(tpl2)
+    retrieved = registry.get("Demo")
+    assert retrieved.version == "v2"
+    assert retrieved.system == "s2"


### PR DESCRIPTION
## Summary
- introduce `PromptRegistry` with `PromptTemplate` dataclass and `RetrievalPolicy` enum
- seed templates for Planner, Research Scientist, and Synthesizer
- add `PromptFactory` that injects JSON guardrails, retrieval policy metadata, and provider hints
- add JSON I/O schemas for `planner_v1`, `research_v1`, and `synthesizer_v1`
- document prompting rules in [docs/PROMPT_STANDARDS.md](docs/PROMPT_STANDARDS.md)

## Testing
- `pytest tests/test_prompt_registry.py tests/test_prompt_factory.py`
- `python scripts/generate_repo_map.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0bb349b60832cb883fd1566561dc3