### PR TITLE
feat: add single-file HTML report export

### DIFF
--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T15:09:07.903560Z from commit b6082ce_
+_Last generated at 2025-08-30T15:18:38.144590Z from commit e6b2992_

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T15:09:07.903560Z'
-git_sha: b6082ce85d6eb8ad967a45cc8ef6f21eea2c4e18
+generated_at: '2025-08-30T15:18:38.144590Z'
+git_sha: e6b2992816753ea25aeafbd8a7065ac60fc1714c
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -184,13 +184,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/plan_utils.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
@@ -205,14 +198,21 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/__init__.py
+- path: orchestrators/app_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
+- path: orchestrators/plan_utils.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/__init__.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -226,14 +226,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
+- path: core/summarization/integrator.py
   role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_report_html.py
+++ b/tests/test_report_html.py
@@ -1,0 +1,43 @@
+from utils.report_html import build_html_report
+
+
+def test_build_html_report():
+    run_id = "run1"
+    meta = {
+        "idea_preview": "<idea & demo>",
+        "mode": "test",
+        "started_at": 0,
+        "completed_at": 1,
+    }
+    rows = [
+        {
+            "i": 1,
+            "phase": "plan",
+            "name": "step1",
+            "status": "complete",
+            "duration_ms": 10,
+            "tokens": 5,
+            "cost": 0.1,
+            "summary": "did <thing> & stuff",
+        },
+        {
+            "i": 2,
+            "phase": "exec",
+            "name": "step2",
+            "status": "error",
+            "duration_ms": 20,
+            "tokens": 10,
+            "cost": 0.2,
+            "summary": "oops <script>alert(1)</script>",
+        },
+    ]
+    totals = {"tokens": 15, "cost": 0.3}
+    html = build_html_report(run_id, meta, rows, "summary & <b>", totals, [("file.txt", "file.txt")])
+
+    assert f"DR RD Report — {run_id}" in html
+    assert "Tokens" in html and "Cost" in html
+    assert "<th>Phase</th>" in html
+    assert "&lt;b&gt;" in html  # escaped user text
+    assert "<script" not in html.lower()
+    assert "@media print" in html
+    assert len(html.encode("utf-8")) < 1_000_000

--- a/utils/report_html.py
+++ b/utils/report_html.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+"""HTML report builder for DR RD runs."""
+
+from datetime import datetime
+import html
+from typing import Mapping, Sequence, Tuple
+
+from .report_builder import summarize_steps
+
+
+def _esc(text: object | None) -> str:
+    """HTML-escape ``text`` converted to string."""
+    if text is None:
+        return ""
+    return html.escape(str(text), quote=True)
+
+
+def _iso(ts: object | None) -> str:
+    if isinstance(ts, (int, float)):
+        try:
+            return datetime.fromtimestamp(ts).isoformat()
+        except Exception:
+            return ""
+    return ""
+
+
+def _short(text: str | None, limit: int = 80) -> str:
+    text = text or ""
+    return text[:limit]
+
+
+CSS = (
+    "body{font-family:-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,\"Helvetica Neue\",Arial,sans-serif;"
+    "font-size:16px;line-height:1.5;color:#0A0A0A;background:#FFFFFF;padding:1rem;}"
+    "h1,h2,h3{color:#0A0A0A;}"
+    "table{width:100%;border-collapse:collapse;margin-top:1rem;}"
+    "th,td{border:1px solid #ddd;padding:4px 8px;text-align:left;}"
+    "th{background:#F6F8FA;}"
+    ".chip{display:inline-block;padding:0 8px;border-radius:9999px;font-size:12px;line-height:20px;}"
+    ".chip.complete{background:#ECFDF5;color:#065F46;}"
+    ".chip.error{background:#FEE2E2;color:#991B1B;}"
+    ".chip.running{background:#FEF3C7;color:#92400E;}"
+    ".metrics{display:flex;flex-wrap:wrap;gap:0.5rem;margin:1rem 0;}"
+    ".metric{background:#F6F8FA;padding:8px 12px;border-radius:4px;}"
+    ".metric .label{font-size:0.875rem;color:#555;}"
+    ".metric .value{font-weight:600;}"
+    "@media print{a[href]:after{content:''}.no-print{display:none}table{page-break-inside:auto}tr{page-break-inside:avoid}}"
+)
+
+
+def build_html_report(
+    run_id: str,
+    meta: Mapping,
+    rows: Sequence[Mapping],
+    summary_text: str | None,
+    totals: Mapping | None,
+    artifacts: Sequence[Tuple[str, str]] | None = None,
+) -> str:
+    """Return a complete UTF-8 HTML report string."""
+
+    lines: list[str] = []
+    lines.append("<!DOCTYPE html>")
+    lines.append("<html lang=\"en\">")
+    lines.append("<head>")
+    lines.append("<meta charset=\"utf-8\">")
+    lines.append(f"<title>DR RD Report — {_esc(run_id)}</title>")
+    lines.append("<style>" + CSS + "</style>")
+    lines.append("</head>")
+    lines.append("<body>")
+    lines.append(f"<h1>DR RD Report — {_esc(run_id)}</h1>")
+
+    # Overview
+    lines.append("<h2>Overview</h2>")
+    idea = meta.get("idea_preview")
+    mode = meta.get("mode")
+    started = _iso(meta.get("started_at"))
+    completed = _iso(meta.get("completed_at"))
+    duration = ""
+    if meta.get("started_at") and meta.get("completed_at"):
+        try:
+            duration = str(int(meta["completed_at"] - meta["started_at"])) + " s"
+        except Exception:
+            duration = ""
+    if idea:
+        lines.append(f"<p><strong>Idea:</strong> {_esc(idea)}</p>")
+    if mode:
+        lines.append(f"<p><strong>Mode:</strong> {_esc(mode)}</p>")
+    if started:
+        lines.append(f"<p><strong>Started:</strong> {_esc(started)}</p>")
+    if completed:
+        lines.append(f"<p><strong>Completed:</strong> {_esc(completed)}</p>")
+    if duration:
+        lines.append(f"<p><strong>Duration:</strong> {_esc(duration)}</p>")
+
+    # Key results
+    lines.append("<h2>Key results</h2>")
+    if summary_text:
+        lines.append("<pre><code>")
+        lines.append(_esc(summary_text))
+        lines.append("</code></pre>")
+    else:
+        summaries = summarize_steps(rows)
+        if summaries:
+            lines.append("<ul>")
+            for s in summaries:
+                lines.append(f"<li>{_esc(s)}</li>")
+            lines.append("</ul>")
+
+    # Metrics
+    lines.append("<h2>Metrics</h2>")
+    lines.append("<div class=\"metrics\">")
+    lines.append(
+        f"<div class=\"metric\"><span class=\"label\">Steps</span><span class=\"value\">{len(rows)}</span></div>"
+    )
+    if totals:
+        tokens = totals.get("tokens") if isinstance(totals, Mapping) else None
+        cost = totals.get("cost") if isinstance(totals, Mapping) else None
+        if tokens is not None:
+            lines.append(
+                f"<div class=\"metric\"><span class=\"label\">Tokens</span><span class=\"value\">{_esc(tokens)}</span></div>"
+            )
+        if cost is not None:
+            lines.append(
+                f"<div class=\"metric\"><span class=\"label\">Cost</span><span class=\"value\">${float(cost):.4f}</span></div>"
+            )
+    lines.append("</div>")
+
+    # Trace table
+    lines.append("<h2>Trace</h2>")
+    lines.append(
+        "<table><thead><tr><th>#</th><th>Phase</th><th>Name</th><th>Status</th><th>Duration (ms)</th><th>Tokens</th><th>Cost</th><th>Summary</th></tr></thead><tbody>"
+    )
+    for r in rows:
+        status = r.get("status")
+        chip = f"<span class=\"chip {status}\">{_esc(status)}</span>" if status else ""
+        lines.append(
+            "<tr>"
+            f"<td>{_esc(r.get('i'))}</td>"
+            f"<td>{_esc(r.get('phase'))}</td>"
+            f"<td>{_esc(r.get('name'))}</td>"
+            f"<td>{chip}</td>"
+            f"<td>{_esc(r.get('duration_ms'))}</td>"
+            f"<td>{_esc(r.get('tokens'))}</td>"
+            f"<td>{_esc(r.get('cost'))}</td>"
+            f"<td>{_esc(_short(r.get('summary')))}</td>"
+            "</tr>"
+        )
+    lines.append("</tbody></table>")
+
+    # Errors
+    errors = [r for r in rows if r.get("status") == "error"]
+    if errors:
+        lines.append("<h2>Errors</h2>")
+        lines.append("<ul>")
+        for e in errors:
+            lines.append(
+                f"<li>{_esc(e.get('name'))} — {_esc(e.get('summary'))}</li>"
+            )
+        lines.append("</ul>")
+
+    # Artifacts
+    if artifacts:
+        lines.append("<h2>Artifacts</h2>")
+        lines.append("<ul>")
+        for name, rel in artifacts:
+            href = _esc(rel)
+            lines.append(f"<li><a href=\"{href}\">{_esc(name)}</a></li>")
+        lines.append("</ul>")
+
+    lines.append("</body></html>")
+    return "\n".join(lines)
+
+
+__all__ = ["build_html_report"]

--- a/utils/trace_export.py
+++ b/utils/trace_export.py
@@ -18,9 +18,12 @@ def _safe_summary(text: str | None, max_len: int = 80) -> str:
     return text[:max_len]
 
 
-def flatten_trace_rows(trace: Sequence[TraceStep]) -> List[TraceRow]:
-    """Return normalized rows for tabular exports."""
-    rows: List[TraceRow] = []
+def flatten_trace_rows(trace: Sequence[TraceStep]) -> list[dict]:
+    """Return normalized rows for tabular exports.
+
+    Each row contains the fields: i, phase, name, status, duration_ms, tokens, cost, summary.
+    """
+    rows: list[dict] = []
     for idx, step in enumerate(trace, 1):
         rows.append(
             {


### PR DESCRIPTION
## Summary
- add `build_html_report` to generate self-contained browser/print friendly reports
- enable HTML report download on Reports page and log telemetry
- document reusable `flatten_trace_rows` helper and add coverage tests

## Testing
- `pytest` *(fails: tests/gtm/test_generate_deck.py, tests/integrations/test_jira_bridge.py, tests/integrations/test_slack_bridge.py, tests/integrations/test_teams_bridge.py)*
- `pytest tests/test_report_html.py tests/test_report_builder.py`
- `python scripts/generate_repo_map.py`

------
https://chatgpt.com/codex/tasks/task_e_68b3157f4c6c832c92e35068edc74fb9