### PR TITLE
Add global command palette with fuzzy search

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -21,6 +21,7 @@ st.set_page_config(
 
 from app.ui.a11y import inject_accessibility_baseline, live_region_container
 from app.ui.copy import t
+from app.ui.command_palette import open_palette
 from utils.cancellation import CancellationToken
 from utils.telemetry import (
     log_event,
@@ -38,6 +39,43 @@ from utils.user_id import get_user_id
 
 inject_accessibility_baseline()
 live_region_container()
+
+# quick open via button
+if st.button(
+    "⌘K Command palette",
+    key="cmd_btn",
+    use_container_width=False,
+    help="Open global search",
+):
+    log_event({"event": "palette_opened"})
+    open_palette()
+
+# auto open via query param
+if st.query_params.get("cmd") == "1":
+    log_event({"event": "palette_opened", "source": "qp"})
+    open_palette()
+    st.query_params.pop("cmd", None)
+
+act = st.session_state.pop("_cmd_action", None)
+if act:
+    if act["action"] == "switch_page":
+        st.switch_page(act["params"]["page"])
+    elif act["action"] == "set_params":
+        st.query_params.update(act["params"])
+        st.rerun()
+    elif act["action"] == "copy":
+        st.code(act["params"]["text"], language=None)
+        st.toast("Copied link")
+    elif act["action"] == "start_demo":
+        st.query_params.update({"mode": "demo", "view": "run"})
+        st.toast("Demo mode selected. Review and start.")
+    log_event(
+        {
+            "event": "palette_executed",
+            "kind": act.get("kind"),
+            "action": act["action"],
+        }
+    )
 
 params = dict(st.query_params)
 uid = get_user_id()

--- a/app/ui/command_palette.py
+++ b/app/ui/command_palette.py
@@ -1,0 +1,22 @@
+import streamlit as st
+
+from utils.global_search import search, resolve_action
+from utils.telemetry import log_event
+
+
+def open_palette():
+    @st.dialog("Command palette")
+    def _dlg():
+        q = st.text_input("Type a command, page, run, or source", key="cmd_q")
+        log_event({"event": "palette_query", "q_len": len(q or "")})
+        results = search(q) if q else search("")[:10]
+        for i, r in enumerate(results):
+            col1, col2 = st.columns([3, 1])
+            with col1:
+                st.write(f"**{r['label']}**  \n{r.get('hint','')}")
+            with col2:
+                if st.button("Select", key=f"sel_{i}", use_container_width=True):
+                    act = resolve_action(r)
+                    st.session_state["_cmd_action"] = act
+                    st.rerun()
+    _dlg()

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T14:32:55.382359Z from commit b99e152_
+_Last generated at 2025-08-30T14:41:38.014747Z from commit aa61695_

--- a/pages/05_Health.py
+++ b/pages/05_Health.py
@@ -7,6 +7,44 @@ import streamlit as st
 
 from utils import health_check
 from utils.telemetry import log_event
+from app.ui.command_palette import open_palette
+
+# quick open via button
+if st.button(
+    "⌘K Command palette",
+    key="cmd_btn",
+    use_container_width=False,
+    help="Open global search",
+):
+    log_event({"event": "palette_opened"})
+    open_palette()
+
+# auto open via query param
+if st.query_params.get("cmd") == "1":
+    log_event({"event": "palette_opened", "source": "qp"})
+    open_palette()
+    st.query_params.pop("cmd", None)
+
+act = st.session_state.pop("_cmd_action", None)
+if act:
+    if act["action"] == "switch_page":
+        st.switch_page(act["params"]["page"])
+    elif act["action"] == "set_params":
+        st.query_params.update(act["params"])
+        st.rerun()
+    elif act["action"] == "copy":
+        st.code(act["params"]["text"], language=None)
+        st.toast("Copied link")
+    elif act["action"] == "start_demo":
+        st.query_params.update({"mode": "demo", "view": "run"})
+        st.toast("Demo mode selected. Review and start.")
+    log_event(
+        {
+            "event": "palette_executed",
+            "kind": act.get("kind"),
+            "action": act["action"],
+        }
+    )
 
 st.title("System Health")
 

--- a/pages/10_Trace.py
+++ b/pages/10_Trace.py
@@ -18,6 +18,44 @@ from utils.run_config import from_session, to_orchestrator_kwargs
 from utils.runs import last_run_id, list_runs
 from utils.telemetry import log_event
 from utils.flags import is_enabled
+from app.ui.command_palette import open_palette
+
+# quick open via button
+if st.button(
+    "⌘K Command palette",
+    key="cmd_btn",
+    use_container_width=False,
+    help="Open global search",
+):
+    log_event({"event": "palette_opened"})
+    open_palette()
+
+# auto open via query param
+if st.query_params.get("cmd") == "1":
+    log_event({"event": "palette_opened", "source": "qp"})
+    open_palette()
+    st.query_params.pop("cmd", None)
+
+act = st.session_state.pop("_cmd_action", None)
+if act:
+    if act["action"] == "switch_page":
+        st.switch_page(act["params"]["page"])
+    elif act["action"] == "set_params":
+        st.query_params.update(act["params"])
+        st.rerun()
+    elif act["action"] == "copy":
+        st.code(act["params"]["text"], language=None)
+        st.toast("Copied link")
+    elif act["action"] == "start_demo":
+        st.query_params.update({"mode": "demo", "view": "run"})
+        st.toast("Demo mode selected. Review and start.")
+    log_event(
+        {
+            "event": "palette_executed",
+            "kind": act.get("kind"),
+            "action": act["action"],
+        }
+    )
 
 params = dict(st.query_params)
 state = view_state_from_params(params)

--- a/pages/12_History.py
+++ b/pages/12_History.py
@@ -13,6 +13,44 @@ from utils.telemetry import (
     run_annotated,
     run_favorited,
 )
+from app.ui.command_palette import open_palette
+
+# quick open via button
+if st.button(
+    "⌘K Command palette",
+    key="cmd_btn",
+    use_container_width=False,
+    help="Open global search",
+):
+    log_event({"event": "palette_opened"})
+    open_palette()
+
+# auto open via query param
+if st.query_params.get("cmd") == "1":
+    log_event({"event": "palette_opened", "source": "qp"})
+    open_palette()
+    st.query_params.pop("cmd", None)
+
+act = st.session_state.pop("_cmd_action", None)
+if act:
+    if act["action"] == "switch_page":
+        st.switch_page(act["params"]["page"])
+    elif act["action"] == "set_params":
+        st.query_params.update(act["params"])
+        st.rerun()
+    elif act["action"] == "copy":
+        st.code(act["params"]["text"], language=None)
+        st.toast("Copied link")
+    elif act["action"] == "start_demo":
+        st.query_params.update({"mode": "demo", "view": "run"})
+        st.toast("Demo mode selected. Review and start.")
+    log_event(
+        {
+            "event": "palette_executed",
+            "kind": act.get("kind"),
+            "action": act["action"],
+        }
+    )
 
 params = dict(st.query_params)
 

--- a/pages/25_Compare.py
+++ b/pages/25_Compare.py
@@ -22,7 +22,45 @@ from utils.diff_runs import (
 from utils.telemetry import log_event
 from utils.metrics import ensure_run_totals
 from utils.flags import is_enabled
+from app.ui.command_palette import open_palette
 
+
+# quick open via button
+if st.button(
+    "⌘K Command palette",
+    key="cmd_btn",
+    use_container_width=False,
+    help="Open global search",
+):
+    log_event({"event": "palette_opened"})
+    open_palette()
+
+# auto open via query param
+if st.query_params.get("cmd") == "1":
+    log_event({"event": "palette_opened", "source": "qp"})
+    open_palette()
+    st.query_params.pop("cmd", None)
+
+act = st.session_state.pop("_cmd_action", None)
+if act:
+    if act["action"] == "switch_page":
+        st.switch_page(act["params"]["page"])
+    elif act["action"] == "set_params":
+        st.query_params.update(act["params"])
+        st.rerun()
+    elif act["action"] == "copy":
+        st.code(act["params"]["text"], language=None)
+        st.toast("Copied link")
+    elif act["action"] == "start_demo":
+        st.query_params.update({"mode": "demo", "view": "run"})
+        st.toast("Demo mode selected. Review and start.")
+    log_event(
+        {
+            "event": "palette_executed",
+            "kind": act.get("kind"),
+            "action": act["action"],
+        }
+    )
 
 params = dict(st.query_params)
 if not is_enabled("compare_page", params=params):

--- a/pages/30_Metrics.py
+++ b/pages/30_Metrics.py
@@ -9,6 +9,44 @@ from utils import metrics
 from utils.telemetry import log_event
 from app.ui import empty_states
 from app.ui.copy import t
+from app.ui.command_palette import open_palette
+
+# quick open via button
+if st.button(
+    "⌘K Command palette",
+    key="cmd_btn",
+    use_container_width=False,
+    help="Open global search",
+):
+    log_event({"event": "palette_opened"})
+    open_palette()
+
+# auto open via query param
+if st.query_params.get("cmd") == "1":
+    log_event({"event": "palette_opened", "source": "qp"})
+    open_palette()
+    st.query_params.pop("cmd", None)
+
+act = st.session_state.pop("_cmd_action", None)
+if act:
+    if act["action"] == "switch_page":
+        st.switch_page(act["params"]["page"])
+    elif act["action"] == "set_params":
+        st.query_params.update(act["params"])
+        st.rerun()
+    elif act["action"] == "copy":
+        st.code(act["params"]["text"], language=None)
+        st.toast("Copied link")
+    elif act["action"] == "start_demo":
+        st.query_params.update({"mode": "demo", "view": "run"})
+        st.toast("Demo mode selected. Review and start.")
+    log_event(
+        {
+            "event": "palette_executed",
+            "kind": act.get("kind"),
+            "action": act["action"],
+        }
+    )
 
 if st.query_params.get("view") != "metrics":
     st.query_params["view"] = "metrics"

--- a/pages/90_Settings.py
+++ b/pages/90_Settings.py
@@ -7,6 +7,44 @@ from app.ui.copy import t
 
 from utils.prefs import DEFAULT_PREFS, load_prefs, save_prefs
 from utils.telemetry import log_event
+from app.ui.command_palette import open_palette
+
+# quick open via button
+if st.button(
+    "⌘K Command palette",
+    key="cmd_btn",
+    use_container_width=False,
+    help="Open global search",
+):
+    log_event({"event": "palette_opened"})
+    open_palette()
+
+# auto open via query param
+if st.query_params.get("cmd") == "1":
+    log_event({"event": "palette_opened", "source": "qp"})
+    open_palette()
+    st.query_params.pop("cmd", None)
+
+act = st.session_state.pop("_cmd_action", None)
+if act:
+    if act["action"] == "switch_page":
+        st.switch_page(act["params"]["page"])
+    elif act["action"] == "set_params":
+        st.query_params.update(act["params"])
+        st.rerun()
+    elif act["action"] == "copy":
+        st.code(act["params"]["text"], language=None)
+        st.toast("Copied link")
+    elif act["action"] == "start_demo":
+        st.query_params.update({"mode": "demo", "view": "run"})
+        st.toast("Demo mode selected. Review and start.")
+    log_event(
+        {
+            "event": "palette_executed",
+            "kind": act.get("kind"),
+            "action": act["action"],
+        }
+    )
 
 if st.query_params.get("view") != "settings":
     st.query_params["view"] = "settings"

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T14:32:55.382359Z'
-git_sha: b99e1520259d468dbe7bb2b2f9c4c14cb2b0a6d7
+generated_at: '2025-08-30T14:41:38.014747Z'
+git_sha: aa61695ca116ceb28211247cfc0e3e4150d86f57
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -184,27 +184,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/qa_router.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/__init__.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
@@ -219,8 +198,22 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
-  role: Summarization
+- path: orchestrators/app_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/__init__.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/qa_router.py
+  role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
@@ -233,14 +226,21 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
+- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/schemas.py
+- path: core/summarization/integrator.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_global_search.py
+++ b/tests/test_global_search.py
@@ -1,0 +1,65 @@
+import pytest
+
+from utils import global_search as gs
+
+
+def _setup(monkeypatch):
+    runs = [
+        {"run_id": "r1", "idea_preview": "alpha", "started_at": 1},
+        {"run_id": "r2", "idea_preview": "beta", "started_at": 2},
+    ]
+    notes = {
+        "r1": {"title": "first", "note": "", "tags": ["a"], "favorite": False},
+        "r2": {"title": "second", "note": "", "tags": ["b"], "favorite": False},
+    }
+    knowledge = [{"id": "k1", "name": "doc1", "tags": ["ref"], "type": "PDF"}]
+    monkeypatch.setattr(gs.runs_index, "load_index", lambda: runs)
+    monkeypatch.setattr(gs.run_notes, "all_notes", lambda: notes)
+    monkeypatch.setattr(gs.knowledge_store, "list_items", lambda: knowledge)
+    monkeypatch.setattr(
+        gs,
+        "default_actions",
+        lambda: [
+            {
+                "kind": "page",
+                "id": "trace",
+                "label": "Trace",
+                "hint": "Open page",
+                "payload": {"page": "pages/10_Trace.py"},
+                "text": "trace page",
+            },
+            {
+                "kind": "cmd",
+                "id": "start_demo",
+                "label": "Start demo run",
+                "hint": "",
+                "payload": {},
+                "text": "start demo",
+            },
+        ],
+    )
+
+
+def test_search_trace(monkeypatch):
+    _setup(monkeypatch)
+    res = gs.search("trace")
+    assert res
+    assert res[0]["kind"] in {"page", "run"}
+
+
+def test_search_run_id(monkeypatch):
+    _setup(monkeypatch)
+    res = gs.search("r2")
+    assert res
+    assert res[0]["id"].startswith("r2")
+    assert res[0]["score"] >= 0.9
+
+
+def test_resolve_action():
+    assert gs.resolve_action({"kind": "page", "payload": {"page": "app.py"}})["action"] == "switch_page"
+    assert gs.resolve_action({"kind": "run", "payload": {"view": "trace", "run_id": "r1"}})["action"] == "set_params"
+    assert (
+        gs.resolve_action({"kind": "knowledge", "payload": {"item_id": "k1"}})["params"]["use_source"]
+        == "k1"
+    )
+    assert gs.resolve_action({"kind": "cmd", "id": "start_demo", "payload": {}})["action"] == "start_demo"

--- a/utils/global_search.py
+++ b/utils/global_search.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+from typing import List, Dict, Any, Tuple, Optional
+import difflib
+import time
+
+# Optional fast fuzzy matcher
+try:  # pragma: no cover - optional dependency
+    from rapidfuzz import fuzz
+except Exception:  # pragma: no cover - fallback
+    fuzz = None  # type: ignore
+
+from . import runs_index, run_notes, knowledge_store
+
+
+# Result schema:
+# {'kind': 'page'|'cmd'|'run'|'knowledge',
+#  'id': 'trace'|'reports'|run_id|item_id|...,
+#  'label': 'Trace — 2025-08-29 — Idea…',
+#  'hint': 'Open page'|'Open trace'|'Open reports'|'Use source'|...,
+#  'score': float,
+#  'payload': {...}}  # for actions
+
+
+def build_corpus(*, runs: List[Dict], notes: Dict[str, Dict], knowledge: List[Dict]) -> List[Dict]:
+    """Return a flat list of candidate objects with searchable text fields assembled."""
+    corpus: List[Dict] = []
+    for r in runs:
+        rid = r.get("run_id", "")
+        note = notes.get(rid, {})
+        title = note.get("title") or r.get("idea_preview", "")
+        ts = r.get("started_at") or 0
+        date = time.strftime("%Y-%m-%d", time.localtime(ts)) if ts else ""
+        hay = " ".join(
+            [
+                rid,
+                r.get("idea_preview", ""),
+                title,
+                note.get("note", ""),
+                " ".join(note.get("tags", [])),
+            ]
+        )
+        label = f"Trace — {date} — {title}"
+        corpus.append(
+            {
+                "kind": "run",
+                "id": f"{rid}:trace",
+                "label": label,
+                "hint": "Open trace",
+                "payload": {"view": "trace", "run_id": rid},
+                "text": hay,
+            }
+        )
+        label_r = f"Reports — {date} — {title}"
+        corpus.append(
+            {
+                "kind": "run",
+                "id": f"{rid}:reports",
+                "label": label_r,
+                "hint": "Open reports",
+                "payload": {"view": "reports", "run_id": rid},
+                "text": hay,
+            }
+        )
+    for item in knowledge:
+        text = " ".join([item.get("name", ""), " ".join(item.get("tags", []))])
+        corpus.append(
+            {
+                "kind": "knowledge",
+                "id": item.get("id"),
+                "label": item.get("name", ""),
+                "hint": "Use source",
+                "payload": {"item_id": item.get("id")},
+                "text": text,
+            }
+        )
+    return corpus
+
+
+def _score(query: str, text: str) -> float:
+    q = query.lower()
+    hay = text.lower()
+    if not q:
+        return 1.0
+    if q in hay:
+        return 1.0
+    if fuzz:
+        return fuzz.ratio(q, hay) / 100.0  # type: ignore[return-value]
+    return difflib.SequenceMatcher(None, q, hay).ratio()
+
+
+def fuzzy_rank(query: str, candidates: List[Dict], limit: int = 20) -> List[Dict]:
+    """Use difflib.SequenceMatcher or rapidfuzz if available; return top-N with 'score'."""
+    scored: List[Tuple[float, Dict]] = []
+    for c in candidates:
+        text = " ".join([c.get("label", ""), c.get("text", "")])
+        score = _score(query, text)
+        scored.append((score, c))
+    scored.sort(key=lambda t: t[0], reverse=True)
+    out: List[Dict] = []
+    for score, c in scored[:limit]:
+        item = {k: v for k, v in c.items() if k != "text"}
+        item["score"] = score
+        out.append(item)
+    return out
+
+
+def default_actions() -> List[Dict]:
+    """Static command/page entries with labels and payloads."""
+    actions: List[Dict] = []
+    pages = [
+        ("run", "Run", "app.py"),
+        ("trace", "Trace", "pages/10_Trace.py"),
+        ("reports", "Reports", "pages/20_Reports.py"),
+        ("metrics", "Metrics", "pages/30_Metrics.py"),
+        ("compare", "Compare", "pages/25_Compare.py"),
+        ("knowledge", "Knowledge", "pages/15_Knowledge.py"),
+        ("history", "History", "pages/12_History.py"),
+        ("settings", "Settings", "pages/90_Settings.py"),
+        ("health", "Health", "pages/05_Health.py"),
+    ]
+    for pid, label, page in pages:
+        actions.append(
+            {
+                "kind": "page",
+                "id": pid,
+                "label": label,
+                "hint": "Open page",
+                "payload": {"page": page},
+                "text": label,
+            }
+        )
+    runs = runs_index.load_index()
+    last_run = runs[0] if runs else None
+    last_run_id = last_run.get("run_id") if last_run else None
+    resumable = next((r for r in runs if r.get("status") == "resumable"), None)
+    resumable_id = resumable.get("run_id") if resumable else None
+    actions.append(
+        {
+            "kind": "cmd",
+            "id": "start_demo",
+            "label": "Start demo run",
+            "hint": "Start demo",
+            "payload": {},
+            "text": "start demo run",
+        }
+    )
+    if last_run_id:
+        actions.append(
+            {
+                "kind": "cmd",
+                "id": "repro_last_run",
+                "label": "Reproduce last run",
+                "hint": "Prefill from last run",
+                "payload": {"run_id": last_run_id},
+                "text": f"reproduce {last_run_id}",
+            }
+        )
+        actions.append(
+            {
+                "kind": "cmd",
+                "id": "open_latest_trace",
+                "label": "Open latest trace",
+                "hint": "Go to last trace",
+                "payload": {"run_id": last_run_id},
+                "text": f"latest trace {last_run_id}",
+            }
+        )
+    if resumable_id:
+        actions.append(
+            {
+                "kind": "cmd",
+                "id": "resume_last_run",
+                "label": "Resume last run",
+                "hint": "Resume last resumable run",
+                "payload": {"run_id": resumable_id},
+                "text": f"resume {resumable_id}",
+            }
+        )
+    actions.append(
+        {
+            "kind": "cmd",
+            "id": "copy_share_link",
+            "label": "Copy share link",
+            "hint": "Copy share link",
+            "payload": {"text": ""},
+            "text": "copy share link",
+        }
+    )
+    from pathlib import Path
+
+    if Path(".dr_rd/flags.json").exists():  # feature flags file present
+        actions.append(
+            {
+                "kind": "cmd",
+                "id": "open_flags",
+                "label": "Open flags",
+                "hint": "Open flags",
+                "payload": {},
+                "text": "open flags",
+            }
+        )
+    return actions
+
+
+def search(query: str, *, limit: int = 20) -> List[Dict]:
+    """Load runs/notes/knowledge; build corpus + default actions; return ranked results."""
+    runs = runs_index.load_index()
+    notes = run_notes.all_notes()
+    knowledge = knowledge_store.list_items()
+    candidates = build_corpus(runs=runs, notes=notes, knowledge=knowledge)
+    candidates.extend(default_actions())
+    return fuzzy_rank(query, candidates, limit=limit)
+
+
+def resolve_action(item: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert a selected item into a normalized action."""
+    kind = item.get("kind")
+    payload = item.get("payload", {})
+    if kind == "page":
+        return {"action": "switch_page", "params": payload, "kind": kind}
+    if kind == "run":
+        return {"action": "set_params", "params": payload, "kind": kind}
+    if kind == "knowledge":
+        return {"action": "set_params", "params": {"use_source": payload.get("item_id"), "view": "run"}, "kind": kind}
+    if kind == "cmd":
+        cid = item.get("id")
+        if cid == "start_demo":
+            return {"action": "start_demo", "params": {}, "kind": kind}
+        if cid == "repro_last_run":
+            rid = payload.get("run_id")
+            return {"action": "set_params", "params": {"origin_run_id": rid, "view": "run"}, "kind": kind}
+        if cid == "resume_last_run":
+            rid = payload.get("run_id")
+            return {"action": "set_params", "params": {"resume_from": rid, "view": "run"}, "kind": kind}
+        if cid == "copy_share_link":
+            return {"action": "copy", "params": {"text": payload.get("text", "")}, "kind": kind}
+        if cid == "open_latest_trace":
+            rid = payload.get("run_id")
+            return {"action": "set_params", "params": {"view": "trace", "run_id": rid}, "kind": kind}
+        if cid == "open_flags":
+            return {"action": "set_params", "params": {"flags": "1"}, "kind": kind}
+    return {"action": "noop", "params": {}, "kind": kind}
+
+
+__all__ = [
+    "build_corpus",
+    "fuzzy_rank",
+    "default_actions",
+    "search",
+    "resolve_action",
+]


### PR DESCRIPTION
## Summary
- implement global search utilities for runs, pages, commands, and knowledge
- add Streamlit command palette modal and integrate across pages
- cover search behavior with unit tests and update repo map

## Testing
- `pytest tests/test_global_search.py -q`
- `python scripts/generate_repo_map.py`

------
https://chatgpt.com/codex/tasks/task_e_68b30c625c90832ca1e355aec72056b7