### PR TITLE
feat: canonical run IDs and artifact paths

### DIFF
--- a/app/ui/trace_viewer.py
+++ b/app/ui/trace_viewer.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from datetime import datetime
 from typing import Any, Dict, List, Sequence
 
 import json
 import streamlit as st
 
 from utils import trace_export
+from utils.paths import artifact_path
 from utils.telemetry import log_event
 
 PHASE_LABELS = {
@@ -109,27 +109,25 @@ def render_trace(
     st.caption(f"{len(filtered_steps)} of {total_steps} steps")
 
     # export buttons
-    ts = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
-    base = f"trace_{run_id or 'session'}_{ts}"
     col_json, col_csv, col_md = st.columns(3)
     if col_json.download_button(
         "Download full trace (.json)",
         data=trace_export.to_json(steps),
-        file_name=f"{base}.json",
+        file_name=artifact_path(run_id or "session", "trace", "json").name,
         mime="application/json",
     ):
         log_event({"event": "trace_export_clicked", "format": "json", "step_count": len(steps)})
     if col_csv.download_button(
         "Download summary (.csv)",
         data=trace_export.to_csv(steps, run_id=run_id),
-        file_name=f"{base}.csv",
+        file_name=artifact_path(run_id or "session", "summary", "csv").name,
         mime="text/csv",
     ):
         log_event({"event": "trace_export_clicked", "format": "csv", "step_count": len(steps)})
     if col_md.download_button(
         "Download readable report (.md)",
         data=trace_export.to_markdown(steps, run_id=run_id),
-        file_name=f"{base}.md",
+        file_name=artifact_path(run_id or "session", "trace", "md").name,
         mime="text/markdown",
     ):
         log_event({"event": "trace_export_clicked", "format": "md", "step_count": len(steps)})

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,3 +5,6 @@
 - [UX Metrics](UX_METRICS.md)
 - [UI Heuristic Audit](UI_AUDIT.md)
 - [UI Upgrade Spec](UI_SPEC.md)
+
+## Utilities
+- `scripts/cleanup_runs.py` — remove old run artifacts (`--keep N` or `--max-bytes M`)

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T01:44:20.798012Z from commit ae51bd5_
+_Last generated at 2025-08-30T01:58:37.389110Z from commit 49bd2f1_

--- a/pages/10_Trace.py
+++ b/pages/10_Trace.py
@@ -1,14 +1,42 @@
 """Trace page."""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
 import streamlit as st
 
 from app.ui.trace_viewer import render_trace
 from utils.telemetry import log_event
+from utils.paths import artifact_path
+from utils.runs import list_runs, last_run_id
 
-run_id = st.query_params.get("run_id")
-log_event({"event": "nav_page_view", "page": "trace", "run_id": run_id})
+runs = list_runs(limit=100)
+run_id = st.query_params.get("run_id") or last_run_id()
 
 st.title("Trace")
 st.caption("Step-by-step agent activity.")
 
-trace = st.session_state.get("agent_trace", [])
-render_trace(trace, run_id=run_id or st.session_state.get("run_id") or "last")
+if runs:
+    labels = {
+        r["run_id"]: f"{r['run_id']} — {datetime.fromtimestamp(r['started_at']).isoformat()} — {r['idea_preview'][:40]}…"
+        for r in runs
+    }
+    options = list(labels.keys())
+    index = options.index(run_id) if run_id in options else 0
+    selected = st.selectbox("Run", options, index=index, format_func=lambda x: labels[x])
+    if selected != run_id:
+        st.query_params["run_id"] = selected
+        log_event({"event": "run_selected", "run_id": selected})
+        st.rerun()
+    run_id = selected
+    log_event({"event": "nav_page_view", "page": "trace", "run_id": run_id})
+    trace_path = artifact_path(run_id, "trace", "json")
+    if trace_path.exists():
+        trace = json.loads(trace_path.read_text(encoding="utf-8"))
+    else:
+        trace = []
+    render_trace(trace, run_id=run_id)
+else:
+    log_event({"event": "nav_page_view", "page": "trace", "run_id": None})
+    st.info("No runs found.")

--- a/pages/20_Reports.py
+++ b/pages/20_Reports.py
@@ -1,57 +1,82 @@
 """Reports and exports page."""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
 import streamlit as st
 
 from utils import trace_export
 from utils.telemetry import log_event
+from utils.paths import artifact_path
+from utils.runs import list_runs, last_run_id
 from app import generate_pdf
 
-log_event({"event": "nav_page_view", "page": "reports"})
+runs = list_runs(limit=100)
+run_id = st.query_params.get("run_id") or last_run_id()
 
 st.title("Reports & Exports")
 st.caption("Download outputs from your last run.")
 
-report = st.session_state.get("run_report")
-trace = st.session_state.get("agent_trace", [])
-run_id = st.session_state.get("run_id")
-
-if not report and not trace:
-    st.info("No run data found.")
+if runs:
+    labels = {
+        r["run_id"]: f"{r['run_id']} — {datetime.fromtimestamp(r['started_at']).isoformat()} — {r['idea_preview'][:40]}…"
+        for r in runs
+    }
+    options = list(labels.keys())
+    index = options.index(run_id) if run_id in options else 0
+    selected = st.selectbox("Run", options, index=index, format_func=lambda x: labels[x])
+    if selected != run_id:
+        st.query_params["run_id"] = selected
+        log_event({"event": "run_selected", "run_id": selected})
+        st.rerun()
+    run_id = selected
+    log_event({"event": "nav_page_view", "page": "reports", "run_id": run_id})
+    report_path = artifact_path(run_id, "report", "md")
+    report = report_path.read_text(encoding="utf-8") if report_path.exists() else None
+    trace_path = artifact_path(run_id, "trace", "json")
+    trace = json.loads(trace_path.read_text(encoding="utf-8")) if trace_path.exists() else []
+    if not report and not trace:
+        st.info("No run data found.")
+    else:
+        if report:
+            st.subheader("Report")
+            col_md, col_pdf = st.columns(2)
+            if col_md.download_button(
+                "Download report (.md)",
+                data=report.encode("utf-8"),
+                file_name=artifact_path(run_id, "report", "md").name,
+                mime="text/markdown",
+                use_container_width=True,
+            ):
+                log_event({"event": "export_clicked", "format": "report_md", "run_id": run_id})
+            if col_pdf.download_button(
+                "Download report (.pdf)",
+                data=generate_pdf(report),
+                file_name=artifact_path(run_id, "report", "pdf").name,
+                mime="application/pdf",
+                use_container_width=True,
+            ):
+                log_event({"event": "export_clicked", "format": "report_pdf", "run_id": run_id})
+        if trace:
+            st.subheader("Trace")
+            col_json, col_csv = st.columns(2)
+            if col_json.download_button(
+                "Download trace (.json)",
+                data=trace_export.to_json(trace),
+                file_name=artifact_path(run_id, "trace", "json").name,
+                mime="application/json",
+                use_container_width=True,
+            ):
+                log_event({"event": "export_clicked", "format": "trace_json", "run_id": run_id})
+            if col_csv.download_button(
+                "Download summary (.csv)",
+                data=trace_export.to_csv(trace, run_id=run_id),
+                file_name=artifact_path(run_id, "summary", "csv").name,
+                mime="text/csv",
+                use_container_width=True,
+            ):
+                log_event({"event": "export_clicked", "format": "trace_csv", "run_id": run_id})
 else:
-    if report:
-        st.subheader("Report")
-        col_md, col_pdf = st.columns(2)
-        if col_md.download_button(
-            "Download report (.md)",
-            data=report.encode("utf-8"),
-            file_name=f"report_{run_id or 'session'}.md",
-            mime="text/markdown",
-            use_container_width=True,
-        ):
-            log_event({"event": "export_clicked", "format": "report_md", "run_id": run_id})
-        if col_pdf.download_button(
-            "Download report (.pdf)",
-            data=generate_pdf(report),
-            file_name=f"report_{run_id or 'session'}.pdf",
-            mime="application/pdf",
-            use_container_width=True,
-        ):
-            log_event({"event": "export_clicked", "format": "report_pdf", "run_id": run_id})
-    if trace:
-        st.subheader("Trace")
-        col_json, col_csv = st.columns(2)
-        if col_json.download_button(
-            "Download trace (.json)",
-            data=trace_export.to_json(trace),
-            file_name=f"trace_{run_id or 'session'}.json",
-            mime="application/json",
-            use_container_width=True,
-        ):
-            log_event({"event": "export_clicked", "format": "trace_json", "run_id": run_id})
-        if col_csv.download_button(
-            "Download trace (.csv)",
-            data=trace_export.to_csv(trace, run_id=run_id),
-            file_name=f"trace_{run_id or 'session'}.csv",
-            mime="text/csv",
-            use_container_width=True,
-        ):
-            log_event({"event": "export_clicked", "format": "trace_csv", "run_id": run_id})
+    log_event({"event": "nav_page_view", "page": "reports", "run_id": None})
+    st.info("No runs found.")

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T01:44:20.798012Z'
-git_sha: ae51bd5fb91e742dbdaf013ed49841eedbeadd0e
+generated_at: '2025-08-30T01:58:37.389110Z'
+git_sha: 49bd2f18f3c710274daa4cbae26f22f317f382d8
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -184,20 +184,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/__init__.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
- path: orchestrators/__init__.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
@@ -212,6 +198,13 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
+- path: orchestrators/__init__.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
 - path: orchestrators/plan_utils.py
   role: Orchestrator
   responsibilities: []
@@ -219,14 +212,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/schemas.py
-  role: Summarization
+- path: orchestrators/app_builder.py
+  role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/__init__.py
+- path: core/summarization/integrator.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -240,7 +233,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
+- path: core/summarization/__init__.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/scripts/cleanup_runs.py
+++ b/scripts/cleanup_runs.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+RUNS_ROOT = Path(".dr_rd") / "runs"
+
+
+def _run_dirs():
+    if not RUNS_ROOT.exists():
+        return []
+    return sorted([p for p in RUNS_ROOT.iterdir() if p.is_dir()])
+
+
+def cleanup_keep(keep: int) -> None:
+    dirs = _run_dirs()
+    for p in dirs[:-keep]:
+        shutil.rmtree(p, ignore_errors=True)
+        print(f"Deleted {p}")
+
+
+def cleanup_max_bytes(limit: int) -> None:
+    dirs = _run_dirs()
+    sizes = [(p, sum(f.stat().st_size for f in p.rglob("*") if f.is_file())) for p in dirs]
+    total = sum(s for _, s in sizes)
+    for p, s in sizes:
+        if total <= limit:
+            break
+        shutil.rmtree(p, ignore_errors=True)
+        total -= s
+        print(f"Deleted {p}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Cleanup old run artifacts")
+    parser.add_argument("--keep", type=int, help="Keep newest N runs")
+    parser.add_argument("--max-bytes", type=int, dest="max_bytes", help="Max total bytes to keep")
+    args = parser.parse_args()
+    if args.keep is not None:
+        cleanup_keep(args.keep)
+    elif args.max_bytes is not None:
+        cleanup_max_bytes(args.max_bytes)
+    else:
+        parser.error("Specify --keep or --max-bytes")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,16 @@
+import os
+
+from utils.paths import run_root, artifact_path, ensure_run_dirs, write_bytes, write_text
+
+
+def test_artifact_paths_and_writers(tmp_path):
+    os.chdir(tmp_path)
+    run_id = "1234567890-abcd1234"
+    ensure_run_dirs(run_id)
+    root = run_root(run_id)
+    assert root.exists()
+    bpath = write_bytes(run_id, "trace", "json", b"{}");
+    assert bpath == artifact_path(run_id, "trace", "json")
+    assert bpath.read_bytes() == b"{}"
+    tpath = write_text(run_id, "report", "md", "hi")
+    assert tpath.read_text() == "hi"

--- a/tests/test_run_ids.py
+++ b/tests/test_run_ids.py
@@ -1,0 +1,9 @@
+from utils.run_id import new_run_id, is_run_id
+
+
+def test_new_run_id_unique_and_valid():
+    ids = {new_run_id() for _ in range(5)}
+    assert len(ids) == 5
+    for rid in ids:
+        assert is_run_id(rid)
+    assert not is_run_id("bad-id")

--- a/tests/test_runs_listing.py
+++ b/tests/test_runs_listing.py
@@ -1,0 +1,18 @@
+import os
+from utils.runs import create_run_meta, list_runs
+from utils.paths import ensure_run_dirs
+
+
+def test_list_runs_newest_first(tmp_path):
+    os.chdir(tmp_path)
+    ids = [
+        "1000000000-aa",  # older
+        "1000000001-bb",
+        "1000000002-cc",
+    ]
+    for rid in ids:
+        ensure_run_dirs(rid)
+        create_run_meta(rid, mode="m", idea_preview=f"idea {rid}")
+    runs = list_runs()
+    assert [r["run_id"] for r in runs[:3]] == ids[::-1]
+    assert "idea" in runs[0]["idea_preview"]

--- a/utils/paths.py
+++ b/utils/paths.py
@@ -1,11 +1,33 @@
 from __future__ import annotations
-from pathlib import Path
-from datetime import datetime
 
-def new_run_dir(base: Path) -> Path:
-    base = Path(base)
-    base.mkdir(parents=True, exist_ok=True)
-    ts = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
-    run_dir = base / ts
-    run_dir.mkdir(parents=True, exist_ok=False)
-    return run_dir
+from pathlib import Path
+
+RUNS_ROOT = Path(".dr_rd") / "runs"
+
+
+def run_root(run_id: str) -> Path:
+    """Return the root directory for a run."""
+    return RUNS_ROOT / run_id
+
+
+def artifact_path(run_id: str, name: str, ext: str) -> Path:
+    """Return path for a named artifact within a run."""
+    return run_root(run_id) / f"{name}.{ext}"
+
+
+def ensure_run_dirs(run_id: str) -> None:
+    """Ensure the run directory exists."""
+    run_root(run_id).mkdir(parents=True, exist_ok=True)
+
+
+def write_bytes(run_id: str, name: str, ext: str, data: bytes) -> Path:
+    """Write bytes to a run artifact and return its path."""
+    ensure_run_dirs(run_id)
+    path = artifact_path(run_id, name, ext)
+    path.write_bytes(data)
+    return path
+
+
+def write_text(run_id: str, name: str, ext: str, text: str, encoding: str = "utf-8") -> Path:
+    """Write text to a run artifact and return its path."""
+    return write_bytes(run_id, name, ext, text.encode(encoding))

--- a/utils/run_id.py
+++ b/utils/run_id.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import re
+import time
+import uuid
+
+_RUN_ID_RE = re.compile(r"^\d{10}-[0-9a-f]{8}$")
+
+
+def new_run_id() -> str:
+    """Return a sortable run identifier.
+
+    Format: ``{epoch_seconds}-{uuid8}``
+    """
+    return f"{int(time.time())}-{uuid.uuid4().hex[:8]}"
+
+
+def is_run_id(s: str) -> bool:
+    """Return True if ``s`` looks like a run_id."""
+    return bool(_RUN_ID_RE.fullmatch(s))

--- a/utils/runs.py
+++ b/utils/runs.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import List, Dict
+
+from .paths import artifact_path, ensure_run_dirs
+
+
+def create_run_meta(run_id: str, *, mode: str, idea_preview: str) -> None:
+    """Create initial run metadata."""
+    ensure_run_dirs(run_id)
+    meta = {
+        "run_id": run_id,
+        "started_at": int(time.time()),
+        "mode": mode,
+        "idea_preview": idea_preview,
+        "status": "running",
+    }
+    artifact_path(run_id, "run", "json").write_text(
+        json.dumps(meta, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+
+def complete_run_meta(run_id: str, *, status: str) -> None:
+    """Mark a run as completed with status."""
+    path = artifact_path(run_id, "run", "json")
+    if not path.exists():
+        return
+    try:
+        meta = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        meta = {"run_id": run_id}
+    meta.update({"completed_at": int(time.time()), "status": status})
+    path.write_text(json.dumps(meta, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def load_run_meta(run_id: str) -> dict | None:
+    """Load run metadata or return None."""
+    path = artifact_path(run_id, "run", "json")
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def list_runs(limit: int = 200) -> list[dict]:
+    """Return up to ``limit`` run metadata dicts, newest first."""
+    root = Path(".dr_rd") / "runs"
+    if not root.exists():
+        return []
+    metas: List[Dict] = []
+    for child in sorted(root.iterdir(), reverse=True):
+        if not child.is_dir():
+            continue
+        meta = load_run_meta(child.name)
+        if meta:
+            metas.append(meta)
+        if len(metas) >= limit:
+            break
+    metas.sort(key=lambda m: m.get("started_at", 0), reverse=True)
+    return metas
+
+
+def last_run_id() -> str | None:
+    runs = list_runs(limit=1)
+    return runs[0]["run_id"] if runs else None

--- a/utils/trace_export.py
+++ b/utils/trace_export.py
@@ -4,8 +4,9 @@ import csv
 import io
 import json
 from collections import OrderedDict
-from typing import Any, Iterable, List, Dict, Sequence
+from typing import Any, Dict, List, Sequence
 
+from .paths import write_bytes
 
 Row = List[Any]
 
@@ -90,4 +91,23 @@ def to_markdown(trace: Sequence[Dict[str, Any]], run_id: str | None = None) -> b
     return "\n".join(lines).encode("utf-8")
 
 
-__all__ = ["to_json", "to_csv", "to_markdown"]
+def write_trace_json(run_id: str, trace: Sequence[Dict[str, Any]]) -> None:
+    write_bytes(run_id, "trace", "json", to_json(trace))
+
+
+def write_trace_csv(run_id: str, trace: Sequence[Dict[str, Any]]) -> None:
+    write_bytes(run_id, "summary", "csv", to_csv(trace, run_id=run_id))
+
+
+def write_trace_markdown(run_id: str, trace: Sequence[Dict[str, Any]]) -> None:
+    write_bytes(run_id, "trace", "md", to_markdown(trace, run_id=run_id))
+
+
+__all__ = [
+    "to_json",
+    "to_csv",
+    "to_markdown",
+    "write_trace_json",
+    "write_trace_csv",
+    "write_trace_markdown",
+]


### PR DESCRIPTION
## Summary
- Introduce stable run IDs and metadata helpers for listing and completing runs
- Persist run artifacts under `.dr_rd/runs/{run_id}` with canonical names
- Add deep-linkable Trace and Reports pages with run selector
- Provide cleanup script for pruning old runs

## Testing
- `pytest tests/test_trace_export.py tests/test_run_ids.py tests/test_paths.py tests/test_runs_listing.py`
- `python scripts/generate_repo_map.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2599178a0832cb656c3a79b3fed1f