### PR TITLE
feat: split streamlit app into multipage

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,16 +1,21 @@
-"""Streamlit entry point for the DR-RD application.
+"""Run page for the DR-RD Streamlit application."""
 
-This file exists so that ``streamlit run app.py`` finds the application
-module. The bulk of the app lives in the ``app`` package; this script
-provides a small router that can either launch the main application or
-invoke additional tools.
-"""
+import streamlit as st
 
 from app import main
+from utils.telemetry import log_event
 
 
 def run() -> None:
     """Launch the DR-RD Streamlit application."""
+    st.set_page_config(
+        page_title="DR-RD",
+        page_icon=":material/science:",
+        layout="wide",
+        initial_sidebar_state="expanded",
+        menu_items={"About": "DR-RD — AI R&D Workbench"},
+    )
+    log_event({"event": "nav_page_view", "page": "run"})
     main()
 
 

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T01:15:04.367746Z from commit 19a4066_
+_Last generated at 2025-08-30T01:21:50.616739Z from commit 5d3e0ab_

--- a/pages/10_Trace.py
+++ b/pages/10_Trace.py
@@ -1,0 +1,14 @@
+"""Trace page."""
+import streamlit as st
+
+from app.ui.trace_viewer import render_trace
+from utils.telemetry import log_event
+
+run_id = st.query_params.get("run_id")
+log_event({"event": "nav_page_view", "page": "trace", "run_id": run_id})
+
+st.title("Trace")
+st.caption("Step-by-step agent activity.")
+
+trace = st.session_state.get("agent_trace", [])
+render_trace(trace, run_id=run_id or st.session_state.get("run_id") or "last")

--- a/pages/20_Reports.py
+++ b/pages/20_Reports.py
@@ -1,0 +1,57 @@
+"""Reports and exports page."""
+import streamlit as st
+
+from utils import trace_export
+from utils.telemetry import log_event
+from app import generate_pdf
+
+log_event({"event": "nav_page_view", "page": "reports"})
+
+st.title("Reports & Exports")
+st.caption("Download outputs from your last run.")
+
+report = st.session_state.get("run_report")
+trace = st.session_state.get("agent_trace", [])
+run_id = st.session_state.get("run_id")
+
+if not report and not trace:
+    st.info("No run data found.")
+else:
+    if report:
+        st.subheader("Report")
+        col_md, col_pdf = st.columns(2)
+        if col_md.download_button(
+            "Download report (.md)",
+            data=report.encode("utf-8"),
+            file_name=f"report_{run_id or 'session'}.md",
+            mime="text/markdown",
+            use_container_width=True,
+        ):
+            log_event({"event": "export_clicked", "format": "report_md", "run_id": run_id})
+        if col_pdf.download_button(
+            "Download report (.pdf)",
+            data=generate_pdf(report),
+            file_name=f"report_{run_id or 'session'}.pdf",
+            mime="application/pdf",
+            use_container_width=True,
+        ):
+            log_event({"event": "export_clicked", "format": "report_pdf", "run_id": run_id})
+    if trace:
+        st.subheader("Trace")
+        col_json, col_csv = st.columns(2)
+        if col_json.download_button(
+            "Download trace (.json)",
+            data=trace_export.to_json(trace),
+            file_name=f"trace_{run_id or 'session'}.json",
+            mime="application/json",
+            use_container_width=True,
+        ):
+            log_event({"event": "export_clicked", "format": "trace_json", "run_id": run_id})
+        if col_csv.download_button(
+            "Download trace (.csv)",
+            data=trace_export.to_csv(trace, run_id=run_id),
+            file_name=f"trace_{run_id or 'session'}.csv",
+            mime="text/csv",
+            use_container_width=True,
+        ):
+            log_event({"event": "export_clicked", "format": "trace_csv", "run_id": run_id})

--- a/pages/30_Metrics.py
+++ b/pages/30_Metrics.py
@@ -1,0 +1,51 @@
+"""Metrics page."""
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta
+from pathlib import Path
+
+import streamlit as st
+
+from utils import survey_store
+from utils.telemetry import log_event
+
+log_event({"event": "nav_page_view", "page": "metrics"})
+
+st.title("Metrics")
+st.caption("Local usage and survey metrics.")
+
+start_default = date.today() - timedelta(days=7)
+start, end = st.date_input("Date range", value=(start_default, date.today()))
+start_ts = datetime.combine(start, datetime.min.time()).timestamp()
+end_ts = datetime.combine(end, datetime.max.time()).timestamp()
+
+# Load telemetry events
+events_path = Path(".dr_rd/telemetry/events.jsonl")
+events = []
+if events_path.exists():
+    with events_path.open("r", encoding="utf-8") as f:
+        for line in f:
+            ev = json.loads(line)
+            ts = ev.get("ts", 0)
+            if start_ts <= ts <= end_ts:
+                events.append(ev)
+
+runs = sum(1 for e in events if e.get("event") == "start_run")
+views = sum(1 for e in events if e.get("event") == "nav_page_view")
+errors = sum(1 for e in events if e.get("event") == "error_shown")
+
+col1, col2, col3 = st.columns(3)
+col1.metric("Runs", runs)
+col2.metric("Page views", views)
+col3.metric("Errors", errors)
+
+records = survey_store.load_recent(1000)
+records = [r for r in records if start_ts <= r.get("ts", 0) <= end_ts]
+agg = survey_store.compute_aggregates(records)
+
+st.subheader("Surveys")
+if records:
+    st.table(agg)
+else:
+    st.info("No survey data in range.")

--- a/pages/90_Settings.py
+++ b/pages/90_Settings.py
@@ -1,0 +1,40 @@
+"""Settings page."""
+import streamlit as st
+
+from utils.run_config import defaults
+from utils.telemetry import log_event
+from app import load_ui_config, save_ui_config
+
+log_event({"event": "nav_page_view", "page": "settings"})
+
+st.title("Settings")
+st.caption("Configure default run options.")
+
+stored = load_ui_config()
+base = defaults()
+
+mode = st.selectbox(
+    "Default mode",
+    ["standard", "test", "deep"],
+    index=["standard", "test", "deep"].index(stored.get("mode", base.mode)),
+)
+auto_trace = st.checkbox(
+    "Auto export trace",
+    value=stored.get("auto_export_trace", base.auto_export_trace),
+)
+auto_report = st.checkbox(
+    "Auto export report",
+    value=stored.get("auto_export_report", base.auto_export_report),
+)
+
+if st.button("Save", type="primary", use_container_width=True):
+    data = {
+        "mode": mode,
+        "auto_export_trace": auto_trace,
+        "auto_export_report": auto_report,
+    }
+    save_ui_config(data)
+    for k, v in data.items():
+        st.session_state[k] = v
+    log_event({"event": "settings_changed", **data})
+    st.success("Settings saved")

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T01:15:04.367746Z'
-git_sha: 19a40668ae844f43c9715b996cccb0bf0ba49825
+generated_at: '2025-08-30T01:21:50.616739Z'
+git_sha: 5d3e0abce8a4ebf0b89b7a38be3af27bdf948a1d
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -191,13 +191,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/spec_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/plan_utils.py
   role: Orchestrator
   responsibilities: []
@@ -205,7 +198,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/qa_router.py
+- path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -219,8 +212,8 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
-  role: Summarization
+- path: orchestrators/qa_router.py
+  role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
@@ -233,7 +226,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
+- path: core/summarization/integrator.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -241,6 +234,13 @@ modules:
   invoked_by: []
   invokes: []
 - path: core/summarization/__init__.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_pages_imports.py
+++ b/tests/test_pages_imports.py
@@ -1,0 +1,15 @@
+"""Ensure Streamlit pages import without side effects."""
+from pathlib import Path
+import importlib.util
+
+
+def _load(path: Path) -> None:
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)  # type: ignore[arg-type]
+
+
+def test_pages_import() -> None:
+    for page in Path("pages").glob("*.py"):
+        _load(page)


### PR DESCRIPTION
## Summary
- convert single-page Streamlit app into multipage layout with Trace, Reports, Metrics, and Settings pages
- expose config helpers and link from run page to trace; add telemetry nav events on each page
- add smoke tests and regenerate repository map

## Testing
- `pytest tests/test_pages_imports.py -q`
- `pytest tests/test_trace_export.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2516b2410832cbf7b7b771dbd6deb