### PR TITLE
feat: add run checkpointing and resume skeleton

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -183,6 +183,9 @@ def main() -> None:
         cfg = replace(cfg, mode="demo")
 
     kwargs = to_orchestrator_kwargs(cfg)
+    resume_from = st.query_params.pop("resume_from", None)
+    if resume_from:
+        kwargs["resume_from"] = resume_from
     qp = encode_config(kwargs)
     st.query_params.update(qp)
     log_event({"event": "config_encoded_to_url", "field_count": len(qp)})
@@ -421,11 +424,13 @@ def main() -> None:
             }
         )
         components.error_banner(err)
-        r1, r2 = st.columns([1, 1])
+        r1, r2, r3 = st.columns([1, 1, 1])
         with r1:
             retry = st.button("Retry run", type="primary", use_container_width=True)
         with r2:
             open_trace = st.button("Open trace", use_container_width=True)
+        with r3:
+            resume = st.button("Resume run", use_container_width=True)
         if retry:
             st.query_params["retry_of"] = err.context.get("run_id") or ""
             st.rerun()
@@ -433,6 +438,9 @@ def main() -> None:
             st.query_params["run_id"] = err.context.get("run_id") or ""
             st.query_params["view"] = "trace"
             st.switch_page("pages/10_Trace.py")
+        if resume:
+            st.query_params["resume_from"] = err.context.get("run_id") or ""
+            st.rerun()
     except TimeoutError as e:  # pragma: no cover - UI display
         if current_box is not None:
             current_box.update(label="Timeout", state="error")
@@ -460,11 +468,13 @@ def main() -> None:
             }
         )
         components.error_banner(err)
-        r1, r2 = st.columns([1, 1])
+        r1, r2, r3 = st.columns([1, 1, 1])
         with r1:
             retry = st.button("Retry run", type="primary", use_container_width=True)
         with r2:
             open_trace = st.button("Open trace", use_container_width=True)
+        with r3:
+            resume = st.button("Resume run", use_container_width=True)
         if retry:
             st.query_params["retry_of"] = err.context.get("run_id") or ""
             st.rerun()
@@ -472,6 +482,9 @@ def main() -> None:
             st.query_params["run_id"] = err.context.get("run_id") or ""
             st.query_params["view"] = "trace"
             st.switch_page("pages/10_Trace.py")
+        if resume:
+            st.query_params["resume_from"] = err.context.get("run_id") or ""
+            st.rerun()
     except Exception as e:  # pragma: no cover - UI display
         if current_box is not None:
             current_box.update(label="Error", state="error")

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T13:58:54.581119Z from commit 8c4d2a6_
+_Last generated at 2025-08-30T14:09:17.938842Z from commit fd46f69_

--- a/pages/10_Trace.py
+++ b/pages/10_Trace.py
@@ -48,6 +48,7 @@ if runs:
         log_event({"event": "run_selected", "run_id": selected})
         st.rerun()
     run_id = selected
+    meta = next((r for r in runs if r["run_id"] == run_id), {})
     log_event({"event": "nav_page_view", "page": "trace", "run_id": run_id})
     trace_path = artifact_path(run_id, "trace", "json")
     if trace_path.exists():
@@ -57,6 +58,11 @@ if runs:
     if not trace:
         empty_states.trace_empty()
     else:
+        if meta.get("status") == "resumable":
+            st.info("This run can be resumed.")
+            if st.button("Resume run", use_container_width=True):
+                st.query_params.update({"resume_from": run_id, "view": "run"})
+                st.switch_page("app.py")
         include_adv = st.checkbox(
             t("include_adv_label"), key="trace_share_adv", help=t("include_adv_help")
         )

--- a/pages/20_Reports.py
+++ b/pages/20_Reports.py
@@ -38,6 +38,11 @@ else:
             st.toast("Missing run lockfile", icon="⚠️")
 
     meta = load_run_meta(run_id) or {}
+    if meta.get("status") == "resumable":
+        st.info("This run can be resumed.")
+        if st.button("Resume run", use_container_width=True):
+            st.query_params.update({"resume_from": run_id, "view": "run"})
+            st.switch_page("app.py")
     trace_path = artifact_path(run_id, "trace", "json")
     trace = json.loads(trace_path.read_text(encoding="utf-8")) if trace_path.exists() else []
     summary_path = artifact_path(run_id, "synth", "md")

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T13:58:54.581119Z'
-git_sha: 8c4d2a610c721fa9dc6be7f92ff1f03c6b7bbcc9
+generated_at: '2025-08-30T14:09:17.938842Z'
+git_sha: fd46f69dd9a3d4e2588f184acf50f762edf960a9
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -184,21 +184,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/plan_utils.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/qa_router.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/__init__.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -212,6 +198,13 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
+- path: orchestrators/plan_utils.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
 - path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
@@ -219,8 +212,8 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
-  role: Summarization
+- path: orchestrators/__init__.py
+  role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
@@ -234,6 +227,13 @@ modules:
   invoked_by: []
   invokes: []
 - path: core/summarization/__init__.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/integrator.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_checkpoints.py
+++ b/tests/test_checkpoints.py
@@ -1,0 +1,19 @@
+import json
+from pathlib import Path
+
+from utils import checkpoints
+
+
+def test_checkpoints_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    checkpoints.ROOT = tmp_path
+    cp = checkpoints.init("run1", phases=["planner"])
+    checkpoints.mark_step_done("run1", "planner", 1)
+    checkpoints.mark_step_done("run1", "planner", 2)
+    loaded = checkpoints.load("run1")
+    assert loaded["phases"]["planner"]["next_index"] == 2
+    assert checkpoints.last_completed_index("run1", "planner") == 2
+    # ensure json structure stable
+    p = checkpoints.path("run1")
+    data = json.loads(p.read_text())
+    assert data == loaded

--- a/tests/test_resume_flow.py
+++ b/tests/test_resume_flow.py
@@ -1,0 +1,49 @@
+import json
+from pathlib import Path
+
+import streamlit as st
+
+from utils import checkpoints
+from utils import telemetry
+from core import orchestrator
+
+
+def test_resume_flow(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    checkpoints.ROOT = tmp_path
+    events = []
+    monkeypatch.setattr(telemetry, "log_event", lambda ev: events.append(ev))
+
+    # Create run A with planner completed
+    checkpoints.init("A", phases=["planner", "executor", "synth"])
+    checkpoints.mark_step_done("A", "planner", "plan")
+    # create prior trace
+    trace = [{"phase": "planner", "step": "plan"}]
+    trace_path = tmp_path / "A" / "trace.json"
+    trace_path.write_text(json.dumps(trace))
+
+    called = {"planner": 0, "executor": 0, "synth": 0}
+
+    def fake_generate(idea):
+        called["planner"] += 1
+        return []
+
+    def fake_execute(idea, tasks, agents):
+        called["executor"] += 1
+        return {}
+
+    def fake_synth(idea, results):
+        called["synth"] += 1
+        return "final"
+
+    monkeypatch.setattr(orchestrator, "generate_plan", fake_generate)
+    monkeypatch.setattr(orchestrator, "execute_plan", fake_execute)
+    monkeypatch.setattr(orchestrator, "compose_final_proposal", fake_synth)
+
+    st.session_state["run_id"] = "B"
+    out = orchestrator.orchestrate("idea", resume_from="A")
+    assert out == "final"
+    assert called["planner"] == 0  # skipped
+    assert called["executor"] == 1
+    assert called["synth"] == 1
+    assert any(ev["event"] == "run_resumed" for ev in events)

--- a/utils/checkpoints.py
+++ b/utils/checkpoints.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+import json, time, os, tempfile, shutil
+from typing import Any, Dict, Optional
+
+from utils.telemetry import checkpoint_saved
+
+ROOT = Path(".dr_rd/runs")
+
+
+def path(run_id: str) -> Path:
+    p = ROOT / run_id / "checkpoint.json"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def load(run_id: str) -> Optional[Dict[str, Any]]:
+    cp = path(run_id)
+    if not cp.exists():
+        return None
+    with cp.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _atomic_write(p: Path, obj: Dict[str, Any]) -> None:
+    tmp = p.with_suffix(".tmp")
+    with tmp.open("w", encoding="utf-8") as f:
+        json.dump(obj, f, ensure_ascii=False, indent=2)
+    os.replace(tmp, p)
+
+
+def init(run_id: str, *, phases: list[str]) -> Dict[str, Any]:
+    cp = {
+        "run_id": run_id,
+        "created_at": time.time(),
+        "phases": {ph: {"completed": [], "next_index": 0} for ph in phases},
+    }
+    _atomic_write(path(run_id), cp)
+    return cp
+
+
+def mark_step_done(
+    run_id: str,
+    phase: str,
+    step_id: str | int,
+    outputs_meta: Dict[str, Any] | None = None,
+) -> Dict[str, Any]:
+    cp = load(run_id) or {"phases": {}}
+    phase_cp = cp["phases"].setdefault(phase, {"completed": [], "next_index": 0})
+    phase_cp["completed"].append({"step_id": step_id, "at": time.time(), "meta": outputs_meta or {}})
+    phase_cp["next_index"] = len(phase_cp["completed"])
+    _atomic_write(path(run_id), cp)
+    checkpoint_saved(run_id, phase, step_id)
+    return cp
+
+
+def last_completed_index(run_id: str, phase: str) -> int:
+    cp = load(run_id)
+    if not cp:
+        return 0
+    ph = cp["phases"].get(phase, {})
+    return int(ph.get("next_index", 0))

--- a/utils/runs.py
+++ b/utils/runs.py
@@ -8,7 +8,13 @@ from typing import List, Dict
 from .paths import artifact_path, ensure_run_dirs
 
 
-def create_run_meta(run_id: str, *, mode: str, idea_preview: str) -> None:
+def create_run_meta(
+    run_id: str,
+    *,
+    mode: str,
+    idea_preview: str,
+    origin_run_id: str | None = None,
+) -> None:
     """Create initial run metadata."""
     ensure_run_dirs(run_id)
     meta = {
@@ -18,6 +24,9 @@ def create_run_meta(run_id: str, *, mode: str, idea_preview: str) -> None:
         "idea_preview": idea_preview,
         "status": "running",
     }
+    if origin_run_id:
+        meta["origin_run_id"] = origin_run_id
+        meta["resume_of"] = origin_run_id
     artifact_path(run_id, "run", "json").write_text(
         json.dumps(meta, ensure_ascii=False, indent=2), encoding="utf-8"
     )
@@ -26,8 +35,8 @@ def create_run_meta(run_id: str, *, mode: str, idea_preview: str) -> None:
 def complete_run_meta(run_id: str, *, status: str) -> None:
     """Mark a run as completed with ``status``.
 
-    ``status`` may be ``success``, ``error``, ``cancelled`` or ``timeout``.
-    ``completed_at`` is always recorded.
+    ``status`` may be ``success``, ``error``, ``cancelled``, ``timeout`` or
+    ``resumable``. ``completed_at`` is always recorded.
     """
     path = artifact_path(run_id, "run", "json")
     if not path.exists():

--- a/utils/telemetry.py
+++ b/utils/telemetry.py
@@ -34,6 +34,21 @@ def run_cancelled(run_id: str, phase: str | None = None) -> None:
     log_event(ev)
 
 
+def checkpoint_saved(run_id: str, phase: str, step_id: str | int) -> None:
+    """Emit a checkpoint_saved telemetry event."""
+    log_event({"event": "checkpoint_saved", "run_id": run_id, "phase": phase, "step_id": step_id})
+
+
+def run_resumed(new_run_id: str, origin_run_id: str) -> None:
+    """Emit a run_resumed telemetry event."""
+    log_event({"event": "run_resumed", "new_run_id": new_run_id, "origin_run_id": origin_run_id})
+
+
+def resume_failed(origin_run_id: str, reason: str) -> None:
+    """Emit a resume_failed telemetry event."""
+    log_event({"event": "resume_failed", "origin_run_id": origin_run_id, "reason": reason})
+
+
 def timeout_hit(run_id: str, phase: str | None = None) -> None:
     """Emit a timeout_hit telemetry event."""
     ev = {"event": "timeout_hit", "run_id": run_id}
@@ -119,6 +134,9 @@ __all__ = [
     "timeout_hit",
     "demo_started",
     "demo_completed",
+    "checkpoint_saved",
+    "run_resumed",
+    "resume_failed",
     "usage_threshold_crossed",
     "usage_exceeded",
     "knowledge_added",


### PR DESCRIPTION
## Summary
- add utils/checkpoints for atomic checkpoint handling
- allow runs to record origins and "resumable" status
- surface resume CTAs in UI and emit new telemetry events

## Testing
- `python -m pytest tests/test_checkpoints.py tests/test_resume_flow.py`
- `python scripts/generate_repo_map.py`


------
https://chatgpt.com/codex/tasks/task_e_68b304ab0798832cbac008983438c39b