### PR TITLE
feat: add typed RunConfig and sidebar taxonomy

### DIFF
--- a/app/ui/sidebar.py
+++ b/app/ui/sidebar.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, Dict
+
+import streamlit as st
+
+from app.ui_presets import UI_PRESETS
+from utils.run_config import RunConfig, defaults, from_session, to_session
+from utils.telemetry import log_event
+
+
+def render_sidebar() -> RunConfig:
+    """Render the sidebar and return the current :class:`RunConfig`."""
+
+    if not st.session_state.get("_run_config_seeded"):
+        to_session(defaults())
+        st.session_state["_run_config_seeded"] = True
+    if not st.session_state.get("_sidebar_tip_shown"):
+        st.sidebar.caption("Settings apply to the next run.")
+        st.session_state["_sidebar_tip_shown"] = True
+
+    def _track_change(field: str) -> None:
+        value = st.session_state[field]
+        prev_key = f"_{field}_prev"
+        old = st.session_state.get(prev_key)
+        if old is None:
+            st.session_state[prev_key] = value
+            return
+        if old != value:
+            log_event(
+                {
+                    "event": "sidebar_changed",
+                    "field": field,
+                    "old": old,
+                    "new": value,
+                    "run_id": st.session_state.get("run_id"),
+                }
+            )
+            st.session_state[prev_key] = value
+
+    def _reset() -> None:
+        cfg = defaults()
+        to_session(cfg)
+        for f in dataclasses.fields(RunConfig):
+            st.session_state[f"_{f.name}_prev"] = getattr(cfg, f.name)
+        st.session_state["temperature"] = 0.0
+        st.session_state["retries"] = 0
+        st.session_state["timeout"] = 0
+        log_event({"event": "sidebar_reset", "run_id": st.session_state.get("run_id")})
+
+    with st.sidebar:
+        st.subheader("Run settings")
+        st.text_area(
+            "Project idea",
+            key="idea",
+            help="What should the agents work on?",
+        )
+        _track_change("idea")
+        modes = list(UI_PRESETS.keys())
+        st.selectbox("Mode", modes, key="mode", help="Choose run mode")
+        _track_change("mode")
+
+        with st.expander("Knowledge"):
+            st.multiselect(
+                "Sources",
+                ["local_samples", "uploads", "connectors"],
+                key="knowledge_sources",
+                help="Select knowledge sources",
+            )
+            _track_change("knowledge_sources")
+            with st.expander("Manage sources"):
+                st.caption("Manage advanced sources here.")
+
+        with st.expander("Diagnostics"):
+            st.checkbox(
+                "Show agent trace",
+                key="show_agent_trace",
+                help="Display detailed agent steps",
+            )
+            _track_change("show_agent_trace")
+            st.checkbox(
+                "Verbose planner output",
+                key="verbose_planner",
+                help="Print planner debug info",
+            )
+            _track_change("verbose_planner")
+
+        with st.expander("Exports"):
+            st.checkbox(
+                "Auto export trace on completion",
+                key="auto_export_trace",
+            )
+            _track_change("auto_export_trace")
+            st.checkbox(
+                "Auto export report on completion",
+                key="auto_export_report",
+            )
+            _track_change("auto_export_report")
+
+        with st.expander("Advanced options"):
+            st.session_state.setdefault("temperature", 0.0)
+            st.number_input(
+                "Temperature",
+                min_value=0.0,
+                max_value=2.0,
+                step=0.1,
+                key="temperature",
+                help="Sampling temperature",
+            )
+            _track_change("temperature")
+            st.session_state.setdefault("retries", 0)
+            st.number_input(
+                "Retries",
+                min_value=0,
+                max_value=10,
+                step=1,
+                key="retries",
+                help="Max retries for calls",
+            )
+            _track_change("retries")
+            st.session_state.setdefault("timeout", 0)
+            st.number_input(
+                "Timeout (s)",
+                min_value=0,
+                max_value=3600,
+                step=10,
+                key="timeout",
+                help="Overall timeout in seconds",
+            )
+            _track_change("timeout")
+
+        st.button("Reset to defaults", on_click=_reset, help="Restore default settings")
+
+    cfg = from_session()
+    adv: Dict[str, Any] = {
+        "temperature": st.session_state.get("temperature", 0.0),
+        "retries": st.session_state.get("retries", 0),
+        "timeout": st.session_state.get("timeout", 0),
+    }
+    data = dataclasses.asdict(cfg)
+    data["advanced"] = adv
+    return RunConfig(**data)

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T01:02:17.724522Z from commit 4f2b5bf_
+_Last generated at 2025-08-30T01:07:59.335964Z from commit 9867ca3_

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T01:02:17.724522Z'
-git_sha: 4f2b5bf60387dfbe57b96852f647213325069ac2
+generated_at: '2025-08-30T01:07:59.335964Z'
+git_sha: 9867ca3e33184d4d2fd5a3b70bef5402b067a8e9
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -184,21 +184,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/__init__.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/app_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/qa_router.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/__init__.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -219,14 +212,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
-  role: Summarization
+- path: orchestrators/app_builder.py
+  role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -240,7 +233,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/__init__.py
+- path: core/summarization/integrator.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -1,0 +1,47 @@
+import streamlit as st
+
+from utils.run_config import (
+    RunConfig,
+    defaults,
+    from_session,
+    to_orchestrator_kwargs,
+    to_session,
+)
+
+
+def test_defaults():
+    st.session_state.clear()
+    cfg = defaults()
+    assert isinstance(cfg, RunConfig)
+    assert cfg.mode == "standard"
+    assert cfg.idea == ""
+    assert cfg.knowledge_sources == []
+
+
+def test_to_orchestrator_kwargs_minimal():
+    st.session_state.clear()
+    cfg = RunConfig(idea="x", rag_enabled=True)
+    kw = to_orchestrator_kwargs(cfg)
+    assert kw["idea"] == "x"
+    assert kw["rag"] is True
+    assert kw["knowledge_sources"] == []
+
+
+def test_to_orchestrator_kwargs_with_advanced():
+    st.session_state.clear()
+    cfg = RunConfig(idea="y", advanced={"temperature": 0.2})
+    kw = to_orchestrator_kwargs(cfg)
+    assert kw["temperature"] == 0.2
+
+
+def test_session_roundtrip():
+    st.session_state.clear()
+    original = RunConfig(
+        idea="idea",
+        mode="lite",
+        rag_enabled=True,
+        knowledge_sources=["k"],
+    )
+    to_session(original)
+    loaded = from_session()
+    assert loaded == original


### PR DESCRIPTION
## Summary
- add frozen RunConfig dataclass with session helpers and orchestrator adapter
- introduce sidebar renderer with progressive sections, reset, and telemetry
- wire main UI to render sidebar and run using typed config
- add unit tests for RunConfig helpers and regenerate repo map

## Testing
- `pytest tests/test_run_config.py`
- `python scripts/generate_repo_map.py`


------
https://chatgpt.com/codex/tasks/task_e_68b24e2a0d88832c84fab79c07276345