### PR TITLE
Security: Supply Chain — Part 6 of 8 (Secret & Leak Scanning with Gitleaks)

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,10 +1,35 @@
 name: secret-scan
-on: [push, pull_request]
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'
+
+env:
+  GITLEAKS_ALLOW_FINDINGS: "0"
+
 jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gitleaks/gitleaks-action@v2
+      - name: Create reports directory
+        run: mkdir -p reports
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@v2
         with:
-          args: "--no-banner detect -v"
+          args: --source . --verbose --redact --config=.gitleaks.toml --report-format sarif --report-path reports/gitleaks.sarif
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: ${{ env.GITLEAKS_ALLOW_FINDINGS == '1' }}
+      - name: Upload SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: reports/gitleaks.sarif
+      - name: Upload Gitleaks report
+        uses: actions/upload-artifact@v4
+        with:
+          name: gitleaks-sarif
+          path: reports/gitleaks.sarif

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ qa_queue.json
 /dist/
 /*.egg-info/
 /reports/build/
+reports/gitleaks.*
+*.sarif

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,29 @@
+title = "gitleaks config"
+
+[extend]
+  default = true
+
+[allowlist]
+  description = "Allowlist for paths and patterns"
+  paths = [
+    '^sbom/',
+    '^reports/',
+    '^dist/',
+    '^build/',
+    '^\.venv/',
+    '^node_modules/',
+    '^docs/assets/',
+    '^samples/',
+    '^.*\.egg-info/'
+  ]
+  regexes = [
+    "(?i)(dummy|example|sample|test)(_)?(token|key|secret)[:=][\\s\"']?[A-Za-z0-9_\\-]{6,}",
+    "https?://(?:localhost|127\\.0\\.0\\.1)(?::\\d{2,5})?",
+    "[\\w.+-]+@example\\.com",
+    "[\\w.+-]+@test\\.local"
+  ]
+  commits = []
+  # Add commit SHAs to allowlist specific historical false positives
+
+[general]
+  redact = true

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,11 @@ audit:
 sbom:
         python scripts/gen_sbom.py
 
+secrets-scan:
+        mkdir -p reports
+        gitleaks detect --source . --redact --config=.gitleaks.toml --report-format sarif --report-path reports/gitleaks.sarif
+        @echo "Gitleaks report written to reports/gitleaks.sarif"
+
 build:
         python scripts/build_artifacts.py
 

--- a/docs/OPEN_SOURCE_POLICY.md
+++ b/docs/OPEN_SOURCE_POLICY.md
@@ -19,3 +19,13 @@ This project follows a simple open-source license policy.
 - GPL-3.0 (unless an explicit written exemption is granted)
 
 All dependencies must be pinned via `*.lock.txt` files with hashes.
+
+## Secret Scanning
+We use [Gitleaks](https://github.com/gitleaks/gitleaks) to prevent committing secrets.
+The default CI workflow blocks on any findings. In exceptional cases, set
+`GITLEAKS_ALLOW_FINDINGS=1` to allow the workflow to pass, and include a
+justification in the pull request description.
+
+To extend the allowlist in `.gitleaks.toml`, add entries under
+`[allowlist].paths` for additional directories, `regexes` for safe patterns, or
+populate the `commits` array with specific SHAs for historical false positives.

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-29T00:37:27.438395Z from commit 43def92_
+_Last generated at 2025-08-29T00:44:45.666785Z from commit b858996_

--- a/docs/SUPPLY_CHAIN.md
+++ b/docs/SUPPLY_CHAIN.md
@@ -18,3 +18,10 @@ same deterministic environment. It compares the resulting artifact hashes
 and writes `reports/build/repro_report.json`. If the hashes differ the script
 normalizes archives and compares their contents; mismatches are reported but do
 not fail the command. Gating will be introduced in a later phase.
+
+## Secret Scanning
+The `secret-scan` workflow runs [Gitleaks](https://github.com/gitleaks/gitleaks)
+on every push, pull request, manual trigger, and a weekly schedule. Findings are
+uploaded as SARIF to GitHub Code Scanning and preserved as workflow artifacts.
+Run `make secrets-scan` locally to generate `reports/gitleaks.sarif` before
+opening a pull request.

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-29T00:37:27.438395Z'
-git_sha: 43def927efa0aaf97ae969d6ed2695a8dee3415e
+generated_at: '2025-08-29T00:44:45.666785Z'
+git_sha: b858996bd60cb16e24da07480c9983c428a40ce4 # pragma: allowlist secret
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -191,14 +191,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
+- path: orchestrators/plan_utils.py
   role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/plan_utils.py
+- path: orchestrators/qa_router.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -212,7 +212,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/qa_router.py
+- path: orchestrators/app_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -233,14 +233,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/schemas.py
+- path: core/summarization/integrator.py
   role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
+- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []


### PR DESCRIPTION
## Summary
- add `.gitleaks.toml` with redaction and allowlists for benign paths, placeholders, and commit overrides
- introduce `secret-scan` workflow uploading SARIF results and artifacts with override env for exceptional cases
- wire `secrets-scan` Makefile target and document secret scanning policy and workflow references

## Testing
- `python scripts/generate_repo_map.py`
- `gitleaks detect --source . --redact --config=.gitleaks.toml --report-format sarif --report-path reports/gitleaks.sarif`
- `pre-commit run --files .gitleaks.toml .github/workflows/secret-scan.yml .gitignore Makefile docs/OPEN_SOURCE_POLICY.md docs/SUPPLY_CHAIN.md repo_map.yaml docs/REPO_MAP.md`

------
https://chatgpt.com/codex/tasks/task_e_68b0f78fc87c832cb7f1734f004ddfc5