### PR TITLE
feat: persist user preferences and defaults

### DIFF
--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T02:09:55.049619Z from commit a10319a_
+_Last generated at 2025-08-30T02:18:03.093850Z from commit 1c8dd6f_

--- a/pages/90_Settings.py
+++ b/pages/90_Settings.py
@@ -1,42 +1,134 @@
 """Settings page."""
+import json
+import copy
+from typing import Any
 import streamlit as st
 
-from utils.run_config import defaults
+from utils.prefs import DEFAULT_PREFS, load_prefs, save_prefs
 from utils.telemetry import log_event
-from app import load_ui_config, save_ui_config
 
 if st.query_params.get("view") != "settings":
     st.query_params["view"] = "settings"
 log_event({"event": "nav_page_view", "page": "settings"})
 
 st.title("Settings")
-st.caption("Configure default run options.")
+st.caption("Configure preferences and defaults.")
 
-stored = load_ui_config()
-base = defaults()
+prefs = load_prefs()
+original = copy.deepcopy(prefs)
 
+
+def _flatten(d: dict, prefix: str = "", out: dict | None = None) -> dict:
+    out = out or {}
+    for k, v in d.items():
+        path = f"{prefix}.{k}" if prefix else k
+        if isinstance(v, dict):
+            _flatten(v, path, out)
+        else:
+            out[path] = v
+    return out
+
+# Defaults for new runs
+st.subheader("Defaults for new runs")
 mode = st.selectbox(
-    "Default mode",
+    "Mode",
     ["standard", "test", "deep"],
-    index=["standard", "test", "deep"].index(stored.get("mode", base.mode)),
+    index=["standard", "test", "deep"].index(prefs["defaults"].get("mode", "standard")),
 )
-auto_trace = st.checkbox(
-    "Auto export trace",
-    value=stored.get("auto_export_trace", base.auto_export_trace),
+max_tokens = st.number_input(
+    "Max tokens",
+    min_value=0,
+    step=100,
+    value=prefs["defaults"].get("max_tokens", 0),
 )
-auto_report = st.checkbox(
-    "Auto export report",
-    value=stored.get("auto_export_report", base.auto_export_report),
+budget_limit = st.number_input(
+    "Budget limit (USD)",
+    min_value=0.0,
+    step=0.5,
+    value=prefs["defaults"].get("budget_limit_usd") or 0.0,
+)
+knowledge_sources = st.multiselect(
+    "Knowledge sources",
+    ["samples", "uploads", "connectors"],
+    default=prefs["defaults"].get("knowledge_sources", []),
 )
 
-if st.button("Save", type="primary", use_container_width=True):
-    data = {
+# UI behavior
+st.subheader("UI behavior")
+show_trace = st.checkbox(
+    "Show trace by default",
+    value=prefs["ui"].get("show_trace_by_default", True),
+)
+auto_export = st.checkbox(
+    "Auto export on completion",
+    value=prefs["ui"].get("auto_export_on_completion", False),
+)
+trace_page_size = st.number_input(
+    "Trace page size",
+    min_value=10,
+    max_value=200,
+    value=prefs["ui"].get("trace_page_size", 50),
+)
+
+# Privacy
+st.subheader("Privacy")
+telemetry = st.checkbox(
+    "Telemetry enabled",
+    value=prefs["privacy"].get("telemetry_enabled", True),
+)
+share_adv = st.checkbox(
+    "Include advanced options in share links",
+    value=prefs["privacy"].get("include_advanced_in_share_links", False),
+)
+
+updated = {
+    "version": DEFAULT_PREFS["version"],
+    "defaults": {
         "mode": mode,
-        "auto_export_trace": auto_trace,
-        "auto_export_report": auto_report,
-    }
-    save_ui_config(data)
-    for k, v in data.items():
-        st.session_state[k] = v
-    log_event({"event": "settings_changed", **data})
-    st.success("Settings saved")
+        "max_tokens": int(max_tokens),
+        "budget_limit_usd": float(budget_limit) if budget_limit else None,
+        "knowledge_sources": knowledge_sources,
+    },
+    "ui": {
+        "show_trace_by_default": bool(show_trace),
+        "auto_export_on_completion": bool(auto_export),
+        "trace_page_size": int(trace_page_size),
+    },
+    "privacy": {
+        "telemetry_enabled": bool(telemetry),
+        "include_advanced_in_share_links": bool(share_adv),
+    },
+}
+
+if st.button("Save preferences", type="primary"):
+    save_prefs(updated)
+    flat_old = _flatten(original)
+    flat_new = _flatten(updated)
+    changed = [k for k, v in flat_new.items() if flat_old.get(k) != v]
+    log_event({"event": "settings_changed", "keys_changed": changed, "version": updated["version"]})
+    st.success("Preferences saved")
+    prefs = updated
+
+if st.button("Restore factory defaults"):
+    save_prefs(DEFAULT_PREFS)
+    log_event({"event": "settings_changed", "keys_changed": list(_flatten(original).keys()), "version": DEFAULT_PREFS["version"]})
+    st.success("Preferences restored")
+    prefs = load_prefs()
+
+uploaded = st.file_uploader("Import preferences (.json)", type="json")
+if uploaded is not None:
+    try:
+        data = json.load(uploaded)
+        save_prefs(data)
+        log_event({"event": "settings_imported", "version": data.get("version")})
+        st.success("Preferences imported")
+        prefs = load_prefs()
+    except Exception:
+        st.error("Invalid preferences file")
+
+if st.download_button(
+    "Export preferences",
+    data=json.dumps(prefs).encode("utf-8"),
+    file_name="config.json",
+):
+    log_event({"event": "settings_exported", "version": prefs.get("version")})

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T02:09:55.049619Z'
-git_sha: a10319aa0d7cbdcb7011de80ca6d741f4323897a
+generated_at: '2025-08-30T02:18:03.093850Z'
+git_sha: 1c8dd6f0b44703765b7d83777f5906d32cee7726
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -184,13 +184,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/__init__.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/app_builder.py
   role: Orchestrator
   responsibilities: []
@@ -198,7 +191,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/spec_builder.py
+- path: orchestrators/qa_router.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -212,7 +205,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/qa_router.py
+- path: orchestrators/__init__.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []

--- a/tests/test_prefs.py
+++ b/tests/test_prefs.py
@@ -1,0 +1,74 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from utils import prefs
+
+
+def _patch_config(tmp_path: Path, monkeypatch):
+    cfg_dir = tmp_path / ".dr_rd"
+    monkeypatch.setattr(prefs, "CONFIG_DIR", cfg_dir)
+    monkeypatch.setattr(prefs, "CONFIG_PATH", cfg_dir / "config.json")
+
+
+def test_load_creates_defaults(tmp_path, monkeypatch):
+    _patch_config(tmp_path, monkeypatch)
+    if prefs.CONFIG_PATH.exists():
+        prefs.CONFIG_PATH.unlink()
+    loaded = prefs.load_prefs()
+    assert loaded == prefs.DEFAULT_PREFS
+    assert prefs.CONFIG_PATH.exists()
+
+
+def test_save_and_load_roundtrip(tmp_path, monkeypatch):
+    _patch_config(tmp_path, monkeypatch)
+    data = prefs.DEFAULT_PREFS.copy()
+    data["defaults"] = data["defaults"].copy()
+    data["defaults"]["mode"] = "deep"
+    prefs.save_prefs(data)
+    loaded = prefs.load_prefs()
+    assert loaded["defaults"]["mode"] == "deep"
+    assert loaded["version"] == prefs.DEFAULT_PREFS["version"]
+
+
+def test_invalid_values_coerced(tmp_path, monkeypatch):
+    _patch_config(tmp_path, monkeypatch)
+    bad = {
+        "version": 1,
+        "defaults": {"max_tokens": "1000", "extra": True},
+        "ui": {"trace_page_size": 500},
+        "privacy": {"telemetry_enabled": "yes", "unknown": True},
+        "other": {"x": 1},
+    }
+    prefs.save_prefs(bad)
+    loaded = prefs.load_prefs()
+    assert loaded["defaults"]["max_tokens"] == 1000
+    assert "extra" not in loaded["defaults"]
+    assert loaded["ui"]["trace_page_size"] == 200
+    assert loaded["privacy"]["telemetry_enabled"] is True
+    assert "unknown" not in loaded["privacy"]
+    assert "other" not in loaded
+
+
+def test_merge_defaults(tmp_path, monkeypatch):
+    _patch_config(tmp_path, monkeypatch)
+    data = prefs.DEFAULT_PREFS.copy()
+    data["defaults"] = data["defaults"].copy()
+    data["defaults"]["mode"] = "test"
+    prefs.save_prefs(data)
+    base = {"mode": "standard", "max_tokens": 8000, "budget_limit_usd": None, "knowledge_sources": []}
+    merged = prefs.merge_defaults(base)
+    assert merged["mode"] == "test"
+    assert merged["max_tokens"] == 8000
+    assert "budget_limit_usd" in merged
+
+
+def test_trace_page_size_clamped(tmp_path, monkeypatch):
+    _patch_config(tmp_path, monkeypatch)
+    data = prefs.DEFAULT_PREFS.copy()
+    data["ui"] = data["ui"].copy()
+    data["ui"]["trace_page_size"] = 5
+    prefs.save_prefs(data)
+    loaded = prefs.load_prefs()
+    assert loaded["ui"]["trace_page_size"] == 10

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -15,7 +15,9 @@ def test_defaults():
     assert isinstance(cfg, RunConfig)
     assert cfg.mode == "standard"
     assert cfg.idea == ""
-    assert cfg.knowledge_sources == []
+    assert cfg.knowledge_sources == ["samples"]
+    assert cfg.budget_limit_usd is None
+    assert cfg.max_tokens == 8000
 
 
 def test_to_orchestrator_kwargs_minimal():
@@ -25,6 +27,8 @@ def test_to_orchestrator_kwargs_minimal():
     assert kw["idea"] == "x"
     assert kw["rag"] is True
     assert kw["knowledge_sources"] == []
+    assert kw["max_tokens"] == 8000
+    assert kw["budget_limit_usd"] is None
 
 
 def test_to_orchestrator_kwargs_with_advanced():

--- a/utils/prefs.py
+++ b/utils/prefs.py
@@ -1,0 +1,166 @@
+"""Helpers for persisted user preferences."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from .clients import get_firestore_client
+
+CONFIG_DIR = Path(".dr_rd")
+CONFIG_PATH = CONFIG_DIR / "config.json"
+
+DEFAULT_PREFS: dict[str, Any] = {
+    "version": 1,
+    "defaults": {
+        "mode": "standard",
+        "budget_limit_usd": None,
+        "max_tokens": 8000,
+        "knowledge_sources": ["samples"],
+    },
+    "ui": {
+        "show_trace_by_default": True,
+        "auto_export_on_completion": False,
+        "trace_page_size": 50,
+    },
+    "privacy": {
+        "telemetry_enabled": True,
+        "include_advanced_in_share_links": False,
+    },
+}
+
+_ALLOWED_SECTIONS = {"defaults", "ui", "privacy", "version"}
+
+
+def _validate(raw: Mapping[str, Any] | None) -> dict:
+    """Return a sanitized preferences dict."""
+    prefs = json.loads(json.dumps(DEFAULT_PREFS))  # deep copy
+    if not isinstance(raw, Mapping):
+        return prefs
+
+    if isinstance(raw.get("version"), int):
+        prefs["version"] = raw["version"]
+
+    def _coerce(section: str, key: str, value: Any) -> None:
+        base = DEFAULT_PREFS[section][key]
+        if isinstance(base, bool):
+            prefs[section][key] = bool(value)
+        elif isinstance(base, int):
+            try:
+                prefs[section][key] = int(value)
+            except Exception:
+                pass
+        elif isinstance(base, float) or base is None:
+            if value is None:
+                prefs[section][key] = None
+            else:
+                try:
+                    prefs[section][key] = float(value)
+                except Exception:
+                    pass
+        elif isinstance(base, list):
+            if isinstance(value, list):
+                prefs[section][key] = [str(v) for v in value]
+        else:
+            prefs[section][key] = str(value)
+
+    for section in ("defaults", "ui", "privacy"):
+        raw_section = raw.get(section)
+        if not isinstance(raw_section, Mapping):
+            continue
+        for key, value in raw_section.items():
+            if key not in prefs[section]:
+                continue
+            _coerce(section, key, value)
+
+    # Clamp trace_page_size
+    tps = prefs["ui"]["trace_page_size"]
+    try:
+        tps = int(tps)
+    except Exception:
+        tps = DEFAULT_PREFS["ui"]["trace_page_size"]
+    prefs["ui"]["trace_page_size"] = max(10, min(200, tps))
+    return prefs
+
+
+def load_prefs() -> dict:
+    """Load preferences from disk, creating defaults if missing."""
+    if not CONFIG_PATH.exists():
+        save_prefs(DEFAULT_PREFS)
+        return json.loads(json.dumps(DEFAULT_PREFS))
+    try:
+        with CONFIG_PATH.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception:
+        data = {}
+    return _validate(data)
+
+
+def mirror_to_firestore(prefs: Mapping[str, Any]) -> None:
+    """Best effort mirror to Firestore; ignore failures."""
+    try:
+        client = get_firestore_client()
+        if not client:
+            return
+        client.collection("prefs").document("config").set(dict(prefs))
+    except Exception:
+        pass
+
+
+def save_prefs(prefs: Mapping[str, Any]) -> None:
+    """Validate and atomically write preferences."""
+    data = _validate(prefs)
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    tmp = CONFIG_PATH.with_suffix(".tmp")
+    with tmp.open("w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+    tmp.replace(CONFIG_PATH)
+    mirror_to_firestore(data)
+
+
+def merge_defaults(run_defaults: dict) -> dict:
+    """Overlay stored default run values onto ``run_defaults``."""
+    prefs = load_prefs()
+    merged = dict(run_defaults)
+    for k, v in prefs.get("defaults", {}).items():
+        if k in merged:
+            merged[k] = v
+    return merged
+
+
+def get_flag(path: str, default: Any = None) -> Any:
+    """Retrieve a nested flag using dot notation."""
+    prefs = load_prefs()
+    cur: Any = prefs
+    for part in path.split("."):
+        if isinstance(cur, Mapping) and part in cur:
+            cur = cur[part]
+        else:
+            return default
+    return cur
+
+
+def set_flag(path: str, value: Any) -> dict:
+    """Set a nested flag without writing to disk."""
+    prefs = load_prefs()
+    cur: Any = prefs
+    parts = path.split(".")
+    for part in parts[:-1]:
+        nxt = cur.get(part)
+        if not isinstance(nxt, dict):
+            return prefs
+        cur = nxt
+    cur[parts[-1]] = value
+    return _validate(prefs)
+
+
+__all__ = [
+    "CONFIG_DIR",
+    "CONFIG_PATH",
+    "DEFAULT_PREFS",
+    "load_prefs",
+    "save_prefs",
+    "merge_defaults",
+    "get_flag",
+    "set_flag",
+]


### PR DESCRIPTION
## Summary
- add utils.prefs to persist user preferences locally with optional Firestore mirroring
- use stored defaults in RunConfig and expose preferences in Settings page
- load preferences at app startup and honor UI flags for trace viewing and auto export

## Testing
- `pytest tests/test_prefs.py tests/test_run_config.py`
- `python scripts/generate_repo_map.py`

------
https://chatgpt.com/codex/tasks/task_e_68b25dac1808832c8db6cd425457173c