### PR TITLE
Add run history page with annotations and search

### DIFF
--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T14:21:35.064968Z from commit 91b1329_
+_Last generated at 2025-08-30T14:32:55.382359Z from commit b99e152_

--- a/pages/12_History.py
+++ b/pages/12_History.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pandas as pd
+import streamlit as st
+
+from utils import runs_index, run_notes
+from utils.telemetry import (
+    log_event,
+    history_filter_changed,
+    history_export_clicked,
+    run_annotated,
+    run_favorited,
+)
+
+params = dict(st.query_params)
+
+st.title("Run History")
+log_event({"event": "nav_page_view", "page": "history"})
+
+notes_lookup = run_notes.all_notes()
+index = runs_index.load_index()
+
+status_options = sorted({r["status"] for r in index if r.get("status")})
+mode_options = sorted({r["mode"] for r in index if r.get("mode")})
+all_tags = sorted({t for n in notes_lookup.values() for t in n.get("tags", [])})
+
+q_default = params.get("q", "")
+status_default = params.get("status", "")
+fav_default = params.get("fav", "0") == "1"
+
+status_default_list = [s for s in status_default.split(",") if s]
+
+q_val = st.text_input("Search", q_default)
+status_val = st.multiselect("Status", status_options, default=status_default_list)
+mode_val = st.multiselect("Mode", mode_options)
+dates = st.date_input("Date range", value=(None, None))
+tags_val = st.multiselect("Tags", all_tags)
+fav_val = st.checkbox("Favorites only", value=fav_default)
+
+qp_changed = (
+    q_val != q_default
+    or set(status_val) != set(status_default_list)
+    or fav_val != fav_default
+)
+if qp_changed:
+    st.query_params["q"] = q_val
+    st.query_params["status"] = ",".join(status_val)
+    st.query_params["fav"] = "1" if fav_val else "0"
+    history_filter_changed(len(q_val), len(status_val), len(mode_val), fav_val)
+    st.rerun()
+
+date_from = None
+date_to = None
+if isinstance(dates, tuple):
+    if dates[0]:
+        date_from = datetime.combine(dates[0], datetime.min.time()).timestamp()
+    if dates[1]:
+        date_to = datetime.combine(dates[1], datetime.max.time()).timestamp()
+
+rows = runs_index.search(
+    index,
+    q=q_val,
+    status=status_val,
+    mode=mode_val,
+    date_from=date_from,
+    date_to=date_to,
+    favorites_only=fav_val,
+    tags=tags_val,
+    notes_lookup=notes_lookup,
+)
+
+if rows:
+    df = pd.DataFrame(
+        [
+            {
+                "⭐": "★" if notes_lookup.get(r["run_id"], {}).get("favorite") else "",
+                "run_id": r["run_id"],
+                "started_at": datetime.fromtimestamp(r["started_at"]).isoformat()
+                if r.get("started_at")
+                else "",
+                "duration": (r.get("completed_at", 0) - r.get("started_at", 0))
+                if r.get("completed_at") and r.get("started_at")
+                else None,
+                "status": r.get("status"),
+                "mode": r.get("mode"),
+                "idea_preview": r.get("idea_preview", "")[:40],
+                "tokens": r.get("tokens"),
+                "cost": r.get("cost_usd"),
+                "Trace": f"./?view=trace&run_id={r['run_id']}",
+                "Reports": f"./?view=reports&run_id={r['run_id']}",
+                "Reproduce": f"./?view=run&origin_run_id={r['run_id']}",
+                "Resume": f"./?view=run&resume_from={r['run_id']}"
+                if r.get("status") == "resumable"
+                else "",
+            }
+            for r in rows
+        ]
+    )
+    st.dataframe(
+        df,
+        use_container_width=True,
+        hide_index=True,
+        column_config={
+            "Trace": st.column_config.LinkColumn("Trace"),
+            "Reports": st.column_config.LinkColumn("Reports"),
+            "Reproduce": st.column_config.LinkColumn("Reproduce"),
+            "Resume": st.column_config.LinkColumn("Resume"),
+        },
+    )
+else:
+    st.info("No runs match.")
+
+if rows and st.button("Export CSV"):
+    csv_bytes = runs_index.to_csv(rows)
+    history_export_clicked(len(rows))
+    st.download_button(
+        "runs.csv",
+        data=csv_bytes,
+        file_name="runs.csv",
+        mime="text/csv",
+    )
+
+if rows:
+    sel_run = st.sidebar.selectbox("Annotate run", [r["run_id"] for r in rows])
+    note = run_notes.load(sel_run)
+    title = st.sidebar.text_input("Title", value=note.get("title", ""))
+    tags = st.sidebar.text_input("Tags", value=",".join(note.get("tags", [])))
+    favorite = st.sidebar.checkbox("Favorite", value=note.get("favorite", False))
+    body = st.sidebar.text_area("Note", value=note.get("note", ""))
+    if st.sidebar.button("Save"):
+        saved = run_notes.save(
+            sel_run,
+            title=title,
+            note=body,
+            tags=[t.strip() for t in tags.split(",") if t.strip()],
+            favorite=favorite,
+        )
+        run_annotated(
+            sel_run,
+            len(saved.get("title", "")),
+            len(saved.get("tags", [])),
+            len(saved.get("note", "")),
+            saved.get("favorite", False),
+        )
+        st.sidebar.success("Saved")
+        notes_lookup[sel_run] = saved
+        st.rerun()
+    if st.sidebar.button("Toggle Favorite"):
+        toggled = run_notes.toggle_favorite(sel_run)
+        run_favorited(sel_run, toggled.get("favorite", False))
+        st.sidebar.success("Updated")
+        st.rerun()

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T14:21:35.064968Z'
-git_sha: 91b1329c07e314af3cbbf7d114e9ee68ee79bafb
+generated_at: '2025-08-30T14:32:55.382359Z'
+git_sha: b99e1520259d468dbe7bb2b2f9c4c14cb2b0a6d7
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -184,6 +184,27 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
+- path: orchestrators/app_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/qa_router.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/__init__.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
 - path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
@@ -198,27 +219,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/qa_router.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/app_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/__init__.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: core/summarization/integrator.py
   role: Summarization
   responsibilities: []
@@ -226,14 +226,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/__init__.py
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_run_notes.py
+++ b/tests/test_run_notes.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+from utils import run_notes
+
+
+def test_load_save_toggle(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    saved = run_notes.save("r1", title="t", note="n", tags=["a", "b"], favorite=False)
+    assert saved["favorite"] is False
+    loaded = run_notes.load("r1")
+    assert loaded["title"] == "t"
+    toggled = run_notes.toggle_favorite("r1")
+    assert toggled["favorite"] is True
+    notes = run_notes.all_notes()
+    assert "r1" in notes
+
+
+def test_clamp_and_atomic(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    long_note = "x" * 20000
+    many_tags = [str(i) for i in range(20)]
+    saved = run_notes.save("r2", title="", note=long_note, tags=many_tags, favorite=False)
+    assert len(saved["note"]) == 10000
+    assert len(saved["tags"]) == 10
+    path = Path(".dr_rd") / "runs" / "r2" / "notes.json"
+    ino1 = path.stat().st_ino
+    saved2 = run_notes.save("r2", title="a", note="b", tags=[], favorite=True)
+    ino2 = path.stat().st_ino
+    assert ino1 != ino2

--- a/tests/test_runs_index.py
+++ b/tests/test_runs_index.py
@@ -1,0 +1,37 @@
+import json
+from pathlib import Path
+
+from utils import runs_index
+
+
+def _write_run(root: Path, run_id: str, *, started: int, status: str, mode: str) -> None:
+    run_dir = root / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    meta = {
+        "run_id": run_id,
+        "started_at": started,
+        "completed_at": started + 5,
+        "status": status,
+        "mode": mode,
+        "idea_preview": f"idea {run_id}",
+    }
+    (run_dir / "run.json").write_text(json.dumps(meta), encoding="utf-8")
+    totals = {"tokens": 50, "cost_usd": 0.5}
+    (run_dir / "usage_totals.json").write_text(json.dumps(totals), encoding="utf-8")
+
+
+def test_scan_search_csv(tmp_path):
+    _write_run(tmp_path, "r1", started=100, status="success", mode="a")
+    _write_run(tmp_path, "r2", started=200, status="error", mode="b")
+    _write_run(tmp_path, "r3", started=300, status="success", mode="a")
+    rows = runs_index.scan_runs(tmp_path)
+    assert len(rows) == 3
+    succ = runs_index.search(rows, status=["success"])
+    assert len(succ) == 2
+    date_filtered = runs_index.search(rows, date_from=150, date_to=350)
+    assert {r["run_id"] for r in date_filtered} == {"r2", "r3"}
+    csv_bytes = runs_index.to_csv(succ)
+    text = csv_bytes.decode("utf-8").splitlines()
+    assert text[0].startswith("run_id")
+    run_ids = {line.split(",")[0] for line in text[1:]}
+    assert run_ids == {"r1", "r3"}

--- a/utils/run_notes.py
+++ b/utils/run_notes.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Dict, List
+
+from .paths import RUNS_ROOT
+
+_MAX_NOTE_CHARS = 10_000
+_MAX_TAGS = 10
+
+
+def _note_path(run_id: str) -> Path:
+    return RUNS_ROOT / run_id / "notes.json"
+
+
+def load(run_id: str) -> Dict:
+    """Load annotations for a run or return defaults."""
+    path = _note_path(run_id)
+    if not path.exists():
+        return {"title": "", "note": "", "tags": [], "favorite": False, "updated_at": 0}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            data.setdefault("title", "")
+            data.setdefault("note", "")
+            data.setdefault("tags", [])
+            data.setdefault("favorite", False)
+            data.setdefault("updated_at", 0)
+            return data
+    except Exception:
+        pass
+    return {"title": "", "note": "", "tags": [], "favorite": False, "updated_at": 0}
+
+
+def save(run_id: str, *, title: str, note: str, tags: List[str], favorite: bool) -> Dict:
+    """Persist annotations for a run with clamped sizes."""
+    note = note[:_MAX_NOTE_CHARS]
+    tags = [t for t in tags if t][: _MAX_TAGS]
+    data = {
+        "title": title,
+        "note": note,
+        "tags": tags,
+        "favorite": bool(favorite),
+        "updated_at": int(time.time()),
+    }
+    path = _note_path(run_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+    tmp.replace(path)
+    return data
+
+
+def toggle_favorite(run_id: str) -> Dict:
+    """Flip favorite flag for a run and persist."""
+    data = load(run_id)
+    fav = not bool(data.get("favorite"))
+    return save(
+        run_id,
+        title=data.get("title", ""),
+        note=data.get("note", ""),
+        tags=list(data.get("tags", [])),
+        favorite=fav,
+    )
+
+
+def all_notes() -> Dict[str, Dict]:
+    """Return mapping of run_id -> notes."""
+    out: Dict[str, Dict] = {}
+    if not RUNS_ROOT.exists():
+        return out
+    for child in RUNS_ROOT.iterdir():
+        if not child.is_dir():
+            continue
+        path = child / "notes.json"
+        if path.exists():
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+                if isinstance(data, dict):
+                    data.setdefault("title", "")
+                    data.setdefault("note", "")
+                    data.setdefault("tags", [])
+                    data.setdefault("favorite", False)
+                    data.setdefault("updated_at", 0)
+                    out[child.name] = data
+            except Exception:
+                continue
+    return out
+
+
+__all__ = ["load", "save", "toggle_favorite", "all_notes"]

--- a/utils/runs_index.py
+++ b/utils/runs_index.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import csv
+import io
+import json
+from typing import Iterable, Mapping, Optional, List, Dict
+from pathlib import Path
+
+from .paths import RUNS_ROOT
+
+_INDEX_PATH = Path(".dr_rd") / "runs_index.json"
+
+
+def scan_runs(root: Path = RUNS_ROOT) -> List[Dict]:
+    """Scan ``root`` for runs and return list of row dicts."""
+    rows: List[Dict] = []
+    if not root.exists():
+        return rows
+    for child in sorted(root.iterdir()):
+        if not child.is_dir():
+            continue
+        run_id = child.name
+        run_path = child / "run.json"
+        if run_path.exists():
+            try:
+                meta = json.loads(run_path.read_text(encoding="utf-8"))
+            except Exception:
+                meta = {"run_id": run_id}
+        else:
+            meta = {"run_id": run_id}
+        totals_path = child / "usage_totals.json"
+        tokens = 0
+        cost = 0.0
+        if totals_path.exists():
+            try:
+                totals = json.loads(totals_path.read_text(encoding="utf-8"))
+                tokens = int(totals.get("tokens") or totals.get("total_tokens") or 0)
+                cost = float(totals.get("cost_usd") or totals.get("cost") or 0.0)
+            except Exception:
+                pass
+        row = {
+            "run_id": meta.get("run_id", run_id),
+            "started_at": meta.get("started_at"),
+            "completed_at": meta.get("completed_at"),
+            "status": meta.get("status"),
+            "mode": meta.get("mode"),
+            "idea_preview": meta.get("idea_preview", ""),
+            "origin_run_id": meta.get("origin_run_id"),
+            "tokens": meta.get("tokens", tokens),
+            "cost_usd": meta.get("cost_usd", cost),
+        }
+        rows.append(row)
+    rows.sort(key=lambda r: r.get("started_at") or 0, reverse=True)
+    return rows
+
+
+def build_index() -> List[Dict]:
+    """Build the runs index and cache it."""
+    rows = scan_runs()
+    _INDEX_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp = _INDEX_PATH.with_suffix(".tmp")
+    tmp.write_text(json.dumps(rows, ensure_ascii=False), encoding="utf-8")
+    tmp.replace(_INDEX_PATH)
+    return rows
+
+
+def load_index(refresh: bool = False) -> List[Dict]:
+    """Load cached runs index or rebuild if needed."""
+    if refresh or not _INDEX_PATH.exists():
+        return build_index()
+    try:
+        return json.loads(_INDEX_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        return build_index()
+
+
+def search(
+    rows: List[Dict],
+    *,
+    q: str = "",
+    status: Optional[Iterable[str]] = None,
+    mode: Optional[Iterable[str]] = None,
+    date_from: Optional[float] = None,
+    date_to: Optional[float] = None,
+    favorites_only: bool = False,
+    tags: Optional[Iterable[str]] = None,
+    notes_lookup: Mapping[str, Dict] | None = None,
+) -> List[Dict]:
+    """Filter ``rows`` based on provided criteria."""
+    q = q.lower().strip()
+    status_set = {s for s in status or []}
+    mode_set = {m for m in mode or []}
+    tag_set = {t.lower() for t in tags or []}
+    notes_lookup = notes_lookup or {}
+
+    def match(row: Dict) -> bool:
+        rid = row.get("run_id", "")
+        if status_set and row.get("status") not in status_set:
+            return False
+        if mode_set and row.get("mode") not in mode_set:
+            return False
+        if date_from and (row.get("started_at") or 0) < date_from:
+            return False
+        if date_to and (row.get("started_at") or 0) > date_to:
+            return False
+        note = notes_lookup.get(rid, {})
+        if favorites_only and not note.get("favorite"):
+            return False
+        if tag_set and not tag_set.issubset({t.lower() for t in note.get("tags", [])}):
+            return False
+        if q:
+            hay = " ".join(
+                [
+                    rid,
+                    row.get("idea_preview", ""),
+                    note.get("title", ""),
+                    note.get("note", ""),
+                    " ".join(note.get("tags", [])),
+                ]
+            ).lower()
+            if q not in hay:
+                return False
+        return True
+
+    return [r for r in rows if match(r)]
+
+
+def to_csv(rows: List[Dict]) -> bytes:
+    """Return ``rows`` encoded as RFC4180 CSV bytes."""
+    buf = io.StringIO()
+    fieldnames = [
+        "run_id",
+        "started_at",
+        "completed_at",
+        "status",
+        "mode",
+        "idea_preview",
+        "origin_run_id",
+        "tokens",
+        "cost_usd",
+    ]
+    writer = csv.DictWriter(buf, fieldnames=fieldnames)
+    writer.writeheader()
+    for r in rows:
+        writer.writerow({k: r.get(k) for k in fieldnames})
+    return buf.getvalue().encode("utf-8")
+
+
+__all__ = [
+    "scan_runs",
+    "build_index",
+    "load_index",
+    "search",
+    "to_csv",
+]

--- a/utils/telemetry.py
+++ b/utils/telemetry.py
@@ -143,6 +143,43 @@ def knowledge_tags_updated(item_id: str, count: int) -> None:
     log_event({"event": "knowledge_tags_updated", "id": item_id, "count": count})
 
 
+def history_filter_changed(q_len: int, status_count: int, mode_count: int, fav: bool) -> None:
+    """Emit a history_filter_changed telemetry event."""
+    log_event(
+        {
+            "event": "history_filter_changed",
+            "q_len": q_len,
+            "status_count": status_count,
+            "mode_count": mode_count,
+            "fav": bool(fav),
+        }
+    )
+
+
+def history_export_clicked(count: int) -> None:
+    """Emit a history_export_clicked telemetry event."""
+    log_event({"event": "history_export_clicked", "count": count})
+
+
+def run_annotated(run_id: str, title_len: int, tags_count: int, note_len: int, favorite: bool) -> None:
+    """Emit a run_annotated telemetry event."""
+    log_event(
+        {
+            "event": "run_annotated",
+            "run_id": run_id,
+            "title_len": title_len,
+            "tags_count": tags_count,
+            "note_len": note_len,
+            "favorite": bool(favorite),
+        }
+    )
+
+
+def run_favorited(run_id: str, favorite: bool) -> None:
+    """Emit a run_favorited telemetry event."""
+    log_event({"event": "run_favorited", "run_id": run_id, "favorite": bool(favorite)})
+
+
 __all__ = [
     "log_event",
     "run_cancel_requested",
@@ -161,4 +198,8 @@ __all__ = [
     "knowledge_added",
     "knowledge_removed",
     "knowledge_tags_updated",
+    "history_filter_changed",
+    "history_export_clicked",
+    "run_annotated",
+    "run_favorited",
 ]


### PR DESCRIPTION
## Summary
- add run_notes utility for per-run titles, notes, tags, and favorites with atomic storage
- index and search runs from `.dr_rd/runs` with CSV export support
- implement Run History page with filters, annotations, quick actions, and telemetry

## Testing
- `pytest tests/test_run_notes.py tests/test_runs_index.py -q`
- `python scripts/generate_repo_map.py`

------
https://chatgpt.com/codex/tasks/task_e_68b30a7c70dc832c98ca98697fee7268