### PR TITLE
feat: add versioned telemetry with rotation and export tools

### DIFF
--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T14:55:09.853857Z from commit 6d1e429_
+_Last generated at 2025-08-30T15:09:07.903560Z from commit b6082ce_

--- a/docs/UX_METRICS.md
+++ b/docs/UX_METRICS.md
@@ -48,3 +48,17 @@ weekly_sus = df[df.event=="survey_submitted"].set_index("ts").scores.resample("7
 - No PII captured; run IDs are anonymous.
 - Secrets are redacted before logging.
 - Users can opt out by setting `DRRD_TELEMETRY_OPTOUT=1`.
+
+## Telemetry schema + rotation + purge
+- Events are validated against a versioned schema (`schema_version`), currently `1`. Older records are upcast on read so analytics stay consistent.
+- Writers emit JSONL files daily under `.dr_rd/telemetry/` and roll to `events-YYYYMMDD.partN.jsonl` when they exceed ~25MB.
+- `scripts/telemetry_purge.py` deletes old files (`--older-than`/`--keep-last-days`) or removes a specific run's events (`--delete-run`). Use `--dry-run` to preview.
+- `scripts/telemetry_export.py` exports logs to CSV or Parquet and offers `usage` or `runs` rollups.
+
+### Examples
+```bash
+python scripts/telemetry_export.py --days 7 --out events.csv
+python scripts/telemetry_export.py --from 2025-01-01 --to 2025-01-31 --out events.parquet --rollup usage
+python scripts/telemetry_purge.py --older-than 30
+python scripts/telemetry_purge.py --delete-run r123
+```

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T14:55:09.853857Z'
-git_sha: 6d1e42946531be61be981fc8f456c066249f2781
+generated_at: '2025-08-30T15:09:07.903560Z'
+git_sha: b6082ce85d6eb8ad967a45cc8ef6f21eea2c4e18
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -184,14 +184,21 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/qa_router.py
+- path: orchestrators/plan_utils.py
   role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/plan_utils.py
+- path: orchestrators/spec_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/qa_router.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -212,13 +219,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/spec_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
@@ -226,7 +226,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/__init__.py
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -240,7 +240,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/scripts/telemetry_export.py
+++ b/scripts/telemetry_export.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path as _P
+sys.path.insert(0, str(_P(__file__).resolve().parents[1]))
+
+
+"""Export telemetry events to CSV or Parquet with simple rollups."""
+
+import argparse
+import csv
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, List
+
+from utils.telemetry import read_events
+
+try:  # optional dependency
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+    HAS_PARQUET = True
+except Exception:  # pragma: no cover
+    HAS_PARQUET = False
+
+
+def _parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description="Export telemetry events")
+    grp = ap.add_mutually_exclusive_group(required=False)
+    grp.add_argument("--days", type=int, help="Number of days back to include")
+    grp.add_argument("--from", dest="from_", help="Start date YYYY-MM-DD")
+    ap.add_argument("--to", dest="to", help="End date YYYY-MM-DD")
+    ap.add_argument("--out", required=True, help="Output file path (.csv or .parquet)")
+    ap.add_argument("--rollup", choices=["usage", "runs"], help="Optional rollup")
+    return ap.parse_args()
+
+
+def _filter_range(events: List[Dict[str, Any]], start: datetime, end: datetime) -> List[Dict[str, Any]]:
+    return [e for e in events if start.timestamp() <= e.get("ts", 0) < end.timestamp()]
+
+
+def _rollup_usage(events: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    per_run: Dict[str, Dict[str, Any]] = {}
+    for ev in events:
+        rid = ev.get("run_id")
+        if not rid:
+            continue
+        stats = per_run.setdefault(rid, {"tokens": 0, "cost_usd": 0.0, "errors": 0, "start": None, "end": None})
+        if ev.get("event") == "start_run":
+            stats["start"] = ev.get("ts")
+        if ev.get("event") == "run_completed":
+            stats["end"] = ev.get("ts")
+        if ev.get("event") == "error_shown":
+            stats["errors"] += 1
+        if "total_tokens" in ev:
+            try:
+                stats["tokens"] += int(ev["total_tokens"])
+            except Exception:
+                pass
+        if "cost_usd" in ev:
+            try:
+                stats["cost_usd"] += float(ev["cost_usd"])
+            except Exception:
+                pass
+    rows: List[Dict[str, Any]] = []
+    for rid, s in per_run.items():
+        duration = None
+        if s["start"] and s["end"]:
+            duration = s["end"] - s["start"]
+        rows.append({"run_id": rid, "tokens": s["tokens"], "cost_usd": round(s["cost_usd"], 6),
+                      "duration": duration, "error_count": s["errors"]})
+    return rows
+
+
+def _rollup_runs(events: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    per_day: Dict[str, Dict[str, Any]] = {}
+    starts: Dict[str, float] = {}
+    for ev in events:
+        if ev.get("event") == "start_run" and ev.get("run_id"):
+            starts[ev["run_id"]] = ev.get("ts", 0)
+        if ev.get("event") == "run_completed" and ev.get("run_id"):
+            ts = ev.get("ts", 0)
+            day = datetime.utcfromtimestamp(ts).strftime("%Y-%m-%d")
+            d = per_day.setdefault(day, {"success": 0, "error": 0, "cancelled": 0, "timeout": 0, "durations": []})
+            status = ev.get("status", "unknown")
+            d[status] = d.get(status, 0) + 1
+            start_ts = starts.get(ev["run_id"])
+            if start_ts:
+                d["durations"].append(ts - start_ts)
+    rows: List[Dict[str, Any]] = []
+    for day, d in sorted(per_day.items()):
+        mean_dur = sum(d["durations"]) / len(d["durations"]) if d["durations"] else None
+        rows.append({"day": day, "success": d.get("success", 0), "error": d.get("error", 0),
+                     "cancelled": d.get("cancelled", 0), "timeout": d.get("timeout", 0),
+                     "mean_duration": mean_dur})
+    return rows
+
+
+def main() -> int:
+    args = _parse_args()
+    if args.from_ and args.to:
+        start = datetime.strptime(args.from_, "%Y-%m-%d")
+        end = datetime.strptime(args.to, "%Y-%m-%d") + timedelta(days=1)
+        days = (datetime.utcnow() - start).days + 1
+        events = read_events(days=days)
+        events = _filter_range(events, start, end)
+    else:
+        events = read_events(days=args.days or 7)
+
+    if args.rollup == "usage":
+        rows = _rollup_usage(events)
+    elif args.rollup == "runs":
+        rows = _rollup_runs(events)
+    else:
+        rows = events
+
+    out = Path(args.out)
+    if out.suffix == ".parquet":
+        if not HAS_PARQUET:
+            raise SystemExit("pyarrow not available")
+        table = pa.Table.from_pylist(rows)
+        pq.write_table(table, out)
+    else:
+        fieldnames = sorted({k for r in rows for k in r.keys()}) if rows else []
+        with out.open("w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames, extrasaction="ignore")
+            writer.writeheader()
+            for row in rows:
+                writer.writerow(row)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/telemetry_purge.py
+++ b/scripts/telemetry_purge.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path as _P
+sys.path.insert(0, str(_P(__file__).resolve().parents[1]))
+
+
+"""CLI for purging telemetry event logs."""
+
+import argparse
+import json
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from utils import telemetry
+
+
+def _parse_day(p: Path) -> datetime.date:
+    name = p.name
+    for token in name.split("."):
+        if token.startswith("events-"):
+            token = token[len("events-") :]
+        if token[:8].isdigit():
+            try:
+                return datetime.strptime(token[:8], "%Y%m%d").date()
+            except ValueError:
+                pass
+    return datetime.utcfromtimestamp(0).date()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Purge telemetry logs")
+    ap.add_argument("--older-than", type=int, default=None, help="Delete files older than DAYS")
+    ap.add_argument("--keep-last-days", type=int, default=None, help="Keep only last N days of logs")
+    ap.add_argument("--delete-run", dest="delete_run", help="Remove events for a specific run_id")
+    ap.add_argument("--dry-run", action="store_true", help="Print actions without making changes")
+    args = ap.parse_args()
+
+    files = telemetry.list_files()
+    now = datetime.utcnow().date()
+    to_delete: list[Path] = []
+
+    if args.older_than is not None:
+        cutoff = now - timedelta(days=args.older_than)
+        to_delete.extend([p for p in files if _parse_day(p) < cutoff])
+
+    if args.keep_last_days is not None:
+        cutoff = now - timedelta(days=args.keep_last_days)
+        to_delete.extend([p for p in files if _parse_day(p) < cutoff and p not in to_delete])
+
+    deleted_bytes = 0
+    rewritten = []
+
+    # Delete whole files
+    for p in to_delete:
+        try:
+            deleted_bytes += p.stat().st_size
+        except OSError:
+            pass
+        if args.dry_run:
+            print(f"Would delete {p}")
+        else:
+            try:
+                p.unlink()
+            except OSError:
+                pass
+
+    # Delete specific run_id occurrences
+    if args.delete_run:
+        rid = args.delete_run
+        for p in telemetry.list_files():
+            try:
+                lines = p.read_text(encoding="utf-8", errors="ignore").splitlines()
+            except OSError:
+                continue
+            new_lines = []
+            removed = 0
+            for line in lines:
+                try:
+                    ev = json.loads(line)
+                except Exception:
+                    ev = None
+                if ev and ev.get("run_id") == rid:
+                    removed += len(line.encode("utf-8"))
+                    continue
+                new_lines.append(line)
+            if removed:
+                rewritten.append(p)
+                deleted_bytes += removed
+                if args.dry_run:
+                    print(f"Would rewrite {p} excluding run_id={rid}")
+                else:
+                    tmp = p.with_suffix(p.suffix + ".tmp")
+                    tmp.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+                    tmp.replace(p)
+
+    print(
+        f"deleted_files={len(to_delete)} rewritten_files={len(rewritten)} freed_bytes={deleted_bytes}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_telemetry_export.py
+++ b/tests/test_telemetry_export.py
@@ -1,0 +1,45 @@
+import csv
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def _write_events(tmp_path, monkeypatch):
+    import importlib
+    monkeypatch.setenv("TELEMETRY_LOG_DIR", str(tmp_path))
+    import utils.telemetry as telem
+    importlib.reload(telem)
+    telem.log_event({"event": "start_run", "run_id": "r1"})
+    telem.log_event({"event": "error_shown", "run_id": "r1"})
+    telem.log_event({"event": "run_completed", "run_id": "r1", "status": "success"})
+    return telem
+
+
+def test_export_csv(tmp_path, monkeypatch):
+    _write_events(tmp_path, monkeypatch)
+    out = tmp_path / "events.csv"
+    subprocess.check_call(
+        [sys.executable, "scripts/telemetry_export.py", "--days", "1", "--out", str(out)],
+        env={**os.environ, "TELEMETRY_LOG_DIR": str(tmp_path)},
+    )
+    import csv
+    with out.open() as f:
+        rows = list(csv.DictReader(f))
+    assert len(rows) >= 3
+    assert "event" in rows[0]
+
+
+@pytest.mark.skipif(not pytest.importorskip("pyarrow", reason="pyarrow not installed"), reason="pyarrow not installed")
+def test_export_parquet(tmp_path, monkeypatch):
+    _write_events(tmp_path, monkeypatch)
+    out = tmp_path / "events.parquet"
+    subprocess.check_call(
+        [sys.executable, "scripts/telemetry_export.py", "--days", "1", "--out", str(out)],
+        env={**os.environ, "TELEMETRY_LOG_DIR": str(tmp_path)},
+    )
+    import pyarrow.parquet as pq
+
+    table = pq.read_table(out)
+    assert table.num_rows >= 3

--- a/tests/test_telemetry_purge.py
+++ b/tests/test_telemetry_purge.py
@@ -1,0 +1,38 @@
+import importlib
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timedelta
+
+
+def _setup(tmp_path, monkeypatch):
+    monkeypatch.setenv("TELEMETRY_LOG_DIR", str(tmp_path))
+    import utils.telemetry as telem
+    importlib.reload(telem)
+    # yesterday file
+    yday = datetime.utcnow() - timedelta(days=1)
+    yfile = tmp_path / f"events-{yday.strftime('%Y%m%d')}.jsonl"
+    yfile.write_text(json.dumps({"event": "old", "run_id": "old"}) + "\n")
+    # today event
+    telem.log_event({"event": "run_completed", "run_id": "r1", "status": "success"})
+    return telem, yfile
+
+
+def test_purge(tmp_path, monkeypatch):
+    telem, yfile = _setup(tmp_path, monkeypatch)
+    tfile = max(telem.list_files())
+    # purge older than 0 days -> remove yesterday
+    subprocess.check_call(
+        [sys.executable, "scripts/telemetry_purge.py", "--older-than", "0"],
+        env={**os.environ, "TELEMETRY_LOG_DIR": str(tmp_path)},
+    )
+    assert not yfile.exists()
+    assert tfile.exists()
+    # delete run r1
+    subprocess.check_call(
+        [sys.executable, "scripts/telemetry_purge.py", "--delete-run", "r1"],
+        env={**os.environ, "TELEMETRY_LOG_DIR": str(tmp_path)},
+    )
+    text = tfile.read_text()
+    assert "r1" not in text

--- a/tests/test_telemetry_rotation.py
+++ b/tests/test_telemetry_rotation.py
@@ -1,0 +1,15 @@
+import importlib
+from pathlib import Path
+
+
+def test_rotation(tmp_path, monkeypatch):
+    monkeypatch.setenv("TELEMETRY_LOG_DIR", str(tmp_path))
+    monkeypatch.setenv("TELEMETRY_MAX_BYTES", "200")
+    import utils.telemetry as telem
+    importlib.reload(telem)
+    for i in range(50):
+        telem.log_event({"event": "test", "i": i})
+    files = telem.list_files()
+    assert len(files) > 1
+    events = telem.read_events()
+    assert len(events) == 50

--- a/tests/test_telemetry_schema.py
+++ b/tests/test_telemetry_schema.py
@@ -1,0 +1,13 @@
+from utils.telemetry_schema import validate, upcast, CURRENT_SCHEMA_VERSION
+
+
+def test_validate_adds_version_ts_and_drops_pii():
+    ev = validate({"event": "start_run", "run_id": "r1", "email": "x@example.com"})
+    assert ev["schema_version"] == CURRENT_SCHEMA_VERSION
+    assert "ts" in ev
+    assert "email" not in ev
+
+
+def test_upcast_noop_for_v1():
+    ev = {"event": "start_run", "run_id": "r1", "schema_version": CURRENT_SCHEMA_VERSION}
+    assert upcast(ev)["schema_version"] == CURRENT_SCHEMA_VERSION

--- a/utils/telemetry_schema.py
+++ b/utils/telemetry_schema.py
@@ -1,0 +1,105 @@
+"""Telemetry event schema registry and validation.
+
+Provides minimal schema contracts for telemetry events and helpers to
+validate and upcast them. The schema is intentionally permissive and
+only enforces required keys for known events. Extra keys are ignored and
+obvious PII fields are stripped.
+"""
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, List
+
+CURRENT_SCHEMA_VERSION = 1
+
+# Basic schema definition: mapping event name -> required keys.
+# Only a small subset of fields are enforced to keep things flexible.
+_SCHEMAS: Dict[str, List[str]] = {
+    "start_run": ["run_id"],
+    "run_created": ["run_id"],
+    "step_completed": ["run_id", "step"],
+    "run_completed": ["run_id", "status"],
+    "error_shown": ["run_id", "code"],
+    "export_clicked": ["run_id", "format"],
+    "nav_page_view": ["page"],
+    "survey_shown": ["survey"],
+    "survey_submitted": ["survey", "scores"],
+    "usage_threshold_crossed": ["type", "frac"],
+    "usage_exceeded": ["type"],
+    "run_cancel_requested": ["run_id"],
+    "run_cancelled": ["run_id"],
+    "timeout_hit": ["run_id"],
+    "run_resumed": ["new_run_id", "origin_run_id"],
+    "checkpoint_saved": ["run_id", "phase", "step_id"],
+    "demo_started": ["run_id"],
+    "demo_completed": ["run_id"],
+    "knowledge_added": ["id", "name", "type", "size"],
+    "knowledge_removed": ["id"],
+    "palette_opened": [],
+    "palette_executed": ["command"],
+}
+
+# Keys that should never be persisted. This is a simple heuristic to strip
+# accidental PII or user identifying information.
+_PII_KEYS = {
+    "email",
+    "e-mail",
+    "user",
+    "username",
+    "user_name",
+    "user_id",
+    "name",
+    "full_name",
+    "address",
+    "phone",
+    "ip",
+    "ip_address",
+}
+
+
+def validate(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Validate and sanitize a telemetry event.
+
+    - Ensures the "event" key exists.
+    - Attaches a ``schema_version`` and timestamp ``ts`` if missing.
+    - Ensures required keys exist for known events (filling with ``None``).
+    - Strips obvious PII fields.
+    - Never raises on extra or malformed fields.
+    """
+
+    ev: Dict[str, Any] = dict(event or {})
+    if "event" not in ev:
+        ev["event"] = "unknown"
+
+    # Drop potential PII keys.
+    for key in list(ev.keys()):
+        if key.lower() in _PII_KEYS:
+            ev.pop(key, None)
+
+    # Ensure required keys exist.
+    required = _SCHEMAS.get(ev["event"], [])
+    for key in required:
+        ev.setdefault(key, None)
+
+    # Attach metadata.
+    ev.setdefault("schema_version", CURRENT_SCHEMA_VERSION)
+    ev.setdefault("ts", time.time())
+    return ev
+
+
+def upcast(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Upcast an event to the ``CURRENT_SCHEMA_VERSION``.
+
+    Currently schema version 1 has no historical versions, so this is a
+    no-op other than ensuring the version is set correctly. The helper
+    exists so future migrations can transform older payloads.
+    """
+
+    ev = dict(event or {})
+    ver = int(ev.get("schema_version", 1))
+    if ver < CURRENT_SCHEMA_VERSION:
+        # In the future, transformations for older versions would go here.
+        ev["schema_version"] = CURRENT_SCHEMA_VERSION
+    return ev
+
+__all__ = ["CURRENT_SCHEMA_VERSION", "validate", "upcast"]


### PR DESCRIPTION
## Summary
- add `telemetry_schema` for versioned event validation and upcasting
- harden telemetry writer with daily/size-based rotation and thread safety
- new `telemetry_purge.py` and `telemetry_export.py` CLIs for log maintenance and analysis
- document telemetry schema, rotation, purge/export workflows

## Testing
- `python -m pytest tests/test_telemetry_schema.py tests/test_telemetry_rotation.py tests/test_telemetry_export.py tests/test_telemetry_purge.py -q`
- `python scripts/generate_repo_map.py`

------
https://chatgpt.com/codex/tasks/task_e_68b31278ff60832c8e70167cb78fc447