### PR TITLE
Add centralized secrets and privacy safeguards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ qa_queue.json
 /reports/**/*.json
 /reports/**/*.sarif
 !/reports/**/.gitkeep
+.dr_rd/**
+!samples/demo_run/**

--- a/app/ui/knowledge.py
+++ b/app/ui/knowledge.py
@@ -1,5 +1,7 @@
-import streamlit as st
 from datetime import datetime
+
+import streamlit as st
+
 from utils import uploads
 
 
@@ -13,6 +15,8 @@ def table(items: list[dict]):
     for it in items:
         cols = st.columns([3, 1, 1, 2, 2, 1, 1])
         cols[0].write(it["name"])
+        if it.get("pii_flag"):
+            cols[0].caption("Possible PII detected")
         cols[1].write(it["type"])
         cols[2].write(_fmt_size(it["size"]))
         new_tags = tag_editor(it["id"], it.get("tags", []), key=f"tags_{it['id']}")
@@ -22,9 +26,7 @@ def table(items: list[dict]):
         if cols[5].button("Remove", key=f"rm_{it['id']}"):
             removed.append(it["id"])
         with open(it["path"], "rb") as fh:
-            cols[6].download_button(
-                "Download", fh, file_name=it["name"], key=f"dl_{it['id']}"
-            )
+            cols[6].download_button("Download", fh, file_name=it["name"], key=f"dl_{it['id']}")
     return removed, tag_updates
 
 

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T15:27:08.507740Z from commit 661f3d3_
+_Last generated at 2025-08-30T15:36:36.475055Z from commit 5d0c778_

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,29 @@
+# Security & Privacy
+
+This application follows a few simple rules to keep data safe.
+
+## Secret Management
+Secrets are resolved from environment variables first and then from `st.secrets`.
+Call `utils.secrets.get()` or `require()` to access them. Values are never
+logged and can be typed via a casting function.
+
+## Redaction
+All logs, errors and exports pass through regex-based scrubbing that masks
+access tokens and common PII such as emails, phone numbers and credit card
+numbers. Dictionaries are traversed recursively and long values are truncated
+before writing.
+
+## Upload Policy
+Uploads are limited to a small set of MIME types and a maximum size of 20 MB.
+Text files are scanned for PII; flagged items show a small warning badge in the
+UI. Disallowed types are rejected before storage.
+
+## Repository Scanning
+`scripts/scan_repo_secrets.py` walks the repository (excluding `.dr_rd/` and
+`node_modules`) looking for known token patterns and high-entropy strings.
+The script prints any findings and exits non‑zero if secrets are discovered.
+
+## Privacy Export & Purge
+`scripts/privacy_export.py --run-id <id> --out <dir>` creates a bundle
+containing the run folder and any telemetry events for that run after
+re-applying redaction. Generated data can then be handed to users or removed.

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T15:27:08.507740Z'
-git_sha: 661f3d3c2a28a07bbd91155064e74574cc8fac75
+generated_at: '2025-08-30T15:36:36.475055Z'
+git_sha: 5d0c778996d7b1ba7412d987bac3e5bff5bca824
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -184,20 +184,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/__init__.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/qa_router.py
   role: Orchestrator
   responsibilities: []
@@ -205,7 +191,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/spec_builder.py
+- path: orchestrators/app_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -219,14 +205,28 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
-  role: Summarization
+- path: orchestrators/__init__.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/spec_builder.py
+  role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
 - path: core/summarization/integrator.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/scripts/privacy_export.py
+++ b/scripts/privacy_export.py
@@ -1,0 +1,52 @@
+import argparse
+import json
+import shutil
+from pathlib import Path
+
+from utils.redaction import redact_dict
+
+
+def export_run(run_id: str, out_dir: Path) -> dict[str, int]:
+    runs_root = Path("runs")
+    run_src = runs_root / run_id
+    if not run_src.exists():
+        raise FileNotFoundError(run_src)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    run_dst = out_dir / "runs" / run_id
+    if run_dst.exists():
+        shutil.rmtree(run_dst)
+    shutil.copytree(run_src, run_dst)
+
+    tele_root = Path(".dr_rd/telemetry")
+    events = []
+    if tele_root.exists():
+        for p in tele_root.glob("events-*.jsonl"):
+            with p.open("r", encoding="utf-8", errors="ignore") as f:
+                for line in f:
+                    try:
+                        ev = json.loads(line)
+                    except Exception:
+                        continue
+                    if ev.get("run_id") == run_id:
+                        events.append(redact_dict(ev))
+    if events:
+        tele_out = out_dir / "telemetry.jsonl"
+        with tele_out.open("w", encoding="utf-8") as f:
+            for ev in events:
+                f.write(json.dumps(ev, ensure_ascii=False) + "\n")
+
+    return {"files": sum(1 for _ in run_dst.rglob("*")), "events": len(events)}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Export run data with redaction")
+    ap.add_argument("--run-id", required=True)
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+    summary = export_run(args.run_id, Path(args.out))
+    print(f"exported {summary['files']} files and {summary['events']} events")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/scan_repo_secrets.py
+++ b/scripts/scan_repo_secrets.py
@@ -1,0 +1,62 @@
+import argparse
+import math
+import re
+import sys
+from pathlib import Path
+
+TOKEN_PATTERNS = [
+    (re.compile(r"sk-[A-Za-z0-9]{20,}"), "openai_key"),
+    (re.compile(r"AKIA[0-9A-Z]{16}"), "aws_key"),
+    (re.compile(r"Bearer\s+[A-Za-z0-9._-]{10,}"), "bearer_token"),
+]
+
+EXCLUDE_DIRS = {".dr_rd", "node_modules"}
+
+
+def shannon_entropy(s: str) -> float:
+    """Compute Shannon entropy of a string."""
+    if not s:
+        return 0.0
+    freq = {c: s.count(c) for c in set(s)}
+    n = len(s)
+    return -sum((f / n) * math.log2(f / n) for f in freq.values())
+
+
+def scan_file(path: Path) -> list[tuple[int, str]]:
+    findings: list[tuple[int, str]] = []
+    try:
+        with path.open("r", encoding="utf-8", errors="ignore") as f:
+            for lineno, line in enumerate(f, 1):
+                for rx, name in TOKEN_PATTERNS:
+                    if rx.search(line):
+                        findings.append((lineno, name))
+                for token in re.findall(r"[A-Za-z0-9+/=_-]{20,}", line):
+                    if shannon_entropy(token) > 4.0:
+                        findings.append((lineno, "high-entropy"))
+    except Exception:
+        pass
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Scan repository for secrets")
+    parser.add_argument("path", nargs="?", default=".")
+    args = parser.parse_args()
+
+    root = Path(args.path)
+    hits: list[str] = []
+    for p in root.rglob("*"):
+        if any(part in EXCLUDE_DIRS for part in p.parts):
+            continue
+        if p.is_file():
+            for lineno, name in scan_file(p):
+                rel = p.relative_to(root)
+                hits.append(f"{rel}:{lineno}: {name}")
+
+    for h in hits:
+        print(h)
+    return 1 if hits else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_privacy_export.py
+++ b/tests/test_privacy_export.py
@@ -1,0 +1,23 @@
+import json
+from pathlib import Path
+
+from scripts.privacy_export import export_run
+
+
+def test_privacy_export(tmp_path, monkeypatch):
+    run_id = "r1"
+    run_dir = Path("runs") / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "note.txt").write_text("hello")
+
+    tele_dir = Path(".dr_rd/telemetry")
+    tele_dir.mkdir(parents=True, exist_ok=True)
+    event = {"event": "test", "run_id": run_id, "msg": "email foo@example.com"}
+    (tele_dir / "events-20250101.jsonl").write_text(json.dumps(event) + "\n")
+
+    out = tmp_path / "out"
+    summary = export_run(run_id, out)
+    assert (out / "runs" / run_id / "note.txt").exists()
+    data = (out / "telemetry.jsonl").read_text()
+    assert "foo@example.com" not in data
+    assert summary["events"] == 1

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -1,0 +1,17 @@
+from utils.redaction import redact_dict, redact_text
+
+
+def test_redact_text_masks():
+    s = "token sk-ABCDEFGHIJKLMNOPQRST email foo@example.com"
+    out = redact_text(s)
+    assert "sk-" not in out
+    assert "foo@example.com" not in out
+    assert out.count("•••") >= 2
+
+
+def test_redact_dict_clamp_and_passthrough():
+    data = {"a": "sk-ABCDEFGHIJKLMNOPQRST", "b": "x" * 3000, "c": 42}
+    red = redact_dict(data, max_len=100)
+    assert red["a"] == "•••"
+    assert len(red["b"]) <= 101  # includes ellipsis
+    assert red["c"] == 42

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -1,0 +1,25 @@
+import sys
+import types
+
+import pytest
+
+from utils import secrets
+
+
+def test_env_precedence(monkeypatch):
+    monkeypatch.setenv("MY_SECRET", "123")
+    assert secrets.get("MY_SECRET") == "123"
+
+
+def test_streamlit_fallback(monkeypatch):
+    monkeypatch.delenv("MY_SECRET", raising=False)
+    fake = types.SimpleNamespace(secrets={"MY_SECRET": "abc"})
+    monkeypatch.setitem(sys.modules, "streamlit", fake)
+    assert secrets.get("MY_SECRET") == "abc"
+
+
+def test_require_raises(monkeypatch):
+    monkeypatch.delenv("MISSING", raising=False)
+    sys.modules.pop("streamlit", None)
+    with pytest.raises(RuntimeError):
+        secrets.require("MISSING")

--- a/tests/test_upload_scan.py
+++ b/tests/test_upload_scan.py
@@ -1,0 +1,18 @@
+from utils import upload_scan
+
+
+def test_allowed_and_pii_detection(tmp_path):
+    p = tmp_path / "a.txt"
+    p.write_text("hello")
+    assert upload_scan.allowed(p)
+
+    binf = tmp_path / "a.bin"
+    binf.write_bytes(b"\x00")
+    assert not upload_scan.allowed(binf)
+
+    big = tmp_path / "big.txt"
+    big.write_text("a" * (upload_scan.MAX_BYTES + 1))
+    assert not upload_scan.allowed(big)
+
+    assert upload_scan.detect_pii("email test@example.com")
+    assert not upload_scan.detect_pii("no pii here")

--- a/utils/redaction.py
+++ b/utils/redaction.py
@@ -1,30 +1,87 @@
 from __future__ import annotations
-import json
+
 import re
 from pathlib import Path
-from typing import Dict, Any
+from typing import Any, Mapping
+
 import yaml
 
+TOKEN_PATTERNS = [
+    r"sk-[A-Za-z0-9]{20,}",
+    r"AKIA[0-9A-Z]{16}",
+    r"Bearer\s+[A-Za-z0-9._-]{10,}",
+]
 
-def load_policy(path_or_dict: Any) -> Dict[str, Any]:
+PII_PATTERNS = [
+    r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}",
+    r"\b\+?\d[\d \-()]{7,}\d\b",
+    r"\b\d{3}-\d{2}-\d{4}\b",
+    r"\b(?:\d[ -]*?){13,19}\b",
+]
+
+_COMPILED = [re.compile(p) for p in TOKEN_PATTERNS + PII_PATTERNS]
+
+
+def _regex_redact(s: str, mask: str = "•••") -> str:
+    for rx in _COMPILED:
+        s = rx.sub(mask, s)
+    return s
+
+
+def redact_text(
+    arg1: Any,
+    arg2: str | None = None,
+    mask: str = "•••",
+    *,
+    policy: Mapping[str, Any] | None = None,
+) -> str:
+    """Redact tokens/PII or apply a legacy policy.
+
+    This function supports two call styles for backward compatibility:
+    ``redact_text("secret")`` for regex-based redaction and
+    ``redact_text(policy, text)`` for the older policy-based interface.
+    """
+    if isinstance(arg1, Mapping) or policy is not None:
+        if policy is None:
+            policy = arg1  # type: ignore[assignment]
+            text = arg2 or ""
+        else:
+            text = str(arg1)
+        result = text
+        for name, cfg in policy.items():
+            if not cfg.get("enabled", True):
+                continue
+            pattern = cfg.get("pattern")
+            token = cfg.get("token", f"[REDACTED:{name.upper()}]")
+            if not pattern:
+                continue
+            result = re.sub(pattern, token, result, flags=re.IGNORECASE)
+        return result
+    text = str(arg1)
+    return _regex_redact(text, mask)
+
+
+def redact_dict(obj: Any, mask: str = "•••", max_len: int = 2000) -> Any:
+    """Walk mappings/lists, redact strings, and clamp long values."""
+    if isinstance(obj, Mapping):
+        return {k: redact_dict(v, mask, max_len) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [redact_dict(v, mask, max_len) for v in obj]
+    if isinstance(obj, str):
+        s = _regex_redact(obj, mask)
+        if len(s) > max_len:
+            return s[:max_len] + "\u2026"
+        return s
+    return obj
+
+
+# Legacy helpers -----------------------------------------------------------
+
+
+def load_policy(path_or_dict: Any) -> dict[str, Any]:
     if isinstance(path_or_dict, dict):
         return path_or_dict
     path = Path(path_or_dict)
-    with open(path, "r", encoding="utf-8") as f:
+    with open(path, encoding="utf-8") as f:
         data = yaml.safe_load(f) or {}
     return data
-
-
-def redact_text(text: str, *, policy: Dict[str, Any]) -> str:
-    if not text:
-        return text
-    result = text
-    for name, cfg in policy.items():
-        if not cfg.get("enabled", True):
-            continue
-        pattern = cfg.get("pattern")
-        token = cfg.get("token", f"[REDACTED:{name.upper()}]")
-        if not pattern:
-            continue
-        result = re.sub(pattern, token, result, flags=re.IGNORECASE)
-    return result

--- a/utils/secrets.py
+++ b/utils/secrets.py
@@ -1,0 +1,44 @@
+import json
+import os
+from typing import Callable, Optional, TypeVar
+
+T = TypeVar("T")
+
+
+def get(
+    name: str, cast: Callable[[str], T] | None = None, *, default: Optional[T] = None
+) -> Optional[T]:
+    """Resolve secret by precedence: env var → st.secrets → default.
+
+    Parameters
+    ----------
+    name: Secret name.
+    cast: Optional callable applied to the secret value. If it raises, the
+        default is returned instead.
+    default: Value returned when the secret is missing or cast fails.
+    """
+    v: Optional[str] | None = os.getenv(name)
+    if v is None:
+        try:  # lazy import to avoid heavy Streamlit dependency
+            import streamlit as st  # type: ignore
+
+            sv = st.secrets.get(name)
+            if sv is not None:
+                v = sv if isinstance(sv, str) else json.dumps(sv)
+        except Exception:
+            v = None
+    if v is None:
+        return default
+    if cast:
+        try:
+            return cast(v)
+        except Exception:
+            return default
+    return v  # type: ignore[return-value]
+
+
+def require(name: str) -> str:
+    v = get(name)
+    if not v:
+        raise RuntimeError(f"missing secret: {name}")
+    return v

--- a/utils/upload_scan.py
+++ b/utils/upload_scan.py
@@ -1,0 +1,30 @@
+import mimetypes
+import os
+import re
+from pathlib import Path
+
+SAFE_TYPES = {
+    "text/plain",
+    "text/markdown",
+    "application/pdf",
+    "application/json",
+    "text/csv",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+}
+
+MAX_BYTES = int(os.getenv("UPLOAD_MAX_BYTES", 20_000_000))
+
+
+def sniff_type(path: Path) -> str:
+    return mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+
+
+def allowed(path: Path) -> bool:
+    typ = sniff_type(path)
+    return typ in SAFE_TYPES and path.stat().st_size <= MAX_BYTES
+
+
+def detect_pii(text: str) -> bool:
+    from .redaction import PII_PATTERNS
+
+    return any(re.search(p, text) for p in PII_PATTERNS)


### PR DESCRIPTION
## Summary
- add typed secret resolver and regex-based redaction utilities
- scrub logs, errors, surveys and knowledge uploads
- provide repo secret scanner, upload guard and privacy export tool

## Testing
- `pre-commit run --files .gitignore app/ui/knowledge.py docs/REPO_MAP.md pages/15_Knowledge.py repo_map.yaml utils/errors.py utils/knowledge_store.py utils/redaction.py utils/survey_store.py utils/telemetry.py docs/SECURITY.md scripts/privacy_export.py scripts/scan_repo_secrets.py tests/test_privacy_export.py tests/test_redaction.py tests/test_secrets.py tests/test_upload_scan.py utils/secrets.py utils/upload_scan.py`
- `pytest tests/test_secrets.py tests/test_redaction.py tests/test_upload_scan.py tests/test_privacy_export.py`
- `python scripts/generate_repo_map.py`


------
https://chatgpt.com/codex/tasks/task_e_68b319a66780832cbebe61f10f3d505b