### PR TITLE
Add system health diagnostics

### DIFF
--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T05:25:36.514724Z from commit 3799aab_
+_Last generated at 2025-08-30T13:58:54.581119Z from commit 8c4d2a6_

--- a/pages/05_Health.py
+++ b/pages/05_Health.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import os
+
+import pandas as pd
+import streamlit as st
+
+from utils import health_check
+from utils.telemetry import log_event
+
+st.title("System Health")
+
+if st.button("Run diagnostics"):
+    report = health_check.run_all()
+    cols = st.columns(3)
+    cols[0].metric("pass", report.summary.get("pass", 0))
+    cols[1].metric("warn", report.summary.get("warn", 0))
+    cols[2].metric("fail", report.summary.get("fail", 0))
+    df = pd.DataFrame([{"id": c.id, "name": c.name, "status": c.status} for c in report.checks])
+    st.dataframe(df, use_container_width=True)
+    for c in report.checks:
+        with st.expander(c.name):
+            st.write(c.details)
+            if c.remedy:
+                st.caption(c.remedy)
+    st.download_button(
+        "health_report.json",
+        data=health_check.to_json(report),
+        file_name="health_report.json",
+        mime="application/json",
+    )
+    st.download_button(
+        "health_report.md",
+        data=health_check.to_markdown(report),
+        file_name="health_report.md",
+        mime="text/markdown",
+    )
+    log_event({"event": "health_check_run", "summary": report.summary})
+    if os.getenv("NO_NET") == "1":
+        st.caption("Network tests skipped")
+else:
+    st.write("Click to run diagnostics")

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T05:25:36.514724Z'
-git_sha: 3799aabe6fc8363e451d74bc154c960418a61b62
+generated_at: '2025-08-30T13:58:54.581119Z'
+git_sha: 8c4d2a610c721fa9dc6be7f92ff1f03c6b7bbcc9
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -184,14 +184,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/qa_router.py
+- path: orchestrators/plan_utils.py
   role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
+- path: orchestrators/qa_router.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -205,7 +205,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/plan_utils.py
+- path: orchestrators/app_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -219,14 +219,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/schemas.py
+- path: core/summarization/integrator.py
   role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
+- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/scripts/self_check.py
+++ b/scripts/self_check.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+import argparse
+import os
+
+from utils.health_check import run_all, to_markdown
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--no-net", action="store_true", help="skip network checks")
+    args = parser.parse_args()
+    if args.no_net:
+        os.environ["NO_NET"] = "1"
+    report = run_all()
+    print(to_markdown(report))
+    sys.exit(0 if report.summary.get("fail", 0) == 0 else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from utils import health_check as hc
+
+
+def _patch_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    base = tmp_path / ".dr_rd"
+    monkeypatch.setattr(hc, "DR_DIR", base)
+    monkeypatch.setattr(hc, "TELEMETRY_DIR", base / "telemetry")
+    monkeypatch.setattr(hc, "RUNS_DIR", base / "runs")
+
+
+def test_run_all_basic(tmp_path, monkeypatch):
+    _patch_dirs(tmp_path, monkeypatch)
+    monkeypatch.setenv("NO_NET", "1")
+    report = hc.run_all()
+    assert isinstance(report.summary, dict)
+    assert report.checks
+    assert report.env["python"]
+    data = json.loads(hc.to_json(report).decode("utf-8"))
+    assert data["summary"] == report.summary
+    md = hc.to_markdown(report)
+    assert "| id | status | name | remedy |" in md
+
+
+def test_filesystem_probe_fail(monkeypatch):
+    ro = Path("/proc/ro")
+    monkeypatch.setattr(hc, "DR_DIR", ro)
+    monkeypatch.setattr(hc, "TELEMETRY_DIR", ro / "telemetry")
+    monkeypatch.setattr(hc, "RUNS_DIR", ro / "runs")
+    monkeypatch.setenv("NO_NET", "1")
+    report = hc.run_all()
+    fs = [c for c in report.checks if c.id == "filesystem"][0]
+    assert fs.status == "fail"

--- a/utils/health_check.py
+++ b/utils/health_check.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import importlib.metadata as importlib_metadata
+import json
+import os
+import platform
+import shutil
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+try:  # Python 3.11+
+    import tomllib as toml  # type: ignore
+except Exception:  # pragma: no cover
+    try:
+        import tomli as toml  # type: ignore
+    except Exception:  # pragma: no cover
+        toml = None  # type: ignore
+
+
+DR_DIR = Path(".dr_rd")
+TELEMETRY_DIR = DR_DIR / "telemetry"
+RUNS_DIR = DR_DIR / "runs"
+REPO_MAP_PATH = Path("repo_map.yaml")
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    id: str
+    name: str
+    status: str  # "pass" | "warn" | "fail"
+    details: str
+    remedy: str
+    duration_ms: int
+
+
+@dataclass(frozen=True)
+class HealthReport:
+    summary: dict[str, int]
+    checks: list[CheckResult]
+    env: dict[str, Any]
+
+
+def _time_it(func):
+    def wrapper() -> CheckResult:
+        start = time.time()
+        res = func()
+        duration_ms = int((time.time() - start) * 1000)
+        return CheckResult(
+            id=res[0],
+            name=res[1],
+            status=res[2],
+            details=res[3],
+            remedy=res[4],
+            duration_ms=duration_ms,
+        )
+
+    return wrapper
+
+
+@_time_it
+def _check_python() -> tuple[str, str, str, str, str]:
+    version_ok = sys.version_info >= (3, 10)
+    packages = ["streamlit", "requests", "pandas", "numpy"]
+    missing: list[str] = []
+    versions: dict[str, str | None] = {}
+    for p in packages:
+        try:
+            versions[p] = importlib_metadata.version(p)
+        except importlib_metadata.PackageNotFoundError:
+            missing.append(p)
+            versions[p] = None
+    details = (
+        f"python {platform.python_version()}"
+        + ", "
+        + ", ".join(f"{k}:{v}" for k, v in versions.items())
+    )
+    if not version_ok or missing:
+        status = "warn"
+        remedy = "Update Python or install missing packages"
+    else:
+        status = "pass"
+        remedy = ""
+    return (
+        "python",
+        "Python & packages",
+        status,
+        details,
+        remedy,
+    )
+
+
+@_time_it
+def _check_theme() -> tuple[str, str, str, str, str]:
+    config_path = Path(".streamlit/config.toml")
+    if not config_path.exists():
+        return (
+            "theme",
+            "Theme config",
+            "warn",
+            "Missing .streamlit/config.toml",
+            "Add theme config",
+        )
+    if toml is None:
+        return (
+            "theme",
+            "Theme config",
+            "warn",
+            "toml parser unavailable",
+            "Install tomllib/tomli",
+        )
+    try:
+        data = toml.loads(config_path.read_text(encoding="utf-8"))
+    except Exception as e:
+        return (
+            "theme",
+            "Theme config",
+            "warn",
+            f"Invalid TOML: {e}",
+            "Fix config.toml",
+        )
+    theme = data.get("theme", {})
+    allowed = {
+        "primaryColor",
+        "backgroundColor",
+        "secondaryBackgroundColor",
+        "textColor",
+        "font",
+    }
+    invalid = [k for k in theme.keys() if k not in allowed]
+    if invalid:
+        return (
+            "theme",
+            "Theme config",
+            "warn",
+            f"Invalid keys: {', '.join(invalid)}",
+            "Remove invalid theme keys",
+        )
+    return (
+        "theme",
+        "Theme config",
+        "pass",
+        "Theme config valid",
+        "",
+    )
+
+
+@_time_it
+def _check_filesystem() -> tuple[str, str, str, str, str]:
+    try:
+        DR_DIR.mkdir(exist_ok=True)
+        TELEMETRY_DIR.mkdir(parents=True, exist_ok=True)
+        RUNS_DIR.mkdir(parents=True, exist_ok=True)
+        for p in [DR_DIR, TELEMETRY_DIR, RUNS_DIR]:
+            if not os.access(p, os.W_OK):
+                raise PermissionError(f"{p} not writable")
+        free = shutil.disk_usage(DR_DIR).free
+        if free < 100 * 1024 * 1024:
+            status = "warn"
+            details = f"Free disk {free}B"
+            remedy = "Free up disk space"
+        else:
+            tmp = DR_DIR / "tmp_health.txt"
+            tmp.write_text("ping", encoding="utf-8")
+            _ = tmp.read_text(encoding="utf-8")
+            tmp.unlink()
+            status = "pass"
+            details = "Directories writable"
+            remedy = ""
+    except Exception as e:
+        status = "fail"
+        details = str(e)
+        remedy = "Ensure .dr_rd directories exist and are writable"
+    return (
+        "filesystem",
+        "Filesystem",
+        status,
+        details,
+        remedy,
+    )
+
+
+@_time_it
+def _check_telemetry() -> tuple[str, str, str, str, str]:
+    path = TELEMETRY_DIR / "health_probe.jsonl"
+    try:
+        TELEMETRY_DIR.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as f:
+            f.write("{}\n")
+        path.unlink()
+        return (
+            "telemetry",
+            "Telemetry write",
+            "pass",
+            "Telemetry directory writable",
+            "",
+        )
+    except Exception as e:
+        return (
+            "telemetry",
+            "Telemetry write",
+            "fail",
+            str(e),
+            "Check telemetry directory permissions",
+        )
+
+
+@_time_it
+def _check_secrets() -> tuple[str, str, str, str, str]:
+    secret = os.environ.get("gcp_service_account")
+    if not secret:
+        secrets_path = Path(".streamlit/secrets.toml")
+        if secrets_path.exists() and toml is not None:
+            try:
+                data = toml.loads(secrets_path.read_text(encoding="utf-8"))
+                secret = data.get("gcp_service_account")
+            except Exception:
+                pass
+    if not secret:
+        return (
+            "secrets",
+            "GCP service account",
+            "warn",
+            "gcp_service_account missing",
+            "Set gcp_service_account in env or secrets",
+        )
+    try:
+        json.loads(secret)
+        return (
+            "secrets",
+            "GCP service account",
+            "pass",
+            "gcp_service_account present",
+            "",
+        )
+    except Exception as e:
+        return (
+            "secrets",
+            "GCP service account",
+            "fail",
+            f"Invalid JSON: {e}",
+            "Provide valid JSON",
+        )
+
+
+@_time_it
+def _check_network() -> tuple[str, str, str, str, str]:
+    if os.getenv("NO_NET") == "1":
+        return (
+            "network",
+            "Network reachability",
+            "warn",
+            "NO_NET=1",
+            "Unset NO_NET to enable network tests",
+        )
+    import requests
+
+    urls = ["https://api.openai.com", "https://www.google.com"]
+    failures: list[str] = []
+    for u in urls:
+        try:
+            r = requests.head(u, timeout=2)
+            if r.status_code >= 400:
+                failures.append(u)
+        except Exception:
+            failures.append(u)
+    if failures:
+        return (
+            "network",
+            "Network reachability",
+            "warn",
+            ", ".join(failures),
+            "Check network connectivity",
+        )
+    return (
+        "network",
+        "Network reachability",
+        "pass",
+        "All endpoints reachable",
+        "",
+    )
+
+
+@_time_it
+def _check_repo_map() -> tuple[str, str, str, str, str]:
+    if not REPO_MAP_PATH.exists():
+        return (
+            "repo_map",
+            "Repo map",
+            "warn",
+            "repo_map.yaml missing",
+            "Run scripts/generate_repo_map.py",
+        )
+    try:
+        REPO_MAP_PATH.read_text(encoding="utf-8")
+        return (
+            "repo_map",
+            "Repo map",
+            "pass",
+            "repo_map.yaml present",
+            "",
+        )
+    except Exception as e:
+        return (
+            "repo_map",
+            "Repo map",
+            "warn",
+            str(e),
+            "Ensure repo_map.yaml readable",
+        )
+
+
+CHECKS = [
+    _check_python,
+    _check_theme,
+    _check_filesystem,
+    _check_telemetry,
+    _check_secrets,
+    _check_network,
+    _check_repo_map,
+]
+
+
+def env_summary() -> dict[str, Any]:
+    packages = {}
+    for p in ["streamlit", "requests", "pandas", "numpy"]:
+        try:
+            packages[p] = importlib_metadata.version(p)
+        except importlib_metadata.PackageNotFoundError:
+            packages[p] = None
+    return {
+        "python": platform.python_version(),
+        "platform": platform.platform(),
+        "packages": packages,
+    }
+
+
+def run_all() -> HealthReport:
+    checks = [func() for func in CHECKS]
+    summary: dict[str, int] = {}
+    for c in checks:
+        summary[c.status] = summary.get(c.status, 0) + 1
+    return HealthReport(summary=summary, checks=checks, env=env_summary())
+
+
+def to_markdown(report: HealthReport) -> str:
+    lines = ["| id | status | name | remedy |", "| --- | --- | --- | --- |"]
+    for c in report.checks:
+        lines.append(f"| {c.id} | {c.status} | {c.name} | {c.remedy} |")
+    return "\n".join(lines)
+
+
+def to_json(report: HealthReport) -> bytes:
+    from dataclasses import asdict
+
+    return json.dumps(asdict(report), ensure_ascii=False).encode("utf-8")


### PR DESCRIPTION
## Summary
- implement reusable health checks and report builders for environment, config, filesystem, telemetry, secrets, network and repo map
- surface health results in new `System Health` Streamlit page with downloads and telemetry
- add `scripts/self_check.py` CLI and tests for diagnostics

## Testing
- `python scripts/generate_repo_map.py`
- `pre-commit run --files pages/05_Health.py utils/health_check.py scripts/self_check.py tests/test_health_check.py repo_map.yaml docs/REPO_MAP.md`
- `pytest tests/test_health_check.py`


------
https://chatgpt.com/codex/tasks/task_e_68b302a81050832c9bd827860c0062fb