### PR TITLE
Handle non-dict tasks in role normalizer

### DIFF
--- a/core/role_normalizer.py
+++ b/core/role_normalizer.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-from difflib import get_close_matches
 from collections import Counter
-from typing import Dict, List, Set
+from difflib import get_close_matches
 
 # Map canonical role names to sets of specialist synonyms
-SYNONYMS: Dict[str, Set[str]] = {
+SYNONYMS: dict[str, set[str]] = {
     "Mechanical Systems Lead": {
         "Mechanical Engineer",
         "Manufacturing Engineer",
@@ -61,14 +60,14 @@ SYNONYMS: Dict[str, Set[str]] = {
 }
 
 # Precompute reverse lookup for synonyms (case-insensitive)
-_LOOKUP: Dict[str, str] = {}
+_LOOKUP: dict[str, str] = {}
 for canon, syns in SYNONYMS.items():
     _LOOKUP[canon.lower()] = canon
     for s in syns:
         _LOOKUP[s.lower()] = canon
 
 
-def normalize_role(name: str, allowed_roles: Set[str]) -> str:
+def normalize_role(name: str, allowed_roles: set[str]) -> str:
     """Map a specialist role name to a canonical allowed role.
 
     Parameters
@@ -99,15 +98,17 @@ def normalize_role(name: str, allowed_roles: Set[str]) -> str:
 
 
 def normalize_tasks(
-    tasks: List[Dict],
+    tasks: list[dict],
     *,
-    allowed_roles: Set[str],
+    allowed_roles: set[str],
     max_roles: int | None = None,
-) -> List[Dict]:
+) -> list[dict]:
     """Attach ``normalized_role`` to each task and optionally limit distinct roles."""
 
-    normalized: List[Dict] = []
+    normalized: list[dict] = []
     for t in tasks:
+        if not isinstance(t, dict):
+            t = {"description": str(t)}
         role = str(t.get("role", ""))
         norm = normalize_role(role, allowed_roles)
         normalized.append({**t, "normalized_role": norm})
@@ -123,12 +124,11 @@ def normalize_tasks(
     return normalized
 
 
-def group_by_role(tasks: List[Dict], *, key: str) -> Dict[str, List[Dict]]:
+def group_by_role(tasks: list[dict], *, key: str) -> dict[str, list[dict]]:
     """Group tasks by ``key`` value."""
 
-    grouped: Dict[str, List[Dict]] = {}
+    grouped: dict[str, list[dict]] = {}
     for t in tasks:
         role = t.get(key, "Synthesizer")
         grouped.setdefault(role, []).append(t)
     return grouped
-

--- a/tests/test_role_normalizer.py
+++ b/tests/test_role_normalizer.py
@@ -1,10 +1,8 @@
-import pytest
-
 from core.role_normalizer import (
     SYNONYMS,
+    group_by_role,
     normalize_role,
     normalize_tasks,
-    group_by_role,
 )
 
 ALLOWED = set(SYNONYMS.keys())
@@ -15,17 +13,11 @@ def test_exact_match():
 
 
 def test_synonym_mapping():
-    assert (
-        normalize_role("Mechanical Engineer", ALLOWED)
-        == "Mechanical Systems Lead"
-    )
+    assert normalize_role("Mechanical Engineer", ALLOWED) == "Mechanical Systems Lead"
 
 
 def test_fuzzy_fallback():
-    assert (
-        normalize_role("Reserch Scientst", ALLOWED)
-        == "Research Scientist"
-    )
+    assert normalize_role("Reserch Scientst", ALLOWED) == "Research Scientist"
 
 
 def test_tail_collapse_by_frequency():
@@ -68,3 +60,9 @@ def test_paperclip_plan_grouping():
     grouped = group_by_role(normalized, key="normalized_role")
     assert set(grouped) == {"Mechanical Systems Lead", "Regulatory", "Planner"}
     assert len(grouped["Planner"]) == 2
+
+
+def test_handles_string_tasks():
+    tasks = ["do something"]
+    normalized = normalize_tasks(tasks, allowed_roles=ALLOWED)
+    assert normalized[0]["normalized_role"] == "Synthesizer"


### PR DESCRIPTION
## Summary
- prevent AttributeError in role normalizer by coercing non-dict tasks to dictionaries
- test normalization behavior with string tasks

## Testing
- `pre-commit run --files core/role_normalizer.py tests/test_role_normalizer.py`
- `pytest tests/test_role_normalizer.py`


------
https://chatgpt.com/codex/tasks/task_e_68b24837b0f8832c840060b7891dc438