### PR TITLE
feat: add reproducible run support

### DIFF
--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T04:07:30.842606Z from commit ea85f93_
+_Last generated at 2025-08-30T04:16:39.860227Z from commit 5cace92_

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T04:07:30.842606Z'
-git_sha: ea85f9324def59cee0c8ec1b9b9fe1e28023af38
+generated_at: '2025-08-30T04:16:39.860227Z'
+git_sha: 5cace929892df7a4f875a94ef80be168b2ce67a4
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -184,20 +184,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/plan_utils.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/__init__.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/qa_router.py
   role: Orchestrator
   responsibilities: []
@@ -212,6 +198,20 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
+- path: orchestrators/plan_utils.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/__init__.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
 - path: orchestrators/app_builder.py
   role: Orchestrator
   responsibilities: []
@@ -219,7 +219,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -233,7 +233,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
+- path: core/summarization/integrator.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_env_snapshot.py
+++ b/tests/test_env_snapshot.py
@@ -1,0 +1,11 @@
+from utils.env_snapshot import capture_env
+
+
+def test_capture_env_has_expected_keys():
+    snap = capture_env()
+    assert "python_version" in snap
+    assert "python_executable" in snap
+    assert "platform" in snap
+    assert "created_at" in snap
+    assert isinstance(snap.get("packages"), dict)
+    assert snap["packages"]

--- a/tests/test_run_config_io.py
+++ b/tests/test_run_config_io.py
@@ -1,0 +1,38 @@
+import pytest
+
+from utils import run_config_io
+
+
+def test_round_trip_and_truncation():
+    cfg = {
+        "idea": "x" * 300,
+        "mode": "standard",
+        "budget_limit_usd": 5.0,
+        "max_tokens": 1000,
+        "knowledge_sources": ["a", "b"],
+        "advanced": {"foo": "bar"},
+        "seed": 42,
+        "extra": "drop",
+    }
+    lock = run_config_io.to_lockfile(cfg)
+    assert lock["inputs"]["idea"] == "x" * 200
+    out = run_config_io.from_lockfile(lock)
+    assert out == {
+        "idea": "x" * 200,
+        "mode": "standard",
+        "budget_limit_usd": 5.0,
+        "max_tokens": 1000,
+        "knowledge_sources": ["a", "b"],
+        "advanced": {"foo": "bar"},
+        "seed": 42,
+    }
+
+
+def test_type_validation():
+    bad = {
+        "schema": run_config_io.SCHEMA_VERSION,
+        "created_at": 0,
+        "inputs": {"idea": "ok", "knowledge_sources": "oops"},
+    }
+    with pytest.raises(ValueError):
+        run_config_io.from_lockfile(bad)

--- a/tests/test_run_reproduce.py
+++ b/tests/test_run_reproduce.py
@@ -1,0 +1,33 @@
+import json
+
+import pytest
+
+from utils import paths, run_config_io, run_reproduce
+
+
+def test_load_and_map(tmp_path, monkeypatch):
+    monkeypatch.setattr(paths, "RUNS_ROOT", tmp_path)
+    run_id = "r1"
+    cfg = {
+        "idea": "hi",
+        "mode": "standard",
+        "budget_limit_usd": 1.0,
+        "max_tokens": 100,
+        "knowledge_sources": ["web"],
+        "advanced": {"foo": "bar"},
+        "seed": 7,
+    }
+    lock = run_config_io.to_lockfile(cfg)
+    run_dir = tmp_path / run_id
+    run_dir.mkdir(parents=True)
+    (run_dir / "run_config.lock.json").write_text(json.dumps(lock))
+
+    loaded = run_reproduce.load_run_inputs(run_id)
+    kwargs = run_reproduce.to_orchestrator_kwargs(loaded)
+    assert kwargs["idea"] == "hi"
+    assert kwargs["knowledge_sources"] == ["web"]
+    assert kwargs["foo"] == "bar"
+    assert kwargs["seed"] == 7
+
+    with pytest.raises(FileNotFoundError):
+        run_reproduce.load_run_inputs("missing")

--- a/utils/env_snapshot.py
+++ b/utils/env_snapshot.py
@@ -1,0 +1,32 @@
+"""Capture a snapshot of the current Python environment."""
+
+from __future__ import annotations
+
+import platform
+import sys
+import time
+
+
+def capture_env() -> dict[str, object]:
+    """Return a JSON-serializable snapshot of the runtime environment."""
+    info: dict[str, object] = {
+        "python_version": platform.python_version(),
+        "python_executable": sys.executable,
+        "platform": platform.platform(),
+        "created_at": int(time.time()),
+        "packages": {},
+    }
+    try:
+        import pkg_resources  # type: ignore
+
+        info["packages"] = {d.project_name: d.version for d in pkg_resources.working_set}
+    except Exception:
+        try:
+            import importlib.metadata as md  # type: ignore
+
+            info["packages"] = {
+                dist.metadata.get("Name", dist.name): dist.version for dist in md.distributions()
+            }
+        except Exception:
+            info["packages"] = {}
+    return info

--- a/utils/run_config_io.py
+++ b/utils/run_config_io.py
@@ -1,0 +1,93 @@
+"""Serialization helpers for run configuration lockfiles."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Mapping
+
+SCHEMA_VERSION = 1
+
+
+def _validate_str(value: Any, field: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be a string")
+    return value
+
+
+def _validate_list_str(value: Any, field: str) -> list[str]:
+    if not isinstance(value, list) or not all(isinstance(v, str) for v in value):
+        raise ValueError(f"{field} must be a list of strings")
+    return value
+
+
+def _validate_mapping(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{field} must be a mapping")
+    return dict(value)
+
+
+def to_lockfile(cfg: Mapping[str, Any]) -> dict:
+    """
+    Returns a dict with:
+      {"schema": SCHEMA_VERSION, "created_at": ts,
+       "inputs": {idea, mode, budget_limit_usd, max_tokens, knowledge_sources, advanced, seed}}
+    """
+    idea = _validate_str(cfg.get("idea", ""), "idea")[:200]
+    mode = _validate_str(cfg.get("mode", "standard"), "mode")
+    budget_limit = cfg.get("budget_limit_usd")
+    if budget_limit is not None:
+        budget_limit = float(budget_limit)
+    max_tokens = cfg.get("max_tokens")
+    if max_tokens is not None:
+        max_tokens = int(max_tokens)
+    ks = cfg.get("knowledge_sources") or []
+    ks = _validate_list_str(ks, "knowledge_sources")
+    adv = cfg.get("advanced") or {}
+    if not isinstance(adv, Mapping):
+        raise ValueError("advanced must be a mapping")
+    seed = cfg.get("seed")
+    if seed is not None:
+        seed = int(seed)
+    inputs = {
+        "idea": idea,
+        "mode": mode,
+        "budget_limit_usd": budget_limit,
+        "max_tokens": max_tokens,
+        "knowledge_sources": ks,
+        "advanced": dict(adv),
+        "seed": seed,
+    }
+    return {"schema": SCHEMA_VERSION, "created_at": int(time.time()), "inputs": inputs}
+
+
+def from_lockfile(obj: Mapping[str, Any]) -> dict:
+    """Validate types, drop unknowns, return normalized dict suitable for RunConfig adapter."""
+    if obj.get("schema") != SCHEMA_VERSION:
+        raise ValueError("unsupported schema version")
+    inputs = obj.get("inputs")
+    if not isinstance(inputs, Mapping):
+        raise ValueError("inputs must be a mapping")
+    idea = _validate_str(inputs.get("idea", ""), "idea")[:200]
+    mode = _validate_str(inputs.get("mode", "standard"), "mode")
+    budget_limit = inputs.get("budget_limit_usd")
+    if budget_limit is not None:
+        budget_limit = float(budget_limit)
+    max_tokens = inputs.get("max_tokens")
+    if max_tokens is not None:
+        max_tokens = int(max_tokens)
+    ks = inputs.get("knowledge_sources") or []
+    ks = _validate_list_str(ks, "knowledge_sources")
+    adv = inputs.get("advanced") or {}
+    adv = _validate_mapping(adv, "advanced")
+    seed = inputs.get("seed")
+    if seed is not None:
+        seed = int(seed)
+    return {
+        "idea": idea,
+        "mode": mode,
+        "budget_limit_usd": budget_limit,
+        "max_tokens": max_tokens,
+        "knowledge_sources": ks,
+        "advanced": adv,
+        "seed": seed,
+    }

--- a/utils/run_reproduce.py
+++ b/utils/run_reproduce.py
@@ -1,0 +1,39 @@
+"""Helpers for reproducing previous runs."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping
+
+from . import run_config_io
+from .paths import artifact_path
+from .run_config import RunConfig
+from .run_config import to_orchestrator_kwargs as _to_orch_kwargs
+
+
+def load_run_inputs(run_id: str) -> dict[str, Any]:
+    """Read run_config.lock.json; raise FileNotFoundError if missing."""
+    path = artifact_path(run_id, "run_config", "lock.json")
+    if not path.exists():
+        raise FileNotFoundError(path)
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def to_orchestrator_kwargs(locked: Mapping[str, Any]) -> dict[str, Any]:
+    """Map lockfile 'inputs' → orchestrator kwargs (single place)."""
+    cfg_dict = run_config_io.from_lockfile(locked)
+    seed = cfg_dict.pop("seed", None)
+    rc = RunConfig(**cfg_dict)
+    kwargs = _to_orch_kwargs(rc)
+    if seed is not None:
+        kwargs["seed"] = seed
+    return kwargs
+
+
+def diff_configs(a: Mapping[str, Any], b: Mapping[str, Any]) -> dict[str, Any]:
+    """Return entries in ``b`` that differ from ``a`` (shallow)."""
+    out: dict[str, Any] = {}
+    for k, v in b.items():
+        if a.get(k) != v:
+            out[k] = v
+    return out


### PR DESCRIPTION
## Summary
- capture run inputs to a lockfile and snapshot runtime environment
- load prior run configs and prefill UI for one-click reproduction
- log telemetry for reproduction start and completion

## Testing
- `pre-commit run --files app/__init__.py pages/10_Trace.py pages/20_Reports.py utils/run_config_io.py utils/env_snapshot.py utils/run_reproduce.py tests/test_run_config_io.py tests/test_env_snapshot.py tests/test_run_reproduce.py`
- `pytest tests/test_run_config_io.py tests/test_env_snapshot.py tests/test_run_reproduce.py`


------
https://chatgpt.com/codex/tasks/task_e_68b279d148e8832cb2b866e1a71736e1