### PR TITLE
feat: add trace viewer and export helpers

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -10,6 +10,7 @@ import streamlit as st
 from markdown_pdf import MarkdownPdf, Section
 
 from app.ui import components
+from app.ui.trace_viewer import render_trace
 from app.ui_presets import UI_PRESETS
 from config.agent_models import AGENT_MODEL_MAP
 import config.feature_flags as ff
@@ -121,6 +122,8 @@ def main() -> None:
         })
         progress(3, "Run complete")
         st.markdown(final)
+        trace = st.session_state.get("agent_trace", [])
+        render_trace(trace, run_id)
     except Exception as e:  # pragma: no cover - UI display
         log_event({"event": "error_shown", "run_id": run_id, "where": "main", "message": str(e)})
         st.error(str(e))

--- a/app/ui/trace_viewer.py
+++ b/app/ui/trace_viewer.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Sequence
+
+import json
+import streamlit as st
+
+from utils import trace_export
+from utils.telemetry import log_event
+
+PHASE_LABELS = {
+    "planner": "Planner",
+    "executor": "Executor",
+    "synth": "Synthesizer",
+}
+STATUS_ICONS = {"complete": "✅", "error": "⚠️", "running": "⏳"}
+
+
+def _normalize_step(step: Dict[str, Any]) -> Dict[str, Any]:
+    """Best effort adapter for varying trace shapes."""
+    return {
+        "phase": (step.get("phase") or step.get("stage") or "executor").lower(),
+        "name": step.get("name") or step.get("title") or step.get("role") or "step",
+        "status": step.get("status") or ("error" if step.get("error") else "complete"),
+        "started_at": step.get("started_at") or step.get("ts_start"),
+        "ended_at": step.get("ended_at") or step.get("ts_end"),
+        "duration_ms": step.get("duration_ms")
+        or step.get("duration")
+        or (step.get("duration_s", 0) * 1000 if step.get("duration_s") else None),
+        "tokens": step.get("tokens") or step.get("tokens_out") or step.get("tokens_in"),
+        "cost": step.get("cost") or step.get("cost_usd"),
+        "summary": step.get("summary") or step.get("finding") or step.get("output"),
+        "raw": step.get("raw") or step.get("raw_json") or step.get("events"),
+        "step_id": step.get("step_id") or step.get("task_id") or step.get("id"),
+        "error": step.get("error"),
+    }
+
+
+def render_trace(trace: Sequence[Dict[str, Any]], run_id: str | None = None, *, default_view: str = "summary") -> None:
+    steps = [_normalize_step(s) for s in trace]
+    if not steps:
+        st.markdown("### No trace yet")
+        st.caption("Run the pipeline to see step by step output.")
+        return
+
+    total_steps = len(steps)
+
+    view_opts = ["Summary", "Raw", "Both"]
+    view_index = view_opts.index(default_view.capitalize()) if default_view.capitalize() in view_opts else 0
+    view = st.radio("View", view_opts, index=view_index, horizontal=True)
+
+    query = st.text_input("Filter steps", placeholder="Search in name or text…")
+    phase_names = ["All"] + [PHASE_LABELS[p] for p in PHASE_LABELS]
+    jump = st.radio("Jump to", phase_names, horizontal=True, index=0)
+
+    # telemetry for filter changes
+    state_key = "_trace_filter_state"
+    state_val = (view, query, jump)
+    if st.session_state.get(state_key) != state_val:
+        log_event(
+            {
+                "event": "trace_filter_changed",
+                "view": view.lower(),
+                "query_len": len(query),
+                "phase_scope": jump.lower(),
+            }
+        )
+        st.session_state[state_key] = state_val
+
+    expand_key = "_trace_expand"
+    expand_state = st.session_state.get(expand_key) or {p: True for p in PHASE_LABELS}
+    col_a, col_b = st.columns(2)
+    if col_a.button("Expand all"):
+        expand_state = {p: True for p in PHASE_LABELS}
+    if col_b.button("Collapse all"):
+        expand_state = {p: False for p in PHASE_LABELS}
+    if jump != "All":
+        target = [k for k, v in PHASE_LABELS.items() if v == jump][0]
+        expand_state = {p: p == target for p in PHASE_LABELS}
+    st.session_state[expand_key] = expand_state
+
+    # filter steps
+    q = query.lower().strip()
+    filtered_steps: List[Dict[str, Any]] = []
+    for s in steps:
+        haystack = " ".join(
+            [
+                s.get("name", ""),
+                s.get("summary", ""),
+                json.dumps(s.get("raw"), ensure_ascii=False) if isinstance(s.get("raw"), dict) else str(s.get("raw", "")),
+            ]
+        ).lower()
+        if q and q not in haystack:
+            continue
+        filtered_steps.append(s)
+    st.caption(f"{len(filtered_steps)} of {total_steps} steps")
+
+    # export buttons
+    ts = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    base = f"trace_{run_id or 'session'}_{ts}"
+    col_json, col_csv, col_md = st.columns(3)
+    if col_json.download_button(
+        "Download full trace (.json)",
+        data=trace_export.to_json(steps),
+        file_name=f"{base}.json",
+        mime="application/json",
+    ):
+        log_event({"event": "trace_export_clicked", "format": "json", "step_count": len(steps)})
+    if col_csv.download_button(
+        "Download summary (.csv)",
+        data=trace_export.to_csv(steps, run_id=run_id),
+        file_name=f"{base}.csv",
+        mime="text/csv",
+    ):
+        log_event({"event": "trace_export_clicked", "format": "csv", "step_count": len(steps)})
+    if col_md.download_button(
+        "Download readable report (.md)",
+        data=trace_export.to_markdown(steps, run_id=run_id),
+        file_name=f"{base}.md",
+        mime="text/markdown",
+    ):
+        log_event({"event": "trace_export_clicked", "format": "md", "step_count": len(steps)})
+
+    # group and render
+    groups: Dict[str, List[Dict[str, Any]]] = {p: [] for p in PHASE_LABELS}
+    for s in filtered_steps:
+        groups.setdefault(s["phase"], []).append(s)
+
+    for phase, label in PHASE_LABELS.items():
+        phase_steps = groups.get(phase) or []
+        if not phase_steps:
+            continue
+        expander = st.expander(label, expanded=expand_state.get(phase, False))
+        with expander:
+            total = len(phase_steps)
+            for idx, step in enumerate(phase_steps, 1):
+                status = STATUS_ICONS.get(step["status"], step["status"])
+                meta: List[str] = []
+                if step.get("duration_ms") is not None:
+                    meta.append(f"{step['duration_ms']} ms")
+                if step.get("tokens") is not None:
+                    meta.append(f"{step['tokens']} tok")
+                if step.get("cost") is not None:
+                    meta.append(f"${step['cost']:.4f}")
+                header = f"Step {idx}/{total} — {step['name']} {status}".rstrip()
+                if meta:
+                    header += " — " + ", ".join(meta)
+                st.markdown(f"**{header}**")
+                if step["status"] == "error":
+                    st.error(step.get("summary") or "Error")
+                    with st.expander("Show details", expanded=False):
+                        if isinstance(step.get("raw"), dict):
+                            st.json(step.get("raw"))
+                        else:
+                            st.code(str(step.get("raw")), language=None)
+                    continue
+                if view in ("Summary", "Both"):
+                    st.code(step.get("summary") or "", language=None)
+                if view in ("Raw", "Both"):
+                    raw = step.get("raw")
+                    if isinstance(raw, dict):
+                        st.json(raw)
+                    else:
+                        st.code("" if raw is None else str(raw), language=None)
+

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T00:52:55.279006Z from commit fe30905_
+_Last generated at 2025-08-30T01:02:17.724522Z from commit 4f2b5bf_

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T00:52:55.279006Z'
-git_sha: fe30905fe46c100c3f95031585af90cdd6e1fb40
+generated_at: '2025-08-30T01:02:17.724522Z'
+git_sha: 4f2b5bf60387dfbe57b96852f647213325069ac2
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -184,14 +184,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
+- path: orchestrators/__init__.py
   role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/spec_builder.py
+- path: orchestrators/app_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -205,6 +205,13 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
+- path: orchestrators/spec_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
 - path: orchestrators/plan_utils.py
   role: Orchestrator
   responsibilities: []
@@ -212,14 +219,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/__init__.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: core/summarization/schemas.py
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -233,7 +233,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
+- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_agent_trace_ui_smoke.py
+++ b/tests/test_agent_trace_ui_smoke.py
@@ -1,11 +1,10 @@
 import streamlit as st
 
 from app.agent_trace_ui import (
-    render_agent_trace,
     render_live_status,
     render_role_summaries,
-    render_exports,
 )
+from app.ui.trace_viewer import render_trace
 
 
 def test_agent_trace_ui_smoke(tmp_path):
@@ -24,25 +23,19 @@ def test_agent_trace_ui_smoke(tmp_path):
     }
     trace = [
         {
-            "project_id": "p",
-            "task_id": "T01",
-            "step_no": 1,
-            "role": "CTO",
-            "title": "Test",
-            "model": "gpt",
-            "tokens_in": 1,
-            "tokens_out": 2,
-            "cost_usd": 0.1,
-            "quotes": [],
-            "citations": [],
-            "finding": "done",
-            "raw_json": {},
-            "events": [],
-            "ts_start": "",
-            "ts_end": "",
+            "phase": "planner",
+            "name": "Plan",
+            "status": "complete",
+            "started_at": 0,
+            "ended_at": 1,
+            "duration_ms": 1000,
+            "tokens": 1,
+            "cost": 0.1,
+            "summary": "done",
+            "raw": {},
+            "step_id": "s1",
         }
     ]
     render_live_status(live_status)
-    render_agent_trace(trace, {})
+    render_trace(trace, run_id="proj")
     render_role_summaries({"CTO": "output"})
-    render_exports("proj", trace)

--- a/utils/trace_export.py
+++ b/utils/trace_export.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import csv
+import io
+import json
+from collections import OrderedDict
+from typing import Any, Iterable, List, Dict, Sequence
+
+
+Row = List[Any]
+
+
+def _safe_summary(text: str | None, max_len: int = 80) -> str:
+    text = text or ""
+    return text[:max_len]
+
+
+def to_json(trace: Sequence[Dict[str, Any]]) -> bytes:
+    """Return the trace as JSON bytes."""
+    return json.dumps(list(trace), ensure_ascii=False, indent=2).encode("utf-8")
+
+
+def to_csv(trace: Sequence[Dict[str, Any]], run_id: str | None = None) -> bytes:
+    """Return a CSV summary of the trace."""
+    output = io.StringIO()
+    writer = csv.writer(output, quoting=csv.QUOTE_MINIMAL)
+    writer.writerow([
+        "run_id",
+        "phase",
+        "step_index",
+        "name",
+        "status",
+        "duration_ms",
+        "tokens",
+        "cost",
+        "summary_80chars",
+    ])
+    for idx, step in enumerate(trace, 1):
+        writer.writerow([
+            run_id,
+            step.get("phase"),
+            idx,
+            step.get("name"),
+            step.get("status"),
+            step.get("duration_ms"),
+            step.get("tokens"),
+            step.get("cost"),
+            _safe_summary(step.get("summary")),
+        ])
+    return output.getvalue().encode("utf-8")
+
+
+def to_markdown(trace: Sequence[Dict[str, Any]], run_id: str | None = None) -> bytes:
+    """Return a human readable Markdown report of the trace."""
+    phases: OrderedDict[str, List[Dict[str, Any]]] = OrderedDict()
+    for step in trace:
+        phase = (step.get("phase") or "unknown").lower()
+        phases.setdefault(phase, []).append(step)
+
+    lines: List[str] = []
+    title = f"Trace {run_id}" if run_id else "Trace"
+    lines.append(f"# {title}\n")
+    for phase, steps in phases.items():
+        lines.append(f"## {phase.capitalize()}\n")
+        total = len(steps)
+        for i, step in enumerate(steps, 1):
+            status = step.get("status")
+            badge = {"complete": "✅", "error": "⚠️", "running": "⏳"}.get(status, "")
+            header = f"### Step {i}/{total} — {step.get('name', '')} {badge}".rstrip()
+            meta: List[str] = []
+            if step.get("duration_ms") is not None:
+                meta.append(f"{step['duration_ms']} ms")
+            if step.get("tokens") is not None:
+                meta.append(f"{step['tokens']} tok")
+            if step.get("cost") is not None:
+                meta.append(f"${step['cost']:.4f}")
+            if meta:
+                header += f" ({', '.join(meta)})"
+            lines.append(header)
+            summary = step.get("summary") or ""
+            if len(summary) <= 200:
+                lines.append("```")
+                lines.append(summary.strip())
+                lines.append("```")
+            else:
+                lines.append(
+                    "<details><summary>Summary</summary>\n\n" + summary + "\n\n</details>"
+                )
+            lines.append("")
+    return "\n".join(lines).encode("utf-8")
+
+
+__all__ = ["to_json", "to_csv", "to_markdown"]


### PR DESCRIPTION
## Summary
- introduce Streamlit Trace Viewer with phase groups, filtering, view toggles and exports
- provide pure helpers to export traces to JSON, CSV and Markdown
- render trace viewer after runs and cover export helpers with tests

## Testing
- `pytest tests/test_trace_export.py tests/test_agent_trace_ui_smoke.py tests/test_agent_trace_ui_summary.py`
- `pytest` *(fails: ERROR tests/gtm/test_generate_deck.py, tests/integrations/test_jira_bridge.py, tests/integrations/test_slack_bridge.py, tests/integrations/test_teams_bridge.py)*


------
https://chatgpt.com/codex/tasks/task_e_68b24c968a80832cb1625d3b8e42d731