### PR TITLE
feat: add report exports and bundle

### DIFF
--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T02:05:34.266856Z from commit 1da5d06_
+_Last generated at 2025-08-30T02:09:55.049619Z from commit a10319a_

--- a/pages/20_Reports.py
+++ b/pages/20_Reports.py
@@ -1,86 +1,88 @@
 """Reports and exports page."""
 from __future__ import annotations
 
+import io
 import json
-from datetime import datetime
+from zipfile import ZipFile
 
 import streamlit as st
 
-from utils import trace_export
+from utils import bundle, report_builder
+from utils.paths import artifact_path, run_root
+from utils.runs import last_run_id, load_run_meta
 from utils.telemetry import log_event
-from utils.paths import artifact_path
-from utils.runs import list_runs, last_run_id
-from app import generate_pdf
-from utils.query_params import view_state_from_params
 
-state = view_state_from_params(st.query_params)
-runs = list_runs(limit=100)
-run_id = state["run_id"] or last_run_id()
-if st.query_params.get("view") != "reports":
-    st.query_params["view"] = "reports"
 
-st.title("Reports & Exports")
-st.caption("Download outputs from your last run.")
+run_id = st.query_params.get("run_id") or last_run_id()
 
-if runs:
-    labels = {
-        r["run_id"]: f"{r['run_id']} — {datetime.fromtimestamp(r['started_at']).isoformat()} — {r['idea_preview'][:40]}…"
-        for r in runs
-    }
-    options = list(labels.keys())
-    index = options.index(run_id) if run_id in options else 0
-    selected = st.selectbox("Run", options, index=index, format_func=lambda x: labels[x])
-    if selected != run_id:
-        st.query_params["run_id"] = selected
-        log_event({"event": "run_selected", "run_id": selected})
-        st.rerun()
-    run_id = selected
+if not run_id:
+    log_event({"event": "nav_page_view", "page": "reports", "run_id": None})
+    st.title("Reports & Exports")
+    st.info("No runs found.")
+else:
     log_event({"event": "nav_page_view", "page": "reports", "run_id": run_id})
-    report_path = artifact_path(run_id, "report", "md")
-    report = report_path.read_text(encoding="utf-8") if report_path.exists() else None
+    st.title("Reports & Exports")
+    st.caption("Preview and export artifacts for this run.")
+
+    meta = load_run_meta(run_id) or {}
     trace_path = artifact_path(run_id, "trace", "json")
     trace = json.loads(trace_path.read_text(encoding="utf-8")) if trace_path.exists() else []
-    if not report and not trace:
-        st.info("No run data found.")
-    else:
-        if report:
-            st.subheader("Report")
-            col_md, col_pdf = st.columns(2)
-            if col_md.download_button(
-                "Download report (.md)",
-                data=report.encode("utf-8"),
-                file_name=artifact_path(run_id, "report", "md").name,
-                mime="text/markdown",
+    summary_path = artifact_path(run_id, "synth", "md")
+    summary_text = summary_path.read_text(encoding="utf-8") if summary_path.exists() else None
+    totals = {
+        "tokens": sum((step.get("tokens") or 0) for step in trace),
+        "cost": sum((step.get("cost") or 0.0) for step in trace),
+    }
+    md = report_builder.build_markdown_report(run_id, meta, trace, summary_text, totals)
+
+    with st.expander("Report preview", expanded=True):
+        st.code(md, language=None)
+
+    def _read_bytes(rid: str, name: str, ext: str) -> bytes:
+        if name == "report" and ext == "md":
+            return md.encode("utf-8")
+        path = artifact_path(rid, name, ext)
+        if not path.exists():
+            raise FileNotFoundError
+        return path.read_bytes()
+
+    def _list_existing(rid: str):
+        root = run_root(rid)
+        if not root.exists():
+            return []
+        return [(p.stem, p.suffix.lstrip(".")) for p in sorted(root.iterdir()) if p.is_file()]
+
+    bundle_bytes = bundle.build_zip_bundle(run_id, [], read_bytes=_read_bytes, list_existing=_list_existing)
+    with ZipFile(io.BytesIO(bundle_bytes)) as zf:
+        bundle_count = len(zf.namelist())
+
+    col_md, col_zip = st.columns(2)
+    if col_md.download_button(
+        "Download report (.md)",
+        data=md.encode("utf-8"),
+        file_name=f"report_{run_id}.md",
+        mime="text/markdown",
+        use_container_width=True,
+    ):
+        log_event({"event": "export_clicked", "format": "md", "run_id": run_id})
+    if col_zip.download_button(
+        "Download artifact bundle (.zip)",
+        data=bundle_bytes,
+        file_name=f"artifacts_{run_id}.zip",
+        mime="application/zip",
+        use_container_width=True,
+    ):
+        log_event({"event": "export_clicked", "format": "zip", "run_id": run_id, "count": bundle_count})
+
+    files = _list_existing(run_id)
+    if files:
+        st.subheader("Artifacts")
+        for name, ext in files:
+            path = artifact_path(run_id, name, ext)
+            st.download_button(
+                f"{name}.{ext}",
+                data=path.read_bytes(),
+                file_name=path.name,
                 use_container_width=True,
-            ):
-                log_event({"event": "export_clicked", "format": "report_md", "run_id": run_id})
-            if col_pdf.download_button(
-                "Download report (.pdf)",
-                data=generate_pdf(report),
-                file_name=artifact_path(run_id, "report", "pdf").name,
-                mime="application/pdf",
-                use_container_width=True,
-            ):
-                log_event({"event": "export_clicked", "format": "report_pdf", "run_id": run_id})
-        if trace:
-            st.subheader("Trace")
-            col_json, col_csv = st.columns(2)
-            if col_json.download_button(
-                "Download trace (.json)",
-                data=trace_export.to_json(trace),
-                file_name=artifact_path(run_id, "trace", "json").name,
-                mime="application/json",
-                use_container_width=True,
-            ):
-                log_event({"event": "export_clicked", "format": "trace_json", "run_id": run_id})
-            if col_csv.download_button(
-                "Download summary (.csv)",
-                data=trace_export.to_csv(trace, run_id=run_id),
-                file_name=artifact_path(run_id, "summary", "csv").name,
-                mime="text/csv",
-                use_container_width=True,
-            ):
-                log_event({"event": "export_clicked", "format": "trace_csv", "run_id": run_id})
-else:
-    log_event({"event": "nav_page_view", "page": "reports", "run_id": None})
-    st.info("No runs found.")
+                key=path.name,
+            )

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T02:05:34.266856Z'
-git_sha: 1da5d06b13d7899b2b7d07e5df48eb394495e37a
+generated_at: '2025-08-30T02:09:55.049619Z'
+git_sha: a10319aa0d7cbdcb7011de80ca6d741f4323897a
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -184,6 +184,20 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
+- path: orchestrators/__init__.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/app_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
 - path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
@@ -205,15 +219,8 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/__init__.py
-  role: Orchestrator
+- path: core/summarization/integrator.py
+  role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
@@ -226,21 +233,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
-  role: Summarization
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: core/summarization/integrator.py
-  role: Summarization
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: core/summarization/__init__.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -1,0 +1,22 @@
+from io import BytesIO
+from zipfile import ZipFile
+
+from utils.bundle import build_zip_bundle
+
+
+def _fake_read(run_id: str, name: str, ext: str) -> bytes:
+    return f"{name}.{ext}".encode()
+
+
+def _fake_list(run_id: str):
+    return [("extra", "txt")]
+
+
+def test_build_zip_bundle():
+    data = build_zip_bundle("r1", [], read_bytes=_fake_read, list_existing=_fake_list)
+    with ZipFile(BytesIO(data)) as zf:
+        names = sorted(zf.namelist())
+        contents = {n: zf.read(n) for n in names}
+    assert names == ["extra.txt", "report.md", "summary.csv", "trace.json"]
+    assert contents["trace.json"] == b"trace.json"
+    assert contents["extra.txt"] == b"extra.txt"

--- a/tests/test_report_builder.py
+++ b/tests/test_report_builder.py
@@ -1,0 +1,34 @@
+from utils.report_builder import build_markdown_report
+from utils.paths import ensure_run_dirs, run_root
+
+
+def test_build_markdown_report(tmp_path):
+    run_id = "test-run"
+    ensure_run_dirs(run_id)
+    root = run_root(run_id)
+    (root / "trace.json").write_text("[]", encoding="utf-8")
+    meta = {
+        "run_id": run_id,
+        "idea_preview": "test idea",
+        "mode": "test",
+        "started_at": 0,
+        "completed_at": 1,
+    }
+    trace = [
+        {
+            "phase": "plan",
+            "name": "step1",
+            "status": "complete",
+            "summary": "did thing",
+            "duration_ms": 10,
+            "tokens": 5,
+            "cost": 0.1,
+        },
+        {"phase": "exec", "name": "step2", "status": "error", "summary": "fail"},
+    ]
+    totals = {"tokens": 5, "cost": 0.1}
+    md = build_markdown_report(run_id, meta, trace, None, totals)
+    assert f"DR-RD Report — {run_id}" in md
+    assert "## Overview" in md
+    assert "Trace summary table" in md
+    assert "trace.json" in md

--- a/tests/test_trace_export_rows.py
+++ b/tests/test_trace_export_rows.py
@@ -1,0 +1,30 @@
+from utils.trace_export import flatten_trace_rows
+
+
+def test_flatten_trace_rows():
+    trace = [
+        {
+            "phase": "plan",
+            "name": "a",
+            "status": "complete",
+            "duration_ms": 1,
+            "tokens": 2,
+            "cost": 0.3,
+            "summary": "ok",
+        },
+        {"phase": "exec", "name": "b", "status": "error"},
+    ]
+    rows = flatten_trace_rows(trace)
+    assert len(rows) == 2
+    assert rows[0]["i"] == 1
+    assert rows[1]["status"] == "error"
+    assert set(rows[0].keys()) == {
+        "i",
+        "phase",
+        "name",
+        "status",
+        "duration_ms",
+        "tokens",
+        "cost",
+        "summary",
+    }

--- a/utils/bundle.py
+++ b/utils/bundle.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from io import BytesIO
+from zipfile import ZipFile, ZIP_DEFLATED
+from typing import Callable, Iterable, Tuple
+
+DEFAULT_FILES = [
+    ("trace", "json"),
+    ("summary", "csv"),
+    ("report", "md"),
+]
+
+
+def build_zip_bundle(
+    run_id: str,
+    files: Iterable[Tuple[str, str]],
+    *,
+    read_bytes: Callable[[str, str, str], bytes],
+    list_existing: Callable[[str], Iterable[Tuple[str, str]]],
+) -> bytes:
+    """Create an in-memory ZIP for the run."""
+    to_include = set(DEFAULT_FILES)
+    to_include.update(files)
+    for name_ext in list_existing(run_id):
+        to_include.add(name_ext)
+
+    buffer = BytesIO()
+    with ZipFile(buffer, "w", ZIP_DEFLATED) as zf:
+        for name, ext in sorted(to_include):
+            try:
+                data = read_bytes(run_id, name, ext)
+            except Exception:
+                continue
+            zf.writestr(f"{name}.{ext}", data)
+    return buffer.getvalue()
+
+
+__all__ = ["build_zip_bundle", "DEFAULT_FILES"]

--- a/utils/report_builder.py
+++ b/utils/report_builder.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Mapping, Optional, Sequence
+
+from .paths import run_root
+from .trace_export import flatten_trace_rows
+
+
+def summarize_steps(trace: Sequence[Mapping], limit: int = 8) -> list[str]:
+    """Return up to ``limit`` step summaries from earliest complete steps."""
+    summaries: List[str] = []
+    for step in trace:
+        if step.get("status") != "complete":
+            continue
+        summary = (step.get("summary") or "").strip()
+        if not summary:
+            continue
+        summaries.append(summary)
+        if len(summaries) >= limit:
+            break
+    return summaries
+
+
+def trace_table(rows: Sequence[Mapping]) -> str:
+    """Build a compact Markdown table from flattened rows."""
+    header = "| i | phase | name | status | duration_ms | tokens | cost |\n"
+    header += "|---|---|---|---|---|---|---|\n"
+    lines = [header]
+    for r in rows:
+        line = "| {i} | {phase} | {name} | {status} | {duration_ms} | {tokens} | {cost} |".format(
+            i=r.get("i", ""),
+            phase=r.get("phase", ""),
+            name=r.get("name", ""),
+            status=r.get("status", ""),
+            duration_ms=r.get("duration_ms", ""),
+            tokens=r.get("tokens", ""),
+            cost=r.get("cost", ""),
+        )
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def build_markdown_report(
+    run_id: str,
+    meta: Mapping,
+    trace: Sequence[Mapping],
+    summary_text: Optional[str],
+    totals: Mapping,
+) -> str:
+    """Assemble a human readable markdown report for a run."""
+
+    lines: List[str] = []
+    lines.append(f"# DR-RD Report — {run_id}\n")
+
+    lines.append("## Overview")
+    idea = meta.get("idea_preview", "")
+    mode = meta.get("mode", "")
+    started = meta.get("started_at")
+    completed = meta.get("completed_at")
+    started_str = (
+        datetime.fromtimestamp(started).isoformat() if isinstance(started, (int, float)) else ""
+    )
+    completed_str = (
+        datetime.fromtimestamp(completed).isoformat() if isinstance(completed, (int, float)) else ""
+    )
+    duration = ""
+    if started and completed:
+        duration = str(int(completed - started)) + " s"
+    if idea:
+        lines.append(f"- Idea: {idea}")
+    if mode:
+        lines.append(f"- Mode: {mode}")
+    if started_str:
+        lines.append(f"- Started: {started_str}")
+    if completed_str:
+        lines.append(f"- Completed: {completed_str}")
+    if duration:
+        lines.append(f"- Duration: {duration}")
+    lines.append("")
+
+    lines.append("## Key results")
+    if summary_text:
+        lines.append(summary_text.strip())
+    else:
+        for s in summarize_steps(trace):
+            lines.append(f"- {s}")
+    lines.append("")
+
+    lines.append("## Metrics")
+    tokens = totals.get("tokens")
+    cost = totals.get("cost")
+    lines.append(f"- Steps: {len(trace)}")
+    if tokens is not None:
+        lines.append(f"- Tokens: {tokens}")
+    if cost is not None:
+        lines.append(f"- Cost: ${cost:.4f}")
+    lines.append("")
+
+    rows = flatten_trace_rows(trace)
+    lines.append("## Trace summary table")
+    lines.append(trace_table(rows))
+    lines.append("")
+
+    errors = [step for step in trace if step.get("status") == "error"]
+    if errors:
+        lines.append("## Errors")
+        for e in errors:
+            summary = (e.get("summary") or "").strip()
+            lines.append(f"- {e.get('name', '')} — {summary}")
+        lines.append("")
+
+    root = run_root(run_id)
+    artifacts: list[str] = []
+    if root.exists():
+        artifacts = [p.name for p in sorted(root.iterdir()) if p.is_file()]
+    lines.append("## Artifacts list")
+    for name in artifacts:
+        lines.append(f"- {name}")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+__all__ = ["build_markdown_report", "summarize_steps", "trace_table"]


### PR DESCRIPTION
## Summary
- build deterministic markdown report for runs
- package run artifacts into in-memory ZIP bundles
- streamline Reports page with preview, artifact downloads and telemetry hooks
- expose `flatten_trace_rows` utility

## Testing
- `pytest tests/test_report_builder.py tests/test_bundle.py tests/test_trace_export_rows.py`
- `pytest tests/test_pages_imports.py`


------
https://chatgpt.com/codex/tasks/task_e_68b25cba65bc832ca63c8d552881f3f8