### PR TITLE
feat: add cached metrics and trace pagination

### DIFF
--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T01:33:46.153442Z from commit e103b84_
+_Last generated at 2025-08-30T01:40:25.809582Z from commit b26f7ae_

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T01:33:46.153442Z'
-git_sha: e103b848231249e2d11fedb40f6db6060a324183
+generated_at: '2025-08-30T01:40:25.809582Z'
+git_sha: b26f7aedc600d44540177da0155bc8b70b1261fc
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -191,14 +191,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/qa_router.py
+- path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/spec_builder.py
+- path: orchestrators/qa_router.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -233,14 +233,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
+- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/schemas.py
+- path: core/summarization/integrator.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_metrics_cache.py
+++ b/tests/test_metrics_cache.py
@@ -1,0 +1,69 @@
+import json
+import time
+from pathlib import Path
+
+from utils import metrics
+
+
+def test_load_events_trims_and_caches(tmp_path, monkeypatch):
+    path = tmp_path / "events.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    for i in range(50):
+        with path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps({"idx": i, "event": "e", "ts": i}) + "\n")
+    monkeypatch.setattr(metrics, "EVENTS_PATH", path)
+    metrics.load_events.clear()
+    calls = {"n": 0}
+
+    orig_open = Path.open
+
+    def counting_open(self, *args, **kwargs):
+        if self == path:
+            calls["n"] += 1
+        return orig_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", counting_open)
+
+    first = metrics.load_events(limit=10)
+    assert len(first) == 10
+    assert first[0]["idx"] == 40
+    second = metrics.load_events(limit=10)
+    assert len(second) == 10
+    assert calls["n"] == 1
+
+
+def test_compute_aggregates():
+    now = time.time()
+    events = [
+        {"event": "start_run", "ts": now},
+        {"event": "run_complete", "success": True, "duration_s": 4, "ts": now + 4},
+        {"event": "start_run", "ts": now + 10},
+        {"event": "run_complete", "success": False, "duration_s": 6, "ts": now + 16},
+        {"event": "error_shown", "ts": now + 17},
+        {"event": "nav_page_view", "ts": now},
+    ]
+    surveys = [
+        {"instrument": "SUS", "total": 80, "ts": now},
+        {"instrument": "SUS", "total": 60, "ts": now},
+        {"instrument": "SEQ", "answers": {"score": 3}, "ts": now},
+        {"instrument": "SEQ", "answers": {"score": 5}, "ts": now},
+    ]
+    agg = metrics.compute_aggregates(events, surveys)
+    assert agg["runs"] == 2
+    assert agg["views"] == 1
+    assert agg["errors"] == 1
+    assert agg["error_rate"] == 0.5
+    assert agg["success_rate"] == 0.5
+    assert agg["avg_time_on_task"] == 5
+    assert agg["sus_count"] == 2
+    assert agg["sus_mean"] == 70
+    assert agg["seq_7_day_mean"] == 4
+
+
+def test_list_artifacts(tmp_path, monkeypatch):
+    (tmp_path / "a.txt").write_text("a")
+    (tmp_path / "b.txt").write_text("b")
+    monkeypatch.setattr(metrics, "ARTIFACTS_DIR", tmp_path)
+    metrics.list_artifacts.clear()
+    mapping = metrics.list_artifacts()
+    assert mapping == {"a.txt": str(tmp_path / "a.txt"), "b.txt": str(tmp_path / "b.txt")}

--- a/utils/cache.py
+++ b/utils/cache.py
@@ -1,0 +1,11 @@
+import streamlit as st
+
+
+def cached_data(ttl: int = 15, show_spinner: bool = False):
+    """Wrapper around st.cache_data with sane defaults."""
+    return st.cache_data(ttl=ttl, show_spinner=show_spinner)
+
+
+def cached_resource():
+    """Wrapper around st.cache_resource."""
+    return st.cache_resource

--- a/utils/clients.py
+++ b/utils/clients.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from .cache import cached_resource
+
+
+@cached_resource()
+def get_firestore_client():
+    """Return a Firestore client if libraries and credentials are available."""
+    try:
+        from google.cloud import firestore  # type: ignore
+
+        return firestore.Client()
+    except Exception:
+        return None
+
+
+@cached_resource()
+def get_cloud_logging_client():
+    """Return a Cloud Logging client if available."""
+    try:
+        from google.cloud import logging as cloud_logging  # type: ignore
+
+        return cloud_logging.Client()
+    except Exception:
+        return None

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Dict, List
+
+from .cache import cached_data
+
+EVENTS_PATH = Path(".dr_rd/telemetry/events.jsonl")
+SURVEYS_PATH = Path(".dr_rd/telemetry/surveys.jsonl")
+ARTIFACTS_DIR = Path(".dr_rd/artifacts")
+
+
+@cached_data(ttl=15)
+def load_events(limit: int = 10000) -> List[Dict]:
+    if not EVENTS_PATH.exists():
+        return []
+    with EVENTS_PATH.open("r", encoding="utf-8") as f:
+        lines = f.readlines()[-limit:]
+    return [json.loads(line) for line in lines]
+
+
+@cached_data(ttl=15)
+def load_surveys(limit: int = 2000) -> List[Dict]:
+    if not SURVEYS_PATH.exists():
+        return []
+    with SURVEYS_PATH.open("r", encoding="utf-8") as f:
+        lines = f.readlines()[-limit:]
+    return [json.loads(line) for line in lines]
+
+
+def last_run_id(events: List[Dict]) -> str | None:
+    for ev in reversed(events):
+        if ev.get("event") == "start_run":
+            return ev.get("run_id")
+    return None
+
+
+def _mean(values: List[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def compute_aggregates(events: List[Dict], surveys: List[Dict]) -> Dict[str, float]:
+    now = time.time()
+    cutoff = now - 7 * 24 * 60 * 60
+
+    runs = [e for e in events if e.get("event") == "start_run"]
+    views = [e for e in events if e.get("event") == "nav_page_view"]
+    errors = [e for e in events if e.get("event") == "error_shown"]
+    completes = [e for e in events if e.get("event") == "run_complete"]
+    successes = [e for e in completes if e.get("success", True)]
+    failures = [e for e in completes if not e.get("success", True)]
+    durations = [e.get("duration_s", 0) for e in completes if isinstance(e.get("duration_s"), (int, float))]
+
+    sus_scores = [r.get("total", 0) for r in surveys if r.get("instrument") == "SUS"]
+    sus_recent = [r.get("total", 0) for r in surveys if r.get("instrument") == "SUS" and r.get("ts", 0) >= cutoff]
+    seq_scores = [r.get("answers", {}).get("score") for r in surveys if r.get("instrument") == "SEQ"]
+    seq_recent = [r.get("answers", {}).get("score") for r in surveys if r.get("instrument") == "SEQ" and r.get("ts", 0) >= cutoff]
+
+    return {
+        "runs": len(runs),
+        "views": len(views),
+        "errors": len(errors),
+        "error_rate": len(errors) / len(runs) if runs else 0.0,
+        "success_rate": len(successes) / (len(successes) + len(failures)) if (successes or failures) else 0.0,
+        "avg_time_on_task": _mean(durations),
+        "sus_count": len(sus_scores),
+        "sus_mean": _mean([s for s in sus_scores if s is not None]),
+        "sus_7_day_mean": _mean([s for s in sus_recent if s is not None]),
+        "seq_count": len([s for s in seq_scores if s is not None]),
+        "seq_mean": _mean([s for s in seq_scores if s is not None]),
+        "seq_7_day_mean": _mean([s for s in seq_recent if s is not None]),
+    }
+
+
+@cached_data(ttl=5)
+def list_artifacts(run_id: str | None = None) -> Dict[str, str]:
+    base = ARTIFACTS_DIR / run_id if run_id else ARTIFACTS_DIR
+    if not base.exists():
+        return {}
+    return {p.name: str(p) for p in base.glob("**/*") if p.is_file()}

--- a/utils/survey_store.py
+++ b/utils/survey_store.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Dict, List
 
 import streamlit as st
+from .cache import cached_data
 
 SURVEYS_PATH = Path(".dr_rd/telemetry/surveys.jsonl")
 SURVEYS_PATH.parent.mkdir(parents=True, exist_ok=True)
@@ -65,6 +66,7 @@ def save_seq(run_id: str, score: int, comment: str | None) -> None:
     _write_record(record)
 
 
+@cached_data(ttl=30)
 def load_recent(n: int = 500) -> List[Dict]:
     if not SURVEYS_PATH.exists():
         return []


### PR DESCRIPTION
## Summary
- add standard cache wrappers and cached Firestore/logging clients
- introduce metrics module with cached telemetry reads and rollups
- paginate trace viewer and streamline metrics page

## Testing
- `pytest tests/test_metrics_cache.py -q`
- `pytest tests/test_survey_store.py::test_save_and_load -q`
- `python scripts/generate_repo_map.py`

------
https://chatgpt.com/codex/tasks/task_e_68b25577cd04832ca3b95f207b811406