### PR TITLE
feat: add knowledge manager and uploads

### DIFF
--- a/app/ui/knowledge.py
+++ b/app/ui/knowledge.py
@@ -1,0 +1,44 @@
+import streamlit as st
+from datetime import datetime
+from utils import uploads
+
+
+def _fmt_size(size: int) -> str:
+    return f"{int(size / 1024)} KB"
+
+
+def table(items: list[dict]):
+    removed: list[str] = []
+    tag_updates: dict[str, list[str]] = {}
+    for it in items:
+        cols = st.columns([3, 1, 1, 2, 2, 1, 1])
+        cols[0].write(it["name"])
+        cols[1].write(it["type"])
+        cols[2].write(_fmt_size(it["size"]))
+        new_tags = tag_editor(it["id"], it.get("tags", []), key=f"tags_{it['id']}")
+        if new_tags != it.get("tags", []):
+            tag_updates[it["id"]] = new_tags
+        cols[4].write(datetime.fromtimestamp(it["created_at"]).strftime("%Y-%m-%d %H:%M"))
+        if cols[5].button("Remove", key=f"rm_{it['id']}"):
+            removed.append(it["id"])
+        with open(it["path"], "rb") as fh:
+            cols[6].download_button(
+                "Download", fh, file_name=it["name"], key=f"dl_{it['id']}"
+            )
+    return removed, tag_updates
+
+
+def uploader():
+    return st.file_uploader(
+        "Upload files", accept_multiple_files=True, type=[e.lstrip(".") for e in uploads.SAFE_EXTS]
+    )
+
+
+def tag_editor(item_id: str, tags: list[str], *, key: str | None = None) -> list[str]:
+    text = st.text_input(
+        "Tags",
+        value=", ".join(tags),
+        key=key or f"tags_{item_id}",
+        label_visibility="collapsed",
+    )
+    return [t.strip() for t in text.split(",") if t.strip()]

--- a/app/ui/sidebar.py
+++ b/app/ui/sidebar.py
@@ -8,6 +8,7 @@ import streamlit as st
 from app.ui_presets import UI_PRESETS
 from utils.run_config import RunConfig, defaults, from_session, to_session
 from utils.telemetry import log_event
+from utils import knowledge_store
 
 
 def render_sidebar() -> RunConfig:
@@ -59,10 +60,16 @@ def render_sidebar() -> RunConfig:
         _track_change("mode")
 
         with st.expander("Knowledge"):
+            knowledge_store.init_store()
+            builtins = [("Samples", "samples")]
+            choices = builtins + knowledge_store.as_choice_list()
+            options = [c[1] for c in choices]
+            labels = {c[1]: c[0] for c in choices}
             st.multiselect(
                 "Sources",
-                ["local_samples", "uploads", "connectors"],
+                options,
                 key="knowledge_sources",
+                format_func=lambda x: labels.get(x, x),
                 help="Select knowledge sources",
             )
             _track_change("knowledge_sources")

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T04:56:46.260743Z from commit c4fc12d_
+_Last generated at 2025-08-30T05:25:36.514724Z from commit 3799aab_

--- a/pages/15_Knowledge.py
+++ b/pages/15_Knowledge.py
@@ -1,0 +1,46 @@
+"""Knowledge Manager page."""
+
+import streamlit as st
+
+from app.ui import knowledge as ui
+from utils import knowledge_store, uploads
+from utils.telemetry import (
+    knowledge_added,
+    knowledge_removed,
+    knowledge_tags_updated,
+    log_event,
+)
+
+st.title("Knowledge Manager")
+st.caption("Select sources in Sidebar → Knowledge.")
+log_event({"event": "nav_page_view", "page": "knowledge"})
+knowledge_store.init_store()
+
+st.header("Upload")
+files = ui.uploader()
+tags_text = st.text_input("Tags", key="upload_tags", help="Comma-separated tags")
+if st.button("Add files"):
+    tag_list = [t.strip() for t in tags_text.split(",") if t.strip()]
+    for f in files or []:
+        if not uploads.allowed_ext(f.name):
+            st.warning(f"Unsupported file type: {f.name}")
+            continue
+        dest = uploads.unique_upload_path(f.name)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        with dest.open("wb") as out:
+            out.write(f.getbuffer())
+        item = knowledge_store.add_item(f.name, dest, tags=tag_list, kind="upload")
+        knowledge_added(item["id"], item["name"], item["type"], item["size"])
+        st.toast(f"Uploaded {f.name}")
+
+st.header("Your sources")
+items = knowledge_store.list_items()
+removed, tag_updates = ui.table(items)
+for item_id in removed:
+    if knowledge_store.remove_item(item_id):
+        knowledge_removed(item_id)
+        st.toast("Removed item")
+for item_id, tags in tag_updates.items():
+    knowledge_store.set_tags(item_id, tags)
+    knowledge_tags_updated(item_id, len(tags))
+    st.toast("Tags updated")

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T04:56:46.260743Z'
-git_sha: c4fc12d9d90e2a09143df26d22bf81d75536b62a
+generated_at: '2025-08-30T05:25:36.514724Z'
+git_sha: 3799aabe6fc8363e451d74bc154c960418a61b62
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -191,21 +191,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/plan_utils.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/app_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -219,15 +205,15 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
-  role: Summarization
+- path: orchestrators/plan_utils.py
+  role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
-  role: Summarization
+- path: orchestrators/spec_builder.py
+  role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
@@ -240,7 +226,21 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
+- path: core/summarization/integrator.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
 - path: core/summarization/__init__.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_knowledge_store.py
+++ b/tests/test_knowledge_store.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+from utils import knowledge_store
+
+
+def setup_store(monkeypatch, tmp_path):
+    root = tmp_path / "store"
+    monkeypatch.setattr(knowledge_store, "ROOT", root)
+    monkeypatch.setattr(knowledge_store, "UPLOADS", root / "uploads")
+    monkeypatch.setattr(knowledge_store, "META", root / "meta.json")
+    knowledge_store.init_store()
+
+
+def test_roundtrip(monkeypatch, tmp_path):
+    setup_store(monkeypatch, tmp_path)
+    tmp_file = knowledge_store.UPLOADS / "a.txt"
+    tmp_file.write_text("hi", encoding="utf-8")
+    item = knowledge_store.add_item("a.txt", tmp_file, tags=["foo"], kind="upload")
+    meta_tmp = knowledge_store.META.with_name("meta.json.tmp")
+    assert not meta_tmp.exists()
+    assert Path(item["path"]).parent == knowledge_store.UPLOADS
+    assert knowledge_store.get_item(item["id"]) is not None
+    assert knowledge_store.list_items(["foo"])
+    updated = knowledge_store.set_tags(item["id"], ["bar"])
+    assert updated["tags"] == ["bar"]
+    assert knowledge_store.list_items(["bar"])
+    assert not meta_tmp.exists()
+    assert knowledge_store.remove_item(item["id"])
+    assert knowledge_store.list_items() == []
+    assert not tmp_file.exists()
+    assert not meta_tmp.exists()

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -1,0 +1,19 @@
+from utils import knowledge_store, uploads
+
+
+def test_sanitize_filename():
+    assert uploads.sanitize_filename("a b??.txt") == "a b.txt"
+    assert uploads.sanitize_filename("   spaces   ") == "spaces"
+
+
+def test_allowed_ext():
+    assert uploads.allowed_ext("file.TXT")
+    assert not uploads.allowed_ext("file.exe")
+
+
+def test_unique_upload_path(monkeypatch, tmp_path):
+    monkeypatch.setattr(knowledge_store, "UPLOADS", tmp_path)
+    p1 = uploads.unique_upload_path("doc.txt")
+    p2 = uploads.unique_upload_path("doc.txt")
+    assert p1.parent == tmp_path
+    assert p1 != p2

--- a/utils/knowledge_store.py
+++ b/utils/knowledge_store.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+import secrets
+import time
+from pathlib import Path
+from typing import Iterable, Mapping, Optional
+
+ROOT = Path(".dr_rd/knowledge")
+UPLOADS = ROOT / "uploads"
+META = ROOT / "meta.json"
+
+
+def init_store() -> None:
+    """Ensure the knowledge store directories and metadata file exist."""
+    ROOT.mkdir(parents=True, exist_ok=True)
+    UPLOADS.mkdir(parents=True, exist_ok=True)
+    if not META.exists():
+        _write_meta({})
+
+
+def _read_meta() -> dict[str, dict]:
+    if META.exists():
+        try:
+            return json.loads(META.read_text(encoding="utf-8"))
+        except Exception:
+            return {}
+    return {}
+
+
+def _write_meta(data: Mapping[str, dict]) -> None:
+    tmp = META.with_name("meta.json.tmp")
+    try:
+        tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+        tmp.replace(META)
+    finally:
+        if tmp.exists():
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+
+
+def list_items(tags: Optional[Iterable[str]] = None) -> list[dict]:
+    """Return a sorted list of item dicts."""
+    meta = _read_meta()
+    items = list(meta.values())
+    if tags:
+        tagset = set(tags)
+        items = [i for i in items if tagset.intersection(i.get("tags", []))]
+    items.sort(key=lambda x: x.get("created_at", 0))
+    return items
+
+
+def get_item(item_id: str) -> Optional[dict]:
+    return _read_meta().get(item_id)
+
+
+def _ensure_inside_uploads(path: Path) -> None:
+    try:
+        path.resolve().relative_to(UPLOADS.resolve())
+    except Exception as exc:
+        raise ValueError("path outside uploads") from exc
+
+
+def add_item(name: str, path: Path, *, tags: list[str] | None, kind: str) -> dict:
+    """Register an item already copied into uploads and return its metadata."""
+    init_store()
+    _ensure_inside_uploads(path)
+    meta = _read_meta()
+    item_id = f"kn_{int(time.time())}_{secrets.token_hex(4)}"
+    size = path.stat().st_size
+    type_ = path.suffix.lstrip(".").upper()
+    item = {
+        "id": item_id,
+        "name": name,
+        "tags": tags or [],
+        "type": type_,
+        "size": size,
+        "created_at": time.time(),
+        "path": str(path),
+        "kind": kind,
+    }
+    meta[item_id] = item
+    _write_meta(meta)
+    return item
+
+
+def remove_item(item_id: str) -> bool:
+    meta = _read_meta()
+    item = meta.pop(item_id, None)
+    if not item:
+        return False
+    try:
+        Path(item["path"]).unlink(missing_ok=True)
+    except OSError:
+        pass
+    _write_meta(meta)
+    return True
+
+
+def set_tags(item_id: str, tags: list[str]) -> dict:
+    meta = _read_meta()
+    item = meta.get(item_id)
+    if not item:
+        raise KeyError(item_id)
+    item["tags"] = tags
+    meta[item_id] = item
+    _write_meta(meta)
+    return item
+
+
+def as_choice_list() -> list[tuple[str, str]]:
+    """Return a list of ``(label, id)`` tuples for UI multiselects."""
+    choices: list[tuple[str, str]] = []
+    for item in list_items():
+        size_kb = item["size"] / 1024
+        size_str = f"{int(size_kb)} KB"
+        label = f"{item['name']} ({item['type']}, {size_str})"
+        choices.append((label, item["id"]))
+    return choices

--- a/utils/run_config.py
+++ b/utils/run_config.py
@@ -17,6 +17,7 @@ class RunConfig:
     enforce_budget: bool = False
     budget_limit_usd: float | None = None
     max_tokens: int | None = None
+    # Selected knowledge item IDs from built-ins and uploads
     knowledge_sources: List[str] = field(default_factory=list)
     show_agent_trace: bool = False
     verbose_planner: bool = False

--- a/utils/telemetry.py
+++ b/utils/telemetry.py
@@ -97,6 +97,21 @@ def usage_exceeded(
     log_event(ev)
 
 
+def knowledge_added(item_id: str, name: str, type_: str, size: int) -> None:
+    """Emit a knowledge_added telemetry event."""
+    log_event({"event": "knowledge_added", "id": item_id, "name": name, "type": type_, "size": size})
+
+
+def knowledge_removed(item_id: str) -> None:
+    """Emit a knowledge_removed telemetry event."""
+    log_event({"event": "knowledge_removed", "id": item_id})
+
+
+def knowledge_tags_updated(item_id: str, count: int) -> None:
+    """Emit a knowledge_tags_updated telemetry event."""
+    log_event({"event": "knowledge_tags_updated", "id": item_id, "count": count})
+
+
 __all__ = [
     "log_event",
     "run_cancel_requested",
@@ -106,4 +121,7 @@ __all__ = [
     "demo_completed",
     "usage_threshold_crossed",
     "usage_exceeded",
+    "knowledge_added",
+    "knowledge_removed",
+    "knowledge_tags_updated",
 ]

--- a/utils/uploads.py
+++ b/utils/uploads.py
@@ -1,0 +1,30 @@
+import re
+import secrets
+from pathlib import Path
+
+from . import knowledge_store
+
+SAFE_EXTS = {".txt", ".md", ".pdf", ".docx", ".csv", ".json"}
+
+
+def sanitize_filename(name: str) -> str:
+    """Return a safe filename by stripping risky characters and collapsing spaces."""
+    name = re.sub(r"[^A-Za-z0-9._-]+", " ", name)
+    name = re.sub(r"\s+", " ", name).strip()
+    name = re.sub(r"\s+\.", ".", name)
+    return name or "file"
+
+
+def unique_upload_path(original_name: str) -> Path:
+    """Return a unique path under ``knowledge_store.UPLOADS`` for ``original_name``."""
+    safe = sanitize_filename(original_name)
+    stem = Path(safe).stem
+    suffix = Path(safe).suffix
+    token = secrets.token_hex(4)
+    filename = f"{stem}_{token}{suffix}"
+    return knowledge_store.UPLOADS / filename
+
+
+def allowed_ext(name: str) -> bool:
+    """Return True if ``name`` has an allowed extension."""
+    return Path(name).suffix.lower() in SAFE_EXTS


### PR DESCRIPTION
## Summary
- add filesystem-backed knowledge store with safe uploads
- expose Knowledge Manager page for adding, tagging, and removing sources
- surface uploaded sources in sidebar and log telemetry events

## Testing
- `pytest tests/test_uploads.py tests/test_knowledge_store.py`
- `python scripts/generate_repo_map.py`


------
https://chatgpt.com/codex/tasks/task_e_68b28a5e6340832cb1eb832ffb3bce3f