### PR TITLE
Security: Supply Chain — Part 4 of 8 (Reproducible Builds & Repro Check)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ runs/
 outputs/
 qa_queue.json
 *.cache
+
+/build/
+/dist/
+/*.egg-info/
+/reports/build/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: init lint type test cov perf docs map repo-map repo-validate audit audit-tests lock licenses sbom
+.PHONY: init lint type test cov perf docs map repo-map repo-validate audit audit-tests lock licenses sbom build repro
 
 init:
 	pip install -e .[dev]
@@ -48,4 +48,10 @@ audit:
 	python scripts/gate_pip_audit.py --input reports/pip-audit.json
 
 sbom:
-	python scripts/gen_sbom.py
+        python scripts/gen_sbom.py
+
+build:
+        python scripts/build_artifacts.py
+
+repro:
+        python scripts/repro_check.py

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-29T00:19:26.728009Z from commit 8e2a8b5_
+_Last generated at 2025-08-29T00:29:46.899138Z from commit 9029436_

--- a/docs/SUPPLY_CHAIN.md
+++ b/docs/SUPPLY_CHAIN.md
@@ -1,0 +1,20 @@
+# Supply Chain
+
+## Reproducible Builds
+To make release artifacts deterministic we build under a fixed environment:
+
+- `SOURCE_DATE_EPOCH`
+- `PYTHONHASHSEED=0`
+- `TZ=UTC`
+- `LC_ALL=C`
+- `LANG=C`
+
+Run `make build` to produce the sdist and wheel. The script writes
+`reports/build/build_manifest.json` containing the commit, source date
+epoch, and the SHA256 hash and size of each artifact.
+
+`make repro` builds the project twice in isolated work directories with the
+same deterministic environment. It compares the resulting artifact hashes
+and writes `reports/build/repro_report.json`. If the hashes differ the script
+normalizes archives and compares their contents; mismatches are reported but do
+not fail the command. Gating will be introduced in a later phase.

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-29T00:19:26.728009Z'
-git_sha: 8e2a8b5ef566da1587a040f9d0e615e5be6a6ac3
+generated_at: '2025-08-29T00:29:46.899138Z'
+git_sha: 90294368427783352b3f206b29827cfdac4a8379
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -184,20 +184,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/plan_utils.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/qa_router.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/__init__.py
   role: Orchestrator
   responsibilities: []
@@ -205,7 +191,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/spec_builder.py
+- path: orchestrators/plan_utils.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -219,14 +205,28 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/schemas.py
-  role: Summarization
+- path: orchestrators/spec_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/qa_router.py
+  role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
 - path: core/summarization/__init__.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/scripts/build_artifacts.py
+++ b/scripts/build_artifacts.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Build deterministic Python artifacts and record hashes."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def get_source_date_epoch() -> int:
+    """Return SOURCE_DATE_EPOCH from git or current time."""
+    try:
+        result = subprocess.run(
+            ["git", "log", "-1", "--pretty=%ct"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return int(result.stdout.strip())
+    except Exception:
+        return int(time.time())
+
+
+def sha256sum(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def clean(path: Path) -> None:
+    if path.exists():
+        shutil.rmtree(path)
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    epoch = get_source_date_epoch()
+    env = os.environ.copy()
+    env.update(
+        {
+            "SOURCE_DATE_EPOCH": str(epoch),
+            "PYTHONHASHSEED": "0",
+            "TZ": "UTC",
+            "LC_ALL": "C",
+            "LANG": "C",
+        }
+    )
+    os.environ.update(env)
+    if hasattr(time, "tzset"):
+        time.tzset()
+
+    dist_dir = repo_root / "dist"
+    build_dir = repo_root / "build"
+    clean(dist_dir)
+    clean(build_dir)
+
+    try:
+        subprocess.run(
+            [sys.executable, "-m", "build", "--sdist", "--wheel"],
+            check=True,
+            env=env,
+        )
+    except subprocess.CalledProcessError as exc:
+        print("build failed", file=sys.stderr)
+        return exc.returncode
+
+    artifacts = []
+    for file in sorted(dist_dir.iterdir()):
+        if file.is_file():
+            artifacts.append(
+                {
+                    "path": f"dist/{file.name}",
+                    "sha256": sha256sum(file),
+                    "bytes": file.stat().st_size,
+                }
+            )
+
+    reports_dir = repo_root / "reports" / "build"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"], capture_output=True, text=True, check=False
+    ).stdout.strip()
+    manifest = {
+        "commit": commit,
+        "source_date_epoch": epoch,
+        "artifacts": artifacts,
+    }
+    (reports_dir / "build_manifest.json").write_text(json.dumps(manifest, indent=2))
+
+    for art in artifacts:
+        print(f"{art['path']}: sha256={art['sha256']} bytes={art['bytes']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/repro_check.py
+++ b/scripts/repro_check.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Check build reproducibility by building twice and comparing artifacts."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import time
+import zipfile
+from pathlib import Path
+
+
+def get_source_date_epoch() -> int:
+    try:
+        result = subprocess.run(
+            ["git", "log", "-1", "--pretty=%ct"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return int(result.stdout.strip())
+    except Exception:
+        return int(time.time())
+
+
+def sha256sum(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def copy_tree(src: Path, dst: Path) -> None:
+    shutil.copytree(
+        src,
+        dst,
+        ignore=shutil.ignore_patterns("dist", "build", "reports", ".git"),
+        dirs_exist_ok=True,
+    )
+
+
+def build(dir_path: Path, env: dict[str, str]) -> dict[str, dict[str, int | str]]:
+    subprocess.run(
+        [sys.executable, "-m", "build", "--sdist", "--wheel"],
+        cwd=dir_path,
+        env=env,
+        check=True,
+    )
+    dist = dir_path / "dist"
+    artifacts: dict[str, dict[str, int | str]] = {}
+    for file in sorted(dist.iterdir()):
+        if file.is_file():
+            artifacts[file.name] = {
+                "sha256": sha256sum(file),
+                "bytes": file.stat().st_size,
+            }
+    return artifacts
+
+
+def diff_members(p1: Path, p2: Path) -> dict[str, list[str]]:
+    if p1.suffix == ".whl" or p1.suffix.endswith(".zip"):
+        with zipfile.ZipFile(p1) as z1, zipfile.ZipFile(p2) as z2:
+            m1 = {n: hashlib.sha256(z1.read(n)).hexdigest() for n in sorted(z1.namelist()) if not n.endswith("/")}
+            m2 = {n: hashlib.sha256(z2.read(n)).hexdigest() for n in sorted(z2.namelist()) if not n.endswith("/")}
+    else:
+        with tarfile.open(p1, "r:*") as t1, tarfile.open(p2, "r:*") as t2:
+            m1 = {}
+            for m in t1.getmembers():
+                if m.isfile():
+                    f = t1.extractfile(m)
+                    if f:
+                        m1[m.name] = hashlib.sha256(f.read()).hexdigest()
+            m2 = {}
+            for m in t2.getmembers():
+                if m.isfile():
+                    f = t2.extractfile(m)
+                    if f:
+                        m2[m.name] = hashlib.sha256(f.read()).hexdigest()
+    missing1 = sorted(set(m2) - set(m1))
+    missing2 = sorted(set(m1) - set(m2))
+    differing = sorted(name for name in set(m1) & set(m2) if m1[name] != m2[name])
+    return {
+        "missing_in_build1": missing1,
+        "missing_in_build2": missing2,
+        "differing": differing,
+    }
+
+
+def main() -> int:
+    repo_root = Path.cwd()
+    reports_dir = repo_root / "reports" / "build"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+
+    epoch = get_source_date_epoch()
+    env = os.environ.copy()
+    env.update(
+        {
+            "SOURCE_DATE_EPOCH": str(epoch),
+            "PYTHONHASHSEED": "0",
+            "TZ": "UTC",
+            "LC_ALL": "C",
+            "LANG": "C",
+        }
+    )
+
+    report: dict[str, object]
+    try:
+        with tempfile.TemporaryDirectory() as d1, tempfile.TemporaryDirectory() as d2:
+            copy_tree(repo_root, Path(d1))
+            copy_tree(repo_root, Path(d2))
+            arts1 = build(Path(d1), env)
+            arts2 = build(Path(d2), env)
+
+            artifacts_report = []
+            deterministic = arts1 == arts2
+            normalized_pass = True
+            if deterministic:
+                for name, info in sorted(arts1.items()):
+                    artifacts_report.append(
+                        {
+                            "path": f"dist/{name}",
+                            "sha256": info["sha256"],
+                            "bytes": info["bytes"],
+                        }
+                    )
+                report = {"deterministic": True, "artifacts": artifacts_report}
+            else:
+                all_names = sorted(set(arts1) | set(arts2))
+                for name in all_names:
+                    entry = {"path": f"dist/{name}"}
+                    a1 = arts1.get(name)
+                    a2 = arts2.get(name)
+                    if a1:
+                        entry["build1"] = a1
+                    if a2:
+                        entry["build2"] = a2
+                    if a1 and a2 and a1["sha256"] == a2["sha256"]:
+                        entry["matches"] = True
+                    else:
+                        entry["matches"] = False
+                        if a1 and a2:
+                            diff = diff_members(Path(d1) / "dist" / name, Path(d2) / "dist" / name)
+                            entry["member_diffs"] = diff
+                            if (
+                                diff["missing_in_build1"]
+                                or diff["missing_in_build2"]
+                                or diff["differing"]
+                            ):
+                                normalized_pass = False
+                        else:
+                            normalized_pass = False
+                    artifacts_report.append(entry)
+                report = {
+                    "deterministic": False,
+                    "normalized_pass": normalized_pass,
+                    "artifacts": artifacts_report,
+                }
+    except subprocess.CalledProcessError as exc:
+        report = {"deterministic": False, "error": f"build failed: {exc}"}
+        print("reproducibility check failed: build error")
+
+    (reports_dir / "repro_report.json").write_text(json.dumps(report, indent=2))
+    if report.get("deterministic"):
+        print("reproducible build: hashes match")
+    else:
+        print("reproducible build: mismatch")
+        if report.get("normalized_pass"):
+            print("normalized contents match")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `build_artifacts.py` to produce deterministic sdists and wheels along with a build manifest
- introduce `repro_check.py` to build twice under a fixed environment and compare hashes
- wire up new `build` and `repro` make targets, document usage, and ignore build output

## Testing
- `python scripts/build_artifacts.py`
- `python scripts/repro_check.py`
- `pytest -q` *(fails: IndentationError in app/agent_trace_ui.py)*
- `python scripts/generate_repo_map.py`

------
https://chatgpt.com/codex/tasks/task_e_68b0f3a30288832c894a8bbf15f4a01b