### PR TITLE
feat: add run comparison tools

### DIFF
--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T04:21:36.445505Z from commit ec823fe_
+_Last generated at 2025-08-30T04:39:50.447725Z from commit db4b4bc_

--- a/pages/25_Compare.py
+++ b/pages/25_Compare.py
@@ -1,0 +1,193 @@
+"""Compare Runs page."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import List
+
+import streamlit as st
+
+from app.ui import empty_states
+from utils.paths import artifact_path
+from utils.runs import list_runs, load_run_meta
+from utils.trace_export import flatten_trace_rows
+from utils.diff_runs import (
+    align_steps,
+    diff_metrics,
+    diff_table_rows,
+    to_csv,
+    to_markdown,
+)
+from utils.telemetry import log_event
+from utils.metrics import ensure_run_totals
+
+
+if st.query_params.get("view") != "compare":
+    st.query_params["view"] = "compare"
+
+st.title("Compare Runs")
+log_event({"event": "nav_page_view", "page": "compare"})
+
+runs = list_runs(limit=200)
+if not runs:
+    empty_states.trace_empty()
+else:
+    labels = {
+        r["run_id"]: f"{r['run_id']} — {datetime.fromtimestamp(r['started_at']).isoformat()} — {r['idea_preview'][:40]}…"
+        for r in runs
+    }
+    options = [r["run_id"] for r in runs]
+    qp = st.query_params
+    run_id_a = qp.get("run_id_a")
+    run_id_b = qp.get("run_id_b")
+
+    def _default_other(exclude: str | None) -> str | None:
+        for rid in options:
+            if rid != exclude:
+                return rid
+        return None
+
+    if run_id_a and not run_id_b:
+        run_id_b = _default_other(run_id_a)
+    elif run_id_b and not run_id_a:
+        run_id_a = _default_other(run_id_b)
+    elif not run_id_a and not run_id_b:
+        run_id_a = options[0] if options else None
+        run_id_b = _default_other(run_id_a)
+
+    if run_id_a:
+        qp["run_id_a"] = run_id_a
+    if run_id_b:
+        qp["run_id_b"] = run_id_b
+
+    index_a = options.index(run_id_a) if run_id_a in options else 0
+    index_b = options.index(run_id_b) if run_id_b in options else (1 if len(options) > 1 else 0)
+    sel_a = st.selectbox("Run A", options, index=index_a, format_func=lambda x: labels[x], key="run_a")
+    sel_b = st.selectbox("Run B", options, index=index_b, format_func=lambda x: labels[x], key="run_b")
+    if sel_a != run_id_a:
+        qp["run_id_a"] = sel_a
+        st.rerun()
+    if sel_b != run_id_b:
+        qp["run_id_b"] = sel_b
+        st.rerun()
+    run_id_a, run_id_b = sel_a, sel_b
+
+    if (
+        run_id_a
+        and run_id_b
+        and st.session_state.get("_compare_opened") != (run_id_a, run_id_b)
+    ):
+        log_event(
+            {
+                "event": "compare_opened",
+                "run_id_a": run_id_a,
+                "run_id_b": run_id_b,
+            }
+        )
+        st.session_state["_compare_opened"] = (run_id_a, run_id_b)
+
+    def _load(run_id: str) -> tuple[dict, List[dict], dict, str]:
+        meta = load_run_meta(run_id) or {}
+        trace_path = artifact_path(run_id, "trace", "json")
+        trace = (
+            json.loads(trace_path.read_text(encoding="utf-8"))
+            if trace_path.exists()
+            else []
+        )
+        rows = flatten_trace_rows(trace)
+        totals = ensure_run_totals(meta, rows)
+        summary_path = artifact_path(run_id, "summary", "md")
+        summary = summary_path.read_text(encoding="utf-8") if summary_path.exists() else ""
+        return meta, rows, totals, summary
+
+    meta_a, rows_a, totals_a, summary_a = _load(run_id_a)
+    meta_b, rows_b, totals_b, summary_b = _load(run_id_b)
+
+    aligned = align_steps(rows_a, rows_b)
+    rows = diff_table_rows(aligned)
+    summary = diff_metrics(totals_a, totals_b)
+
+    st.subheader("Summary")
+    st.table(
+        [
+            {
+                "metric": k,
+                "a": v["a"],
+                "b": v["b"],
+                "delta": v["delta"],
+            }
+            for k, v in summary.items()
+            if k in {"tokens", "cost_usd", "steps", "errors", "duration_ms"}
+        ]
+    )
+
+    with st.expander("Trace differences", expanded=True):
+        filter_text = st.text_input("Filter", key="compare_filter")
+        changed_only = st.checkbox("Show only changed rows", key="compare_changed_only")
+        prev = (
+            st.session_state.get("_compare_filter"),
+            st.session_state.get("_compare_changed_only"),
+        )
+        cur = (filter_text, changed_only)
+        if cur != prev:
+            log_event(
+                {
+                    "event": "compare_filter_changed",
+                    "run_id_a": run_id_a,
+                    "run_id_b": run_id_b,
+                    "changed_only": changed_only,
+                    "text": filter_text,
+                }
+            )
+            st.session_state["_compare_filter"] = filter_text
+            st.session_state["_compare_changed_only"] = changed_only
+
+        def _is_changed(r: dict) -> bool:
+            return (
+                r["a_status"] != r["b_status"]
+                or r["d_dur_ms"]
+                or r["d_tokens"]
+                or r["d_cost"]
+            )
+
+        display_rows = rows
+        if changed_only:
+            display_rows = [r for r in display_rows if _is_changed(r)]
+        if filter_text:
+            ft = filter_text.lower()
+            display_rows = [r for r in display_rows if ft in (r["name"] or "").lower()]
+        st.dataframe(display_rows)
+
+    col1, col2 = st.columns(2)
+    if col1.download_button(
+        "Download diff CSV", to_csv(rows), file_name="run_diff.csv", use_container_width=True
+    ):
+        log_event(
+            {
+                "event": "compare_export_clicked",
+                "format": "csv",
+                "run_id_a": run_id_a,
+                "run_id_b": run_id_b,
+            }
+        )
+    if col2.download_button(
+        "Download summary Markdown",
+        to_markdown(summary, rows),
+        file_name="run_diff.md",
+        use_container_width=True,
+    ):
+        log_event(
+            {
+                "event": "compare_export_clicked",
+                "format": "md",
+                "run_id_a": run_id_a,
+                "run_id_b": run_id_b,
+            }
+        )
+
+    if summary_a or summary_b:
+        with st.expander("Final summaries"):
+            a_col, b_col = st.columns(2)
+            a_col.code(summary_a)
+            b_col.code(summary_b)

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T04:21:36.445505Z'
-git_sha: ec823feb5d07a45381af694db90d971ccf06ab70
+generated_at: '2025-08-30T04:39:50.447725Z'
+git_sha: db4b4bcae0912e3cf0af05c44ca07f9ed6974898
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -184,7 +184,21 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
+- path: orchestrators/plan_utils.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
 - path: orchestrators/__init__.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/app_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -205,15 +219,8 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/plan_utils.py
-  role: Orchestrator
+- path: core/summarization/integrator.py
+  role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
@@ -226,21 +233,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
-  role: Summarization
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: core/summarization/integrator.py
-  role: Summarization
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: core/summarization/schemas.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_compare_page_import.py
+++ b/tests/test_compare_page_import.py
@@ -1,0 +1,9 @@
+import importlib.util
+from pathlib import Path
+
+
+def test_import_page():
+    path = Path("pages/25_Compare.py")
+    spec = importlib.util.spec_from_file_location("compare_page", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[attr-defined]

--- a/tests/test_diff_runs.py
+++ b/tests/test_diff_runs.py
@@ -1,0 +1,49 @@
+import json
+
+from utils.trace_export import flatten_trace_rows
+from utils.diff_runs import (
+    aggregate_from_rows,
+    align_steps,
+    diff_metrics,
+    diff_table_rows,
+)
+
+TRACE_A = [
+    {"phase": "plan", "name": "step1", "status": "complete", "duration_ms": 10, "tokens": 1, "cost": 0.1},
+    {"phase": "exec", "name": "step2", "status": "complete", "duration_ms": 20, "tokens": 2, "cost": 0.2},
+]
+
+TRACE_B = [
+    {"phase": "plan", "name": "step1_renamed", "status": "complete", "duration_ms": 10, "tokens": 1, "cost": 0.1},
+    {"phase": "exec", "name": "step2", "status": "complete", "duration_ms": 25, "tokens": 2, "cost": 0.2},
+    {"phase": "exec", "name": "step3", "status": "complete", "duration_ms": 5, "tokens": 1, "cost": 0.05},
+]
+
+
+def _rows(trace):
+    return flatten_trace_rows(trace)
+
+
+def test_align_steps_handles_changes():
+    rows_a = _rows(TRACE_A)
+    rows_b = _rows(TRACE_B)
+    aligned = align_steps(rows_a, rows_b)
+    assert any(ra and rb and ra["name"] == "step1" and rb["name"] == "step1_renamed" for ra, rb, _ in aligned)
+    assert any(ra and rb and ra["name"] == "step2" and rb["name"] == "step2" for ra, rb, _ in aligned)
+    assert any(ra is None and rb and rb["name"] == "step3" for ra, rb, _ in aligned)
+
+
+def test_diff_metrics_math():
+    a_tot = aggregate_from_rows(_rows(TRACE_A))
+    b_tot = aggregate_from_rows(_rows(TRACE_B))
+    diff = diff_metrics(a_tot, b_tot)
+    assert diff["duration_ms"]["delta"] == b_tot["duration_ms"] - a_tot["duration_ms"]
+    assert diff["steps"]["b"] == 3
+
+
+def test_diff_table_rows_contains_deltas():
+    aligned = align_steps(_rows(TRACE_A), _rows(TRACE_B))
+    rows = diff_table_rows(aligned)
+    target = [r for r in rows if r["name"] == "step2"][0]
+    assert target["d_dur_ms"] == 5
+    assert target["match_score"] == 1.0

--- a/utils/diff_runs.py
+++ b/utils/diff_runs.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import csv
+import io
+import difflib
+from typing import Dict, List, Mapping, Sequence, Tuple, Optional
+
+TraceRow = Mapping[str, object]
+
+
+def aggregate_from_rows(rows: Sequence[TraceRow]) -> Dict[str, float]:
+    """Return totals: {'steps':N, 'errors':N, 'duration_ms':sum, 'tokens':sum, 'cost_usd':sum}."""
+    steps = len(rows)
+    errors = sum(1 for r in rows if r.get("status") == "error")
+    duration = sum(float(r.get("duration_ms") or 0) for r in rows)
+    tokens = sum(float(r.get("tokens") or 0) for r in rows)
+    cost = sum(float(r.get("cost") or 0) for r in rows)
+    return {
+        "steps": float(steps),
+        "errors": float(errors),
+        "duration_ms": float(duration),
+        "tokens": float(tokens),
+        "cost_usd": float(cost),
+    }
+
+
+def align_steps(a: Sequence[TraceRow], b: Sequence[TraceRow]) -> List[Tuple[Optional[TraceRow], Optional[TraceRow], float]]:
+    """
+    Align by (phase, name) first; if multiple, use order.
+    Fallback: fuzzy ratio on 'name' via difflib.SequenceMatcher.
+    Return list of tuples (row_a, row_b, score) where None denotes an insert/delete.
+    """
+    def key(r: TraceRow) -> Tuple[object, object]:
+        return (r.get("phase"), r.get("name"))
+
+    b_keys: Dict[Tuple[object, object], List[Tuple[int, TraceRow]]] = {}
+    for idx, row in enumerate(b):
+        b_keys.setdefault(key(row), []).append((idx, row))
+
+    matched: List[Tuple[int, int, TraceRow, TraceRow, float]] = []
+    unmatched_a: List[Tuple[int, TraceRow]] = []
+    used_b: set[int] = set()
+
+    for idx_a, row_a in enumerate(a):
+        k = key(row_a)
+        lst = b_keys.get(k)
+        if lst:
+            idx_b, row_b = lst.pop(0)
+            used_b.add(idx_b)
+            matched.append((idx_a, idx_b, row_a, row_b, 1.0))
+        else:
+            unmatched_a.append((idx_a, row_a))
+
+    unmatched_b: List[Tuple[int, TraceRow]] = [
+        (idx, row) for idx, row in enumerate(b) if idx not in used_b
+    ]
+
+    # Fuzzy match remaining rows by name
+    paired: set[int] = set()
+    for ia, row_a in list(unmatched_a):
+        candidates = [
+            (ib, rb) for ib, rb in unmatched_b if rb.get("phase") == row_a.get("phase")
+        ]
+        if not candidates:
+            candidates = unmatched_b
+        best_idx = -1
+        best_score = 0.0
+        best_row: Optional[TraceRow] = None
+        for ib, row_b in candidates:
+            if ib in paired:
+                continue
+            score = difflib.SequenceMatcher(
+                None, str(row_a.get("name")), str(row_b.get("name"))
+            ).ratio()
+            if score > best_score:
+                best_score = score
+                best_idx = ib
+                best_row = row_b
+        if best_idx != -1:
+            matched.append((ia, best_idx, row_a, best_row, best_score))
+            paired.add(best_idx)
+            unmatched_a.remove((ia, row_a))
+    unmatched_b = [(ib, rb) for ib, rb in unmatched_b if ib not in paired]
+
+    combined: List[Tuple[Optional[int], Optional[int], Optional[TraceRow], Optional[TraceRow], float]] = []
+    combined.extend(matched)
+    combined.extend((ia, None, ra, None, 0.0) for ia, ra in unmatched_a)
+    combined.extend((None, ib, None, rb, 0.0) for ib, rb in unmatched_b)
+
+    def sort_key(item: Tuple[Optional[int], Optional[int], Optional[TraceRow], Optional[TraceRow], float]):
+        ia, ib, ra, rb, _ = item
+        phase = (ra or rb).get("phase") if (ra or rb) else ""
+        index = ia if ia is not None else ib
+        return (str(phase), index if index is not None else -1)
+
+    combined.sort(key=sort_key)
+    return [(ra, rb, score) for ia, ib, ra, rb, score in combined]
+
+
+def diff_metrics(a_tot: Mapping[str, float], b_tot: Mapping[str, float]) -> Dict[str, Dict[str, float]]:
+    """Return per-metric {'metric': {'a':x,'b':y,'delta':y-x,'pct':(y-x)/max(x,1e-9)}} for keys present."""
+    metrics: Dict[str, Dict[str, float]] = {}
+    keys = set(a_tot.keys()) | set(b_tot.keys())
+    for k in keys:
+        a_val = float(a_tot.get(k, 0.0))
+        b_val = float(b_tot.get(k, 0.0))
+        delta = b_val - a_val
+        pct = delta / max(a_val, 1e-9)
+        metrics[k] = {"a": a_val, "b": b_val, "delta": delta, "pct": pct}
+    return metrics
+
+
+def diff_table_rows(
+    aligned: Sequence[Tuple[Optional[TraceRow], Optional[TraceRow], float]]
+) -> List[Dict[str, object]]:
+    """
+    Produce flat rows with: phase, name, a_status, b_status, a_dur_ms, b_dur_ms, d_dur_ms,
+    a_tokens, b_tokens, d_tokens, a_cost, b_cost, d_cost, match_score.
+    """
+    rows: List[Dict[str, object]] = []
+    for ra, rb, score in aligned:
+        phase = (ra or rb).get("phase")
+        name = (ra or rb).get("name")
+        a_dur = ra.get("duration_ms") if ra else None
+        b_dur = rb.get("duration_ms") if rb else None
+        a_tok = ra.get("tokens") if ra else None
+        b_tok = rb.get("tokens") if rb else None
+        a_cost = ra.get("cost") if ra else None
+        b_cost = rb.get("cost") if rb else None
+        rows.append(
+            {
+                "phase": phase,
+                "name": name,
+                "a_status": ra.get("status") if ra else None,
+                "b_status": rb.get("status") if rb else None,
+                "a_dur_ms": a_dur,
+                "b_dur_ms": b_dur,
+                "d_dur_ms": (b_dur or 0) - (a_dur or 0),
+                "a_tokens": a_tok,
+                "b_tokens": b_tok,
+                "d_tokens": (b_tok or 0) - (a_tok or 0),
+                "a_cost": a_cost,
+                "b_cost": b_cost,
+                "d_cost": (b_cost or 0) - (a_cost or 0),
+                "match_score": score,
+            }
+        )
+    rows.sort(key=lambda r: (str(r.get("phase")), r.get("name") or ""))
+    return rows
+
+
+def to_csv(rows: List[Dict[str, object]]) -> bytes:
+    output = io.StringIO()
+    fieldnames = list(rows[0].keys()) if rows else []
+    writer = csv.DictWriter(output, fieldnames=fieldnames)
+    writer.writeheader()
+    for row in rows:
+        writer.writerow(row)
+    return output.getvalue().encode("utf-8")
+
+
+def to_markdown(summary: Mapping[str, Mapping[str, float]], rows: List[Dict[str, object]]) -> bytes:
+    lines: List[str] = []
+    lines.append("# Run Comparison\n")
+    lines.append("## Summary\n")
+    for k, v in summary.items():
+        lines.append(
+            f"- {k}: {v['a']} → {v['b']} (Δ {v['delta']}, {v['pct']*100:.1f}% )"
+        )
+    lines.append("")
+    lines.append("## Changed steps\n")
+    headers = [
+        "phase",
+        "name",
+        "a_status",
+        "b_status",
+        "a_dur_ms",
+        "b_dur_ms",
+        "d_dur_ms",
+        "a_tokens",
+        "b_tokens",
+        "d_tokens",
+        "a_cost",
+        "b_cost",
+        "d_cost",
+        "match_score",
+    ]
+    lines.append("|" + "|".join(headers) + "|")
+    lines.append("|" + "|".join(["---"] * len(headers)) + "|")
+    for r in rows:
+        lines.append("|" + "|".join(str(r.get(h, "")) for h in headers) + "|")
+    lines.append("")
+    return "\n".join(lines).encode("utf-8")
+
+
+__all__ = [
+    "aggregate_from_rows",
+    "align_steps",
+    "diff_metrics",
+    "diff_table_rows",
+    "to_csv",
+    "to_markdown",
+]

--- a/utils/trace_export.py
+++ b/utils/trace_export.py
@@ -4,11 +4,13 @@ import csv
 import io
 import json
 from collections import OrderedDict
-from typing import Any, Dict, List, Sequence
+from typing import Any, Dict, List, Mapping, Sequence
 
 from .paths import write_bytes
 
 Row = List[Any]
+TraceStep = Mapping[str, Any]
+TraceRow = Dict[str, Any]
 
 
 def _safe_summary(text: str | None, max_len: int = 80) -> str:
@@ -16,9 +18,9 @@ def _safe_summary(text: str | None, max_len: int = 80) -> str:
     return text[:max_len]
 
 
-def flatten_trace_rows(trace: Sequence[Dict[str, Any]]) -> list[dict]:
+def flatten_trace_rows(trace: Sequence[TraceStep]) -> List[TraceRow]:
     """Return normalized rows for tabular exports."""
-    rows: list[dict] = []
+    rows: List[TraceRow] = []
     for idx, step in enumerate(trace, 1):
         rows.append(
             {


### PR DESCRIPTION
## Summary
- add utilities to aggregate, align, and diff run traces
- introduce Compare Runs page to review metrics and trace differences with exports
- add tests for diff helpers and page import

## Testing
- `pytest tests/test_diff_runs.py tests/test_compare_page_import.py`
- `python scripts/generate_repo_map.py`


------
https://chatgpt.com/codex/tasks/task_e_68b27f9fb1ec832caa72f42c17ed5f26