### PR TITLE
feat: add headless CLI runners

### DIFF
--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T15:18:38.144590Z from commit e6b2992_
+_Last generated at 2025-08-30T15:27:08.507740Z from commit 661f3d3_

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T15:18:38.144590Z'
-git_sha: e6b2992816753ea25aeafbd8a7065ac60fc1714c
+generated_at: '2025-08-30T15:27:08.507740Z'
+git_sha: 661f3d3c2a28a07bbd91155064e74574cc8fac75
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -184,28 +184,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/spec_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/qa_router.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/app_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/plan_utils.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -219,7 +198,28 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/schemas.py
+- path: orchestrators/qa_router.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/spec_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/plan_utils.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -233,14 +233,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/__init__.py
+- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/scripts/batch_run.py
+++ b/scripts/batch_run.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Mapping, Iterable
+
+from utils.cli import print_summary, load_config
+from scripts.run_cli import run as run_single
+from utils import telemetry
+
+
+def _read_items(jsonl: str | None, csv_path: str | None) -> Iterable[Mapping]:
+    if jsonl:
+        for line in Path(jsonl).read_text().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            obj = json.loads(line)
+            if isinstance(obj, Mapping) and "lockfile" in obj:
+                yield load_config(None, obj["lockfile"])
+            else:
+                yield obj
+    elif csv_path:
+        with open(csv_path, newline="", encoding="utf-8") as fh:
+            reader = csv.DictReader(fh)
+            for row in reader:
+                cfg = {k: v for k, v in row.items() if v != ""}
+                if "budget_limit_usd" in cfg:
+                    cfg["budget_limit_usd"] = float(cfg["budget_limit_usd"])
+                if "max_tokens" in cfg:
+                    cfg["max_tokens"] = int(cfg["max_tokens"])
+                yield cfg
+    else:
+        return []
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run multiple DR RD pipelines from a list of configs")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--jsonl", help="Path to JSONL file")
+    group.add_argument("--csv", help="Path to CSV file")
+    parser.add_argument("--concurrency", type=int, default=1)
+    parser.add_argument("--deadline-sec", type=float, default=None)
+    parser.add_argument("--budget-usd", type=float, default=None)
+    parser.add_argument("--max-tokens", type=int, default=None)
+    parser.add_argument("--stop-on-fail", action="store_true")
+    parser.add_argument("--out-dir", default=".dr_rd/runs")
+    parser.add_argument("--no-telemetry", action="store_true")
+    args = parser.parse_args(argv)
+
+    telemetry_enabled = not args.no_telemetry
+    if telemetry_enabled:
+        telemetry.log_event({"event": "batch_started"})
+
+    items = list(_read_items(args.jsonl, args.csv))
+    results: list[dict] = []
+
+    def _do(cfg: Mapping):
+        b = cfg.get("budget_limit_usd") if "budget_limit_usd" in cfg else args.budget_usd
+        mt = cfg.get("max_tokens") if "max_tokens" in cfg else args.max_tokens
+        meta, totals = run_single(
+            cfg,
+            out_dir=args.out_dir,
+            deadline_sec=args.deadline_sec,
+            telemetry_enabled=telemetry_enabled,
+            budget_usd=b,
+            max_tokens=mt,
+        )
+        print_summary(meta, totals)
+        return meta
+
+    with ThreadPoolExecutor(max_workers=args.concurrency) as ex:
+        futures = [ex.submit(_do, cfg) for cfg in items]
+        for fut in as_completed(futures):
+            meta = fut.result()
+            rid = meta.get("run_id")
+            results.append({"run_id": rid, "status": meta.get("status"), "path": str(Path(args.out_dir) / str(rid))})
+            if args.stop_on_fail and meta.get("status") == "error":
+                for f in futures:
+                    f.cancel()
+                break
+
+    counts: dict[str, int] = {}
+    for r in results:
+        counts[r["status"]] = counts.get(r["status"], 0) + 1
+    summary = {"runs": results, "counts": counts}
+    Path("batch_summary.json").write_text(json.dumps(summary, indent=2))
+
+    if telemetry_enabled:
+        telemetry.log_event({"event": "batch_completed", "counts": counts})
+
+    if any(r["status"] == "error" for r in results):
+        code = 1
+    elif any(r["status"] in {"cancelled", "timeout", "resumable"} for r in results):
+        code = 2
+    else:
+        code = 0
+    return code
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main())

--- a/scripts/run_cli.py
+++ b/scripts/run_cli.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+from typing import Mapping
+
+from utils.cli import load_config, print_summary, exit_code
+from utils.env_snapshot import capture_env
+from utils.run_id import new_run_id
+from utils.paths import ensure_run_dirs, write_text
+from utils.runs import create_run_meta, complete_run_meta, load_run_meta
+from utils.run_config_io import to_lockfile
+from utils.run_reproduce import to_orchestrator_kwargs
+from utils import telemetry
+import core.orchestrator as orch
+
+
+def run(cfg: Mapping, *, run_id: str | None = None, out_dir: str | None = None, deadline_sec: float | None = None, telemetry_enabled: bool = True, budget_usd: float | None = None, max_tokens: int | None = None) -> tuple[Mapping, Mapping | None]:
+    """Execute a single run and return metadata and totals."""
+    from utils import paths as paths_mod
+
+    if out_dir:
+        paths_mod.RUNS_ROOT = Path(out_dir)
+    rid = run_id or new_run_id()
+    cfg = dict(cfg)
+    if budget_usd is not None:
+        cfg["budget_limit_usd"] = float(budget_usd)
+        cfg["enforce_budget"] = True
+    if max_tokens is not None:
+        cfg["max_tokens"] = int(max_tokens)
+        cfg["enforce_budget"] = True
+
+    ensure_run_dirs(rid)
+    locked = to_lockfile(cfg)
+    write_text(rid, "run_config", "lock.json", json.dumps(locked))
+    write_text(rid, "env", "snapshot.json", json.dumps(capture_env()))
+    create_run_meta(rid, mode=cfg.get("mode", "standard"), idea_preview=cfg.get("idea", "")[:120])
+    if telemetry_enabled:
+        telemetry.log_event({"event": "run_created", "run_id": rid, "mode": cfg.get("mode", "standard")})
+    kwargs = to_orchestrator_kwargs(locked)
+    deadline_ts = time.time() + float(deadline_sec) if deadline_sec else None
+    status = "error"
+    start = time.time()
+    try:
+        tasks = orch.generate_plan(kwargs["idea"], deadline_ts=deadline_ts)
+        answers = orch.execute_plan(kwargs["idea"], tasks, deadline_ts=deadline_ts)
+        orch.compose_final_proposal(kwargs["idea"], answers)
+        status = "success"
+    except TimeoutError:
+        status = "timeout"
+    except RuntimeError:
+        status = "cancelled"
+    except Exception:
+        status = "error"
+    complete_run_meta(rid, status=status)
+    if telemetry_enabled:
+        telemetry.log_event({"event": "run_completed", "run_id": rid, "status": status})
+    meta = load_run_meta(rid) or {"run_id": rid, "status": status, "started_at": int(start), "completed_at": int(time.time())}
+    return meta, None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run a DR RD pipeline headlessly")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--config", help="Path to JSON config")
+    group.add_argument("--lockfile", help="Path to run_config.lock.json")
+    parser.add_argument("--mode", help="Override run mode")
+    parser.add_argument("--deadline-sec", type=float, default=None)
+    parser.add_argument("--budget-usd", type=float, default=None)
+    parser.add_argument("--max-tokens", type=int, default=None)
+    parser.add_argument("--run-id", help="Explicit run_id")
+    parser.add_argument("--out-dir", default=".dr_rd/runs")
+    parser.add_argument("--no-telemetry", action="store_true")
+    args = parser.parse_args(argv)
+
+    cfg = load_config(args.config, args.lockfile)
+    if args.mode:
+        cfg = dict(cfg)
+        cfg["mode"] = args.mode
+    meta, totals = run(
+        cfg,
+        run_id=args.run_id,
+        out_dir=args.out_dir,
+        deadline_sec=args.deadline_sec,
+        telemetry_enabled=not args.no_telemetry,
+        budget_usd=args.budget_usd,
+        max_tokens=args.max_tokens,
+    )
+    print_summary(meta, totals)
+    return exit_code(meta.get("status", "error"))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main())

--- a/tests/test_batch_run.py
+++ b/tests/test_batch_run.py
@@ -1,0 +1,38 @@
+import json
+from scripts import batch_run
+
+
+def test_batch_run(tmp_path, monkeypatch):
+    def fake_generate(idea, **kwargs):
+        if idea == "timeout":
+            raise TimeoutError("deadline reached")
+        return []
+
+    def fake_execute(idea, tasks, **kwargs):
+        return {}
+
+    def fake_compose(idea, answers, **kwargs):
+        return "ok"
+
+    monkeypatch.setattr("core.orchestrator.generate_plan", fake_generate)
+    monkeypatch.setattr("core.orchestrator.execute_plan", fake_execute)
+    monkeypatch.setattr("core.orchestrator.compose_final_proposal", fake_compose)
+
+    jsonl_path = tmp_path / "items.jsonl"
+    jsonl_path.write_text("\n".join([
+        json.dumps({"idea": "ok", "mode": "demo"}),
+        json.dumps({"idea": "timeout", "mode": "demo"}),
+    ]))
+    out_dir = tmp_path / "runs"
+    monkeypatch.chdir(tmp_path)
+    code = batch_run.main([
+        "--jsonl", str(jsonl_path),
+        "--concurrency", "2",
+        "--out-dir", str(out_dir),
+        "--no-telemetry",
+    ])
+    assert code == 2
+    summary = json.loads((tmp_path / "batch_summary.json").read_text())
+    assert summary["counts"]["success"] == 1
+    assert summary["counts"]["timeout"] == 1
+    assert len(summary["runs"]) == 2

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -1,0 +1,43 @@
+import json
+from pathlib import Path
+
+from scripts import run_cli
+
+
+def test_run_cli_success(tmp_path, monkeypatch):
+    def fake_generate(idea, **kwargs):
+        return []
+
+    def fake_execute(idea, tasks, **kwargs):
+        return {}
+
+    def fake_compose(idea, answers, **kwargs):
+        return "ok"
+
+    monkeypatch.setattr("core.orchestrator.generate_plan", fake_generate)
+    monkeypatch.setattr("core.orchestrator.execute_plan", fake_execute)
+    monkeypatch.setattr("core.orchestrator.compose_final_proposal", fake_compose)
+
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text(json.dumps({"idea": "x", "mode": "demo"}))
+    out_dir = tmp_path / "runs"
+    code = run_cli.main(["--config", str(cfg_path), "--out-dir", str(out_dir), "--no-telemetry"])
+    assert code == 0
+    run_dirs = list(out_dir.iterdir())
+    assert run_dirs, "run directory created"
+    rid_dir = run_dirs[0]
+    assert (rid_dir / "run.json").exists()
+    assert (rid_dir / "run_config.lock.json").exists()
+
+
+def test_run_cli_error(tmp_path, monkeypatch):
+    def boom(*a, **k):
+        raise Exception("boom")
+
+    monkeypatch.setattr("core.orchestrator.generate_plan", boom)
+
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text(json.dumps({"idea": "x", "mode": "demo"}))
+    out_dir = tmp_path / "runs"
+    code = run_cli.main(["--config", str(cfg_path), "--out-dir", str(out_dir), "--no-telemetry"])
+    assert code == 1

--- a/utils/cli.py
+++ b/utils/cli.py
@@ -1,0 +1,66 @@
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Mapping
+
+
+def load_config(path: str | None, lockfile: str | None) -> Mapping:
+    """Load a run configuration mapping.
+
+    Parameters
+    ----------
+    path: path to a JSON config mapping.
+    lockfile: path to a run_config.lock.json. If provided, ``path`` is ignored.
+
+    Returns
+    -------
+    Mapping ready for adaptation to orchestrator kwargs.
+    """
+    if lockfile:
+        from utils import run_config_io
+
+        try:
+            data = json.loads(Path(lockfile).read_text(encoding="utf-8"))
+        except Exception as exc:  # pragma: no cover - argument errors
+            print(f"failed to read lockfile: {exc}", file=sys.stderr)
+            sys.exit(1)
+        return run_config_io.from_lockfile(data)
+    if path:
+        try:
+            data = json.loads(Path(path).read_text(encoding="utf-8"))
+        except Exception as exc:  # pragma: no cover - argument errors
+            print(f"failed to read config: {exc}", file=sys.stderr)
+            sys.exit(1)
+        if not isinstance(data, Mapping):
+            print("config JSON must be an object", file=sys.stderr)
+            sys.exit(1)
+        return data
+    return {}
+
+
+def print_summary(meta: Mapping, totals: Mapping | None) -> None:
+    """Print a one-line summary of a run to stdout."""
+    run_id = meta.get("run_id", "")
+    status = meta.get("status", "")
+    start = int(meta.get("started_at") or 0)
+    end = int(meta.get("completed_at") or time.time())
+    duration = end - start
+    tokens = 0
+    cost = 0.0
+    if totals:
+        tokens = int(totals.get("tokens") or totals.get("total_tokens") or 0)
+        cost = float(totals.get("cost_usd") or totals.get("cost") or 0)
+    else:
+        tokens = int(meta.get("tokens") or 0)
+        cost = float(meta.get("cost_usd") or 0.0)
+    print(f"{run_id} {status} {duration} {tokens} {cost}")
+
+
+def exit_code(status: str) -> int:
+    """Map run status to deterministic exit codes."""
+    if status == "success":
+        return 0
+    if status in {"cancelled", "timeout", "resumable"}:
+        return 2
+    return 1


### PR DESCRIPTION
## Summary
- add utils.cli helpers for loading configs, summarizing runs, and exit codes
- introduce scripts/run_cli.py for single headless run execution with telemetry hooks
- add scripts/batch_run.py for batch execution from JSONL/CSV with summary reporting
- cover new CLI runners with unit tests
- regenerate repo map

## Testing
- `pytest tests/test_run_cli.py tests/test_batch_run.py`
- `python scripts/generate_repo_map.py`

------
https://chatgpt.com/codex/tasks/task_e_68b31745d63c832cbfec476a19cfb0b5