### PR TITLE
Add post-run SUS/SEQ survey and usage metrics panel

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -12,6 +12,7 @@ from markdown_pdf import MarkdownPdf, Section
 from app.ui import components
 from app.ui.sidebar import render_sidebar
 from app.ui.trace_viewer import render_trace
+from app.ui import survey
 from config.agent_models import AGENT_MODEL_MAP
 import config.feature_flags as ff
 from core.agents.unified_registry import build_agents_unified
@@ -45,6 +46,7 @@ def get_agents():
 
 
 def main() -> None:
+    survey.render_usage_panel()
     components.help_once(
         "first_run_tip",
         "After you start, the app plans, executes tasks, then synthesizes a report.",
@@ -114,6 +116,7 @@ def main() -> None:
         st.markdown(final)
         trace = st.session_state.get("agent_trace", [])
         render_trace(trace, run_id)
+        survey.maybe_prompt_after_run(run_id)
     except Exception as e:  # pragma: no cover - UI display
         log_event({"event": "error_shown", "run_id": run_id, "where": "main", "message": str(e)})
         st.error(str(e))

--- a/app/ui/survey.py
+++ b/app/ui/survey.py
@@ -1,0 +1,103 @@
+"""Survey UI components."""
+from __future__ import annotations
+
+from typing import Dict
+
+import streamlit as st
+
+from utils import survey, survey_store
+from utils.telemetry import log_event
+
+
+def render_usage_panel() -> None:
+    records = survey_store.load_recent()
+    metrics = survey_store.compute_aggregates(records)
+    with st.sidebar.expander("Usage & Quality", expanded=False):
+        col1, col2 = st.columns(2)
+        with col1:
+            st.metric("SUS responses", metrics["sus_count"])
+            st.metric(
+                "Mean SUS",
+                f"{metrics['sus_mean']:.1f}" if metrics["sus_count"] else "–",
+            )
+            st.metric(
+                "7d SUS mean",
+                f"{metrics['sus_7_day_mean']:.1f}" if metrics["sus_count"] else "–",
+            )
+        with col2:
+            st.metric("SEQ responses", metrics["seq_count"])
+            st.metric(
+                "Mean SEQ",
+                f"{metrics['seq_mean']:.1f}" if metrics["seq_count"] else "–",
+            )
+            st.metric(
+                "7d SEQ mean",
+                f"{metrics['seq_7_day_mean']:.1f}" if metrics["seq_count"] else "–",
+            )
+
+
+def maybe_prompt_after_run(run_id: str) -> None:
+    key = f"survey_prompted_{run_id}"
+    if st.session_state.get(key):
+        return
+    st.session_state[key] = True
+    log_event({"event": "survey_shown", "run_id": run_id})
+
+    def _render_forms() -> None:
+        sus_tab, seq_tab = st.tabs(["SUS", "Ease"])
+        with sus_tab:
+            responses: Dict[str, int] = {}
+            for qkey, stmt in survey.SUS_ITEMS.items():
+                responses[qkey] = st.radio(
+                    stmt,
+                    [1, 2, 3, 4, 5],
+                    horizontal=True,
+                    format_func=lambda x: [
+                        "Strongly disagree",
+                        "Disagree",
+                        "Neutral",
+                        "Agree",
+                        "Strongly agree",
+                    ][x - 1],
+                    key=f"{run_id}_{qkey}",
+                )
+            comment = st.text_area("Comments (optional)", key=f"sus_comment_{run_id}")
+            if st.button("Submit SUS", key=f"sus_submit_{run_id}"):
+                total = survey.score_sus(responses)
+                survey_store.save_sus(run_id, responses, total, comment)
+                log_event(
+                    {
+                        "event": "survey_submitted",
+                        "run_id": run_id,
+                        "instrument": "SUS",
+                        "total": total,
+                    }
+                )
+                st.success("Thanks!")
+        with seq_tab:
+            score = st.radio(
+                "Overall, how easy was it to complete this task?",
+                list(range(1, 8)),
+                horizontal=True,
+                key=f"seq_score_{run_id}",
+            )
+            comment2 = st.text_area("Comments (optional)", key=f"seq_comment_{run_id}")
+            if st.button("Submit Ease", key=f"seq_submit_{run_id}"):
+                norm = survey.normalize_seq(score)
+                survey_store.save_seq(run_id, norm, comment2)
+                log_event(
+                    {
+                        "event": "survey_submitted",
+                        "run_id": run_id,
+                        "instrument": "SEQ",
+                        "score": norm,
+                    }
+                )
+                st.success("Thanks!")
+
+    if hasattr(st, "dialog"):
+        with st.dialog("Tell us about this run"):
+            _render_forms()
+    else:  # pragma: no cover - fallback
+        with st.expander("Survey"):
+            _render_forms()

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T01:07:59.335964Z from commit 9867ca3_
+_Last generated at 2025-08-30T01:15:04.367746Z from commit 19a4066_

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T01:07:59.335964Z'
-git_sha: 9867ca3e33184d4d2fd5a3b70bef5402b067a8e9
+generated_at: '2025-08-30T01:15:04.367746Z'
+git_sha: 19a40668ae844f43c9715b996cccb0bf0ba49825
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -184,14 +184,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/qa_router.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/__init__.py
+- path: orchestrators/app_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -212,14 +205,21 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
+- path: orchestrators/qa_router.py
   role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/__init__.py
+- path: orchestrators/__init__.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/integrator.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -233,14 +233,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_survey_scoring.py
+++ b/tests/test_survey_scoring.py
@@ -1,0 +1,28 @@
+from utils import survey
+
+
+from utils import survey
+
+
+def test_all_threes():
+    responses = {k: 3 for k in survey.SUS_ITEMS}
+    assert survey.score_sus(responses) == 50
+
+
+def test_all_high():
+    responses = {}
+    for i, k in enumerate(survey.SUS_ITEMS.keys(), start=1):
+        responses[k] = 5 if i % 2 == 1 else 1
+    assert survey.score_sus(responses) == 100
+
+
+def test_all_low():
+    responses = {}
+    for i, k in enumerate(survey.SUS_ITEMS.keys(), start=1):
+        responses[k] = 1 if i % 2 == 1 else 5
+    assert survey.score_sus(responses) == 0
+
+
+def test_normalize_seq():
+    assert survey.normalize_seq(0) == 1
+    assert survey.normalize_seq(8) == 7

--- a/tests/test_survey_store.py
+++ b/tests/test_survey_store.py
@@ -1,0 +1,33 @@
+import time
+
+from utils import survey_store
+
+
+def test_save_and_load(tmp_path, monkeypatch):
+    path = tmp_path / "surveys.jsonl"
+    monkeypatch.setattr(survey_store, "SURVEYS_PATH", path)
+    survey_store.SURVEYS_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+    answers = {f"sus_q{i}": 3 for i in range(1, 11)}
+    survey_store.save_sus("run1", answers, 50, None)
+    survey_store.save_seq("run1", 6, "great")
+    records = survey_store.load_recent()
+    assert len(records) == 2
+    assert {r["instrument"] for r in records} == {"SUS", "SEQ"}
+
+
+def test_compute_aggregates():
+    now = time.time()
+    records = [
+        {"ts": now, "instrument": "SUS", "total": 80},
+        {"ts": now - 9 * 86400, "instrument": "SUS", "total": 60},
+        {"ts": now, "instrument": "SEQ", "answers": {"score": 6}},
+        {"ts": now - 9 * 86400, "instrument": "SEQ", "answers": {"score": 3}},
+    ]
+    stats = survey_store.compute_aggregates(records)
+    assert stats["sus_count"] == 2
+    assert stats["sus_mean"] == 70
+    assert stats["sus_7_day_mean"] == 80
+    assert stats["seq_count"] == 2
+    assert stats["seq_mean"] == 4.5
+    assert stats["seq_7_day_mean"] == 6

--- a/utils/survey.py
+++ b/utils/survey.py
@@ -1,0 +1,43 @@
+"""Survey scoring utilities."""
+from __future__ import annotations
+
+from typing import Dict
+
+SUS_ITEMS: Dict[str, str] = {
+    "sus_q1": "I think that I would like to use this system frequently.",
+    "sus_q2": "I found the system unnecessarily complex.",
+    "sus_q3": "I thought the system was easy to use.",
+    "sus_q4": "I think that I would need the support of a technical person to be able to use this system.",
+    "sus_q5": "I found the various functions in this system were well integrated.",
+    "sus_q6": "I thought there was too much inconsistency in this system.",
+    "sus_q7": "I would imagine that most people would learn to use this system very quickly.",
+    "sus_q8": "I found the system very cumbersome to use.",
+    "sus_q9": "I felt very confident using the system.",
+    "sus_q10": "I needed to learn a lot of things before I could get going with this system.",
+}
+
+
+def validate_sus(responses: Dict[str, int]) -> None:
+    """Validate that all 10 SUS items are present with scores 1-5."""
+    if set(responses) != set(SUS_ITEMS):
+        raise ValueError("SUS responses must include all 10 items")
+    if any(not 1 <= v <= 5 for v in responses.values()):
+        raise ValueError("SUS responses must be between 1 and 5")
+
+
+def score_sus(responses: Dict[str, int]) -> int:
+    """Convert SUS item scores from 1-5 Likert to a 0-100 total."""
+    validate_sus(responses)
+    total = 0
+    for idx, key in enumerate(sorted(SUS_ITEMS.keys(), key=lambda k: int(k.split('q')[1])), start=1):
+        score = responses[key]
+        if idx % 2 == 1:  # odd items
+            total += score - 1
+        else:  # even items
+            total += 5 - score
+    return int(total * 2.5)
+
+
+def normalize_seq(score: int) -> int:
+    """Clamp SEQ score to 1-7 Likert scale."""
+    return max(1, min(int(score), 7))


### PR DESCRIPTION
## Summary
- collect SUS and SEQ feedback after each run and persist results
- surface recent usage & quality aggregates in a sidebar panel
- store survey data in JSONL with optional Firestore mirroring

## Testing
- `pytest tests/test_survey_scoring.py tests/test_survey_store.py`
- `python scripts/generate_repo_map.py`


------
https://chatgpt.com/codex/tasks/task_e_68b24fd75fc8832cbe32b539a11e535a