### PR TITLE
feat: add accessibility and layout helpers

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,2 +1,11 @@
 [server]
 fileWatcherType = "none"
+
+[theme]
+base = "light"
+primaryColor = "#0A63FF"
+backgroundColor = "#FFFFFF"
+secondaryBackgroundColor = "#F6F8FA"
+textColor = "#0A0A0A"
+font = "sans serif"
+# Contrast targets: WCAG AA requires 4.5:1 for normal text, 3:1 for large text.

--- a/app.py
+++ b/app.py
@@ -1,20 +1,11 @@
 """Run page for the DR-RD Streamlit application."""
 
-import streamlit as st
-
 from app import main
 from utils.telemetry import log_event
 
 
 def run() -> None:
     """Launch the DR-RD Streamlit application."""
-    st.set_page_config(
-        page_title="DR-RD",
-        page_icon=":material/science:",
-        layout="wide",
-        initial_sidebar_state="expanded",
-        menu_items={"About": "DR-RD — AI R&D Workbench"},
-    )
     log_event({"event": "nav_page_view", "page": "run"})
     main()
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -11,13 +11,25 @@ import fitz
 import streamlit as st
 from markdown_pdf import MarkdownPdf, Section
 
+st.set_page_config(
+    page_title="DR-RD",
+    page_icon=":material/science:",
+    layout="wide",
+    initial_sidebar_state="expanded",
+    menu_items={"About": "DR-RD — AI R&D Workbench"},
+)
+
+from app.ui.a11y import inject_accessibility_baseline, live_region_container
+
+inject_accessibility_baseline()
+live_region_container()
+
 from app.ui import components
 from app.ui.sidebar import render_sidebar
 from app.ui import survey
 from config.agent_models import AGENT_MODEL_MAP
 import config.feature_flags as ff
 from core.agents.unified_registry import build_agents_unified
-from core.orchestrator import compose_final_proposal, execute_plan, generate_plan
 from utils.run_config import to_orchestrator_kwargs
 from utils.telemetry import log_event
 
@@ -61,6 +73,8 @@ def get_agents():
 
 
 def main() -> None:
+    from core.orchestrator import compose_final_proposal, execute_plan, generate_plan
+
     _apply_stored_defaults()
     survey.render_usage_panel()
     components.help_once(

--- a/app/ui/a11y.py
+++ b/app/ui/a11y.py
@@ -1,0 +1,44 @@
+import streamlit as st
+
+
+_A11Y_CSS = """
+<style>
+/* Focus visibility across common widgets */
+:root { --focus-ring: 2px solid #0A63FF; }
+button:focus-visible,
+[role="button"]:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible {
+  outline: var(--focus-ring) !important;
+  outline-offset: 2px !important;
+  box-shadow: none !important;
+}
+/* Larger hit targets for buttons and downloads */
+.stButton button, .stDownloadButton button {
+  min-height: 44px;
+  padding: 10px 16px;
+}
+/* Respect reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0s !important;
+    transition-duration: 0s !important;
+    scroll-behavior: auto !important;
+  }
+}
+</style>
+"""
+
+
+def inject_accessibility_baseline():
+    st.markdown(_A11Y_CSS, unsafe_allow_html=True)
+
+
+def live_region_container():
+    # screen reader polite announcements
+    st.markdown(
+        '<div aria-live="polite" aria-atomic="true" style="position:absolute;left:-9999px;height:1px;width:1px;overflow:hidden;"></div>',
+        unsafe_allow_html=True,
+    )
+

--- a/app/ui/layout.py
+++ b/app/ui/layout.py
@@ -1,0 +1,14 @@
+import streamlit as st
+
+
+def section(title: str, help_text: str | None = None):
+    st.subheader(title)
+    if help_text:
+        st.caption(help_text)
+    st.divider()
+
+
+def pad_y(units: int = 1):
+    for _ in range(max(1, units)):
+        st.write("")
+

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T01:21:50.616739Z from commit 5d3e0ab_
+_Last generated at 2025-08-30T01:27:50.589100Z from commit af79b7b_

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T01:21:50.616739Z'
-git_sha: 5d3e0abce8a4ebf0b89b7a38be3af27bdf948a1d
+generated_at: '2025-08-30T01:27:50.589100Z'
+git_sha: af79b7bf1d993a17de9ea52cc7b80be6d7826442
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -184,7 +184,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
+- path: orchestrators/qa_router.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -212,15 +212,8 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/qa_router.py
+- path: orchestrators/app_builder.py
   role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: core/summarization/schemas.py
-  role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
@@ -233,14 +226,21 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/__init__.py
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
+- path: core/summarization/schemas.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_a11y_injection.py
+++ b/tests/test_a11y_injection.py
@@ -1,0 +1,18 @@
+import streamlit as st
+
+from app.ui.a11y import inject_accessibility_baseline
+
+
+def test_inject_accessibility_baseline(monkeypatch):
+    captured = {}
+
+    def fake_markdown(content, unsafe_allow_html=False):
+        captured["content"] = content
+        captured["unsafe"] = unsafe_allow_html
+
+    monkeypatch.setattr(st, "markdown", fake_markdown)
+    inject_accessibility_baseline()
+
+    assert captured["unsafe"] is True
+    assert ":root { --focus-ring" in captured["content"]
+


### PR DESCRIPTION
## Summary
- establish base theme tokens and contrast targets
- add accessibility helpers for focus visibility and reduced motion
- provide layout utilities for sections and padding
- inject baseline accessibility on app init and simplify entrypoint
- regenerate repo map

## Testing
- `streamlit run app.py --server.headless true --server.port 8501`
- `pytest tests/test_a11y_injection.py -q`
- `python scripts/generate_repo_map.py`

------
https://chatgpt.com/codex/tasks/task_e_68b252e6d0fc832cb52e3afdd6896391