### PR TITLE
Chore: Housekeeping — Stale Code & Dead‑Link Scans, Badges, Contributor/Security Docs, and Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,25 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug] "
+labels: [bug]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What's wrong?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I have searched existing issues
+        - label: I can reproduce with latest main

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,23 @@
+name: Feature Request
+description: Suggest an idea
+title: "[Feature] "
+labels: [enhancement]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What would you like to see?
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why is this feature needed?
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I have searched existing issues

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,8 +2,8 @@
 
 - [ ] `pre-commit run --files <files>`
 - [ ] `make lint type test`
-- [ ] Coverage collected with `make cov`
-- [ ] Performance within thresholds (`make perf`)
+- [ ] Performance baseline collected (`make perf`) if applicable
 - [ ] `python scripts/validate_config_lock.py`
-- [ ] `make map` committed `repo_map.yaml` and `docs/REPO_MAP.md`
-- [ ] Demo scripts executed
+- [ ] `make repo-map` committed `repo_map.yaml` and `docs/REPO_MAP.md`
+- [ ] Documentation updated and links added
+- [ ] Security review completed (if applicable)

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,5 @@
+core/*: [core]
+dr_rd/*: [dr_rd]
+docs/*: [docs]
+app/*: [app]
+tests/*: [tests]

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -16,8 +16,7 @@ jobs:
         run: |
           python -m pip install -U pip
           pip install -e .[dev]
-          pip install markdown-link-check
-      - name: Link check
-        run: markdown-link-check docs/INDEX.md
+      - name: Dead link check
+        run: python scripts/dead_link_check.py
       - name: Lint docs
         run: python -m scripts.lint_docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,24 @@ jobs:
         run: python scripts/gen_sbom.py
       - name: Reproducibility report
         run: python scripts/repro_check.py || true
+      - name: Stale code scan
+        run: python scripts/stale_code_scan.py --json-output reports/stale_code.json
+      - name: Upload stale code report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stale-code-${{ matrix.python }}
+          path: reports/stale_code.json
+          if-no-files-found: ignore
+      - name: Unused dependency scan
+        run: python scripts/unused_deps_scan.py --json-output reports/unused_deps.json
+      - name: Upload unused dependency report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unused-deps-${{ matrix.python }}
+          path: reports/unused_deps.json
+          if-no-files-found: ignore
       - name: Upload reports
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,18 @@
+name: Close Stale Issues
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 60
+          days-before-close: 14
+          stale-issue-label: stale
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          # stale-pr-message: ''
+          # stale-issue-message: ''

--- a/.github/workflows/triage-labeler.yml
+++ b/.github/workflows/triage-labeler.yml
@@ -1,0 +1,13 @@
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,11 @@ repos:
       - id: detect-secrets
         args: ["--baseline", ".secrets.baseline"]
         exclude: config/config.lock.json
+  - repo: local
+    hooks:
+      - id: dead-link-check
+        name: dead-link-check
+        entry: python scripts/dead_link_check.py --internal-only
+        language: system
+        pass_filenames: true
+        files: \.(md)$

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,77 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at security@example.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1.
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+
+Thanks for considering a contribution. See [docs/CONTRIBUTING_QUICKSTART.md](docs/CONTRIBUTING_QUICKSTART.md) for the fastest path to your first PR.
+
+## Development flow
+- Install deps with `make init`.
+- Run `make lint type test` before pushing.
+- Regenerate the repo map with `make repo-map` when code moves.
+- Use `pre-commit run --files <files>` for formatting and link checks.
+- Keep commits focused and reference issues when applicable.
+- Run demos offline with `python scripts/demo_run.py`.
+
+## Commit style
+- Use conventional commits when possible.
+- Include tests for new behavior.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: init lint type test cov perf docs map repo-map repo-validate audit audit-tests lock licenses sbom build repro supply-chain release-check release-checklist
+.PHONY: init lint type test cov perf docs map repo-map repo-validate audit audit-tests lock licenses sbom build repro supply-chain release-check release-checklist gtm housekeeping
 
 init:
 	pip install -e .[dev]
@@ -78,7 +78,12 @@ release-checklist:
         @echo "release"
 
 gtm:
-	STAMP=$$(date +%Y%m%d_%H%M%S); \
-	python scripts/demo_run.py --flow all --out samples/runs/$$STAMP --flags RAG_ENABLED=0,EVALUATORS_ENABLED=1; \
-	python scripts/snapshots.py --runs samples/runs/$$STAMP --out docs/assets/screens; \
-	python scripts/generate_deck.py --outline docs/templates/deck_outline.yaml --shots docs/assets/screens --out docs/kits
+        STAMP=$$(date +%Y%m%d_%H%M%S); \
+        python scripts/demo_run.py --flow all --out samples/runs/$$STAMP --flags RAG_ENABLED=0,EVALUATORS_ENABLED=1; \
+        python scripts/snapshots.py --runs samples/runs/$$STAMP --out docs/assets/screens; \
+        python scripts/generate_deck.py --outline docs/templates/deck_outline.yaml --shots docs/assets/screens --out docs/kits
+
+housekeeping:
+        python scripts/stale_code_scan.py
+        python scripts/dead_link_check.py --internal-only
+        python scripts/generate_repo_map.py

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # AI R&D Center (Streamlit)
 
-[![tests](https://github.com/clcriswell/DR-RD/actions/workflows/test.yml/badge.svg)](https://github.com/clcriswell/DR-RD/actions/workflows/test.yml)
-[![secret-scan](https://github.com/clcriswell/DR-RD/actions/workflows/secret-scan.yml/badge.svg)](https://github.com/clcriswell/DR-RD/actions/workflows/secret-scan.yml)
+[![Build CI](https://github.com/clcriswell/DR-RD/actions/workflows/ci.yml/badge.svg)](https://github.com/clcriswell/DR-RD/actions/workflows/ci.yml)
+[![Tests](https://github.com/clcriswell/DR-RD/actions/workflows/test.yml/badge.svg)](https://github.com/clcriswell/DR-RD/actions/workflows/test.yml)
+[![Coverage](https://img.shields.io/badge/coverage-unknown-lightgrey.svg)](docs/BADGES.md#coverage)
+[![License](https://img.shields.io/github/license/clcriswell/DR-RD)](LICENSE)
+[![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-blue)](https://www.python.org/)
+[![Code style: Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Lint: Ruff](https://img.shields.io/badge/lint-ruff-46A2F1.svg)](https://github.com/astral-sh/ruff)
 
 A public Streamlit application that masks a user’s idea, decomposes it into
 multi-disciplinary research tasks, and orchestrates AI agents to synthesize a

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+If you discover a vulnerability, please email security@example.com.
+
+Supported versions: latest `main` branch.
+
+We aim to acknowledge reports within 72 hours and provide a fix or mitigation within 30 days.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,5 @@
+# Support
+
+Questions and issues are tracked through GitHub issues. Search existing issues before filing a new one.
+
+For common questions see the [docs index](docs/INDEX.md).

--- a/docs/BADGES.md
+++ b/docs/BADGES.md
@@ -1,0 +1,13 @@
+# Badges
+
+Explanation of repository badges and their sources.
+
+| Badge | Source |
+|-------|--------|
+| Build CI | GitHub Actions workflow [ci.yml](../.github/workflows/ci.yml) |
+| Tests | GitHub Actions workflow [test.yml](../.github/workflows/test.yml) |
+| Coverage | Generated via coverage reports (placeholder) |
+| License | Repository license (if present) |
+| Python | Supported Python versions (3.10–3.12) |
+| Code style: Black | [psf/black](https://github.com/psf/black) |
+| Lint: Ruff | [astral-sh/ruff](https://github.com/astral-sh/ruff) |

--- a/docs/CONTRIBUTING_QUICKSTART.md
+++ b/docs/CONTRIBUTING_QUICKSTART.md
@@ -1,0 +1,9 @@
+# Contributing Quickstart
+
+1. Clone the repo and create a virtual environment.
+2. Run `make init` to install dependencies and pre-commit hooks.
+3. Create a feature branch and make changes.
+4. Run `pre-commit run --files <files>`.
+5. Run `make lint type test`.
+6. Regenerate the repo map with `make repo-map`.
+7. Open a pull request.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -39,3 +39,8 @@ Quick links to core documentation:
 - [Enterprise Deployment](ENTERPRISE_DEPLOY.md)
 - [Helm Quickstart](HELM_QUICKSTART.md)
 - [Slack, Teams & Jira Integrations](INTEGRATIONS_SLACK_TEAMS_JIRA.md)
+- [Contributing Guide](../CONTRIBUTING.md)
+- [Code of Conduct](../CODE_OF_CONDUCT.md)
+- [Security Policy](../SECURITY.md)
+- [Support](../SUPPORT.md)
+- [Badges](BADGES.md)

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-29T02:50:54.946659Z from commit fe22b1a_
+_Last generated at 2025-08-29T23:40:05.143935Z from commit 74c8793_

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-29T02:50:54.946659Z'
-git_sha: fe22b1ad4a48f10a7b7ac18310f64adfee07f6d7
+generated_at: '2025-08-29T23:40:05.143935Z'
+git_sha: 74c87935483139af5bb6d87dddba3518a922c37f
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -184,13 +184,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/spec_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/plan_utils.py
   role: Orchestrator
   responsibilities: []
@@ -199,6 +192,13 @@ modules:
   invoked_by: []
   invokes: []
 - path: orchestrators/__init__.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -226,13 +226,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/__init__.py
-  role: Summarization
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
@@ -241,6 +234,13 @@ modules:
   invoked_by: []
   invokes: []
 - path: core/summarization/role_summarizer.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/scripts/dead_link_check.py
+++ b/scripts/dead_link_check.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Scan markdown files for dead links."""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import re
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+import requests
+
+LINK_RE = re.compile(r"\[.+?\]\(([^)]+)\)")
+HEADER_RE = re.compile(r"^(#+)\s+(.*)", re.MULTILINE)
+
+
+def slugify(text: str) -> str:
+    text = re.sub(r"[^A-Za-z0-9\- ]", "", text).lower().strip()
+    return re.sub(r"\s+", "-", text)
+
+
+def extract_links(text: str) -> Sequence[str]:
+    return LINK_RE.findall(text)
+
+
+def extract_anchors(text: str) -> set[str]:
+    return {slugify(m[1]) for m in HEADER_RE.findall(text)}
+
+
+def check_internal(link: str, current: Path) -> tuple[bool, str]:
+    target, anchor = (link.split("#", 1) + [""])[0:2]
+    target_path = (current.parent / target).resolve()
+    if not target_path.exists():
+        return False, f"missing file: {target}"
+    if anchor:
+        anchors = extract_anchors(target_path.read_text())
+        if slugify(anchor) not in anchors:
+            return False, f"missing anchor: {anchor}"
+    return True, ""
+
+
+def head(url: str) -> int:
+    try:
+        resp = requests.head(url, allow_redirects=True, timeout=5)
+        return resp.status_code
+    except Exception:
+        return 0
+
+
+def check_links(
+    files: Iterable[Path],
+    allowlist: set[str] | None = None,
+    denylist: set[str] | None = None,
+    internal_only: bool = False,
+) -> dict:
+    allowlist = allowlist or set()
+    denylist = denylist or set()
+    internal_errors: list[dict] = []
+    external_warnings: list[dict] = []
+    external_candidates: list[tuple[str, Path]] = []
+    for file in files:
+        text = Path(file).read_text()
+        for link in extract_links(text):
+            if link.startswith("http://") or link.startswith("https://"):
+                if internal_only:
+                    continue
+                domain = re.sub(r"^https?://([^/]+).*", r"\1", link)
+                if allowlist and domain not in allowlist:
+                    continue
+                if denylist and domain in denylist:
+                    continue
+                external_candidates.append((link, Path(file)))
+            else:
+                ok, reason = check_internal(link, Path(file))
+                if not ok:
+                    internal_errors.append({"file": str(file), "link": link, "reason": reason})
+    if not internal_only and external_candidates:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=5) as ex:
+            futures = {ex.submit(head, url): (url, file) for url, file in external_candidates}
+            for fut in concurrent.futures.as_completed(futures):
+                url, file = futures[fut]
+                status = fut.result()
+                if status in {404, 429} or status >= 500 or status == 0:
+                    external_warnings.append({"file": str(file), "url": url, "status": status})
+    return {"internal_errors": internal_errors, "external_warnings": external_warnings}
+
+
+def find_markdown_files() -> list[Path]:
+    files = [Path("README.md")] + list(Path(".").glob("*.md")) + list(Path("docs").rglob("*.md"))
+    return sorted({p.resolve() for p in files if p.exists()})
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check markdown for dead links.")
+    parser.add_argument("files", nargs="*")
+    parser.add_argument("--internal-only", action="store_true")
+    parser.add_argument("--allowlist", default="")
+    parser.add_argument("--denylist", default="")
+    parser.add_argument("--json-output", default="dead_links.json")
+    args = parser.parse_args()
+
+    files = [Path(f) for f in args.files] if args.files else find_markdown_files()
+    allow = {d for d in args.allowlist.split(",") if d}
+    deny = {d for d in args.denylist.split(",") if d}
+    results = check_links(files, allow, deny, args.internal_only)
+    Path(args.json_output).write_text(json.dumps(results, indent=2))
+    print(json.dumps(results, indent=2))
+    if results["internal_errors"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/stale_code_scan.py
+++ b/scripts/stale_code_scan.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Detect potentially stale Python modules and files."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+from collections import defaultdict
+from collections.abc import Iterable
+from pathlib import Path
+
+import yaml
+
+IGNORED_DIRS = {"tests", "examples"}
+
+
+def iter_py_files(dirs: Iterable[Path]) -> Iterable[Path]:
+    for base in dirs:
+        for path in Path(base).rglob("*.py"):
+            if any(part in IGNORED_DIRS for part in path.parts):
+                continue
+            yield path
+
+
+def module_name_from_path(path: Path, root: Path) -> str:
+    rel = path.relative_to(root).with_suffix("")
+    return ".".join(rel.parts)
+
+
+def build_import_graph(
+    files: Iterable[Path], root: Path
+) -> tuple[dict[Path, set[Path]], dict[str, Path]]:
+    module_map: dict[str, Path] = {}
+    graph: dict[Path, set[Path]] = defaultdict(set)
+    for file in files:
+        mod_name = module_name_from_path(file, root)
+        module_map[mod_name] = file
+    for file in files:
+        try:
+            tree = ast.parse(file.read_text())
+        except Exception:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for n in node.names:
+                    base = n.name.split(".")[0]
+                    if base in module_map:
+                        graph[module_map[base]].add(file)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                base = node.module.split(".")[0]
+                if base in module_map:
+                    graph[module_map[base]].add(file)
+    return graph, module_map
+
+
+def load_repo_map(repo_map_path: str) -> set[str]:
+    try:
+        data = yaml.safe_load(Path(repo_map_path).read_text())
+    except FileNotFoundError:
+        return set()
+    modules = set()
+    for mod in data.get("modules", []):
+        path = mod.get("path") if isinstance(mod, dict) else mod
+        modules.add(Path(path).as_posix())
+    return modules
+
+
+def find_empty_packages(dirs: Iterable[Path], root: Path) -> list[str]:
+    empty: list[str] = []
+    for base in dirs:
+        for init in Path(base).rglob("__init__.py"):
+            if any(part in IGNORED_DIRS for part in init.parts):
+                continue
+            pkg_dir = init.parent
+            py_files = [p for p in pkg_dir.glob("*.py") if p.name != "__init__.py"]
+            if not py_files:
+                empty.append(pkg_dir.relative_to(root).as_posix())
+    return empty
+
+
+def scan(dirs: Iterable[Path], repo_map_path: str, root: Path = Path(".")) -> dict[str, list[str]]:
+    files = list(iter_py_files(dirs))
+    graph, module_map = build_import_graph(files, root)
+    incoming: dict[Path, int] = defaultdict(int)
+    for _src, targets in graph.items():
+        for tgt in targets:
+            incoming[tgt] += 1
+    repo_modules = load_repo_map(repo_map_path)
+    unreferenced: list[str] = []
+    for _mod_name, path in module_map.items():
+        rel = path.relative_to(root).as_posix()
+        if rel in repo_modules and incoming[path] == 0:
+            unreferenced.append(rel)
+    orphans = [
+        p.relative_to(root).as_posix()
+        for p in files
+        if p.relative_to(root).as_posix() not in repo_modules
+    ]
+    empty_packages = find_empty_packages(dirs, root)
+    return {
+        "unreferenced_modules": sorted(unreferenced),
+        "orphan_files": sorted(orphans),
+        "empty_packages": sorted(empty_packages),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Detect potentially stale code.")
+    parser.add_argument("--json-output", default="reports/stale_code.json")
+    parser.add_argument("--repo-map", default="repo_map.yaml")
+    parser.add_argument("paths", nargs="*", default=["dr_rd", "core", "app"])
+    args = parser.parse_args()
+
+    root = Path(".")
+    results = scan([Path(p) for p in args.paths], args.repo_map, root)
+    out_path = Path(args.json_output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(results, indent=2))
+    print(json.dumps(results, indent=2))
+    print(f"Stale code scan written to {out_path}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/unused_deps_scan.py
+++ b/scripts/unused_deps_scan.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Report suspected unused dependencies."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+from collections.abc import Iterable
+from pathlib import Path
+
+IGNORED_DIRS = {"tests", "examples"}
+
+
+def iter_py_files(dirs: Iterable[Path]) -> Iterable[Path]:
+    for base in dirs:
+        for path in Path(base).rglob("*.py"):
+            if any(part in IGNORED_DIRS for part in path.parts):
+                continue
+            yield path
+
+
+def collect_imports(files: Iterable[Path]) -> set[str]:
+    modules: set[str] = set()
+    for file in files:
+        try:
+            tree = ast.parse(file.read_text())
+        except Exception:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for n in node.names:
+                    modules.add(n.name.split(".")[0])
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                modules.add(node.module.split(".")[0])
+    return modules
+
+
+def parse_requirements(path: Path) -> set[str]:
+    pkgs: set[str] = set()
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or line.startswith("-e"):
+            continue
+        pkg = re.split(r"[<>=\[]", line, maxsplit=1)[0]
+        pkgs.add(pkg)
+    return pkgs
+
+
+def scan(dirs: Iterable[Path], requirements_file: Path, ignore: set[str]) -> dict:
+    imports = collect_imports(iter_py_files(dirs))
+    reqs = parse_requirements(requirements_file)
+    unused = sorted(pkg for pkg in reqs if pkg not in imports and pkg not in ignore)
+    return {"unused_dependencies": unused}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Detect unused dependencies.")
+    parser.add_argument("--requirements", default=None)
+    parser.add_argument("--json-output", default="reports/unused_deps.json")
+    parser.add_argument("--ignore", default="", help="Comma separated packages to ignore")
+    parser.add_argument("paths", nargs="*", default=["dr_rd", "core", "app"])
+    args = parser.parse_args()
+
+    req_file = (
+        Path(args.requirements)
+        if args.requirements
+        else (
+            Path("requirements.lock.txt")
+            if Path("requirements.lock.txt").exists()
+            else Path("requirements.txt")
+        )
+    )
+    ignore = {p.strip() for p in args.ignore.split(",") if p.strip()}
+    results = scan([Path(p) for p in args.paths], req_file, ignore)
+    out_path = Path(args.json_output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(results, indent=2))
+    print(json.dumps(results, indent=2))
+    print(f"Unused deps report written to {out_path}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/housekeeping/test_dead_link_check.py
+++ b/tests/housekeeping/test_dead_link_check.py
@@ -1,0 +1,19 @@
+import requests
+
+from scripts.dead_link_check import check_links
+
+
+class FakeResp:
+    def __init__(self, status_code):
+        self.status_code = status_code
+
+
+def test_dead_link_check(tmp_path, monkeypatch):
+    doc = tmp_path / "doc.md"
+    doc.write_text("[bad](missing.md)\n[ext](https://example.com/404)\n")
+
+    monkeypatch.setattr(requests, "head", lambda *a, **k: FakeResp(404))
+
+    result = check_links([doc])
+    assert result["internal_errors"]
+    assert result["external_warnings"]

--- a/tests/housekeeping/test_stale_code_scan.py
+++ b/tests/housekeeping/test_stale_code_scan.py
@@ -1,0 +1,13 @@
+from scripts.stale_code_scan import scan
+
+
+def test_reports_orphan_module(tmp_path):
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    orphan = pkg / "orphan.py"
+    orphan.write_text("x = 1\n")
+    repo_map = tmp_path / "repo_map.yaml"
+    repo_map.write_text("modules: []\n")
+    result = scan([pkg], str(repo_map), tmp_path)
+    assert "pkg/orphan.py" in result["orphan_files"]


### PR DESCRIPTION
## Summary
- add `stale_code_scan.py`, `unused_deps_scan.py`, and `dead_link_check.py` with CI wiring and Makefile housekeeping target
- publish contributor, conduct, security, and support docs with badge explanations and README shields
- introduce issue/PR templates, labeler, pre-commit link check, and stale issue workflow; regenerate repo map

## Testing
- `pre-commit run --files .secrets.baseline .github/PULL_REQUEST_TEMPLATE.md .github/workflows/ci-docs.yml .github/workflows/ci.yml .pre-commit-config.yaml Makefile README.md docs/INDEX.md .github/ISSUE_TEMPLATE/bug_report.yml .github/ISSUE_TEMPLATE/feature_request.yml .github/labeler.yml .github/workflows/stale.yml .github/workflows/triage-labeler.yml CODE_OF_CONDUCT.md CONTRIBUTING.md SECURITY.md SUPPORT.md docs/BADGES.md docs/CONTRIBUTING_QUICKSTART.md scripts/dead_link_check.py scripts/stale_code_scan.py scripts/unused_deps_scan.py tests/housekeeping/test_stale_code_scan.py tests/housekeeping/test_dead_link_check.py`
- `pytest tests/housekeeping/test_stale_code_scan.py tests/housekeeping/test_dead_link_check.py -q`
- `python scripts/generate_repo_map.py`

------
https://chatgpt.com/codex/tasks/task_e_68b237e4eaec832cb2ecbfc1947a5111