### PR TITLE
Centralize provider settings with pricing and validation

### DIFF
--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T15:44:40.154571Z from commit 56f842f_
+_Last generated at 2025-08-30T15:51:08.048798Z from commit 425bf0d_

--- a/orchestrators/app_builder.py
+++ b/orchestrators/app_builder.py
@@ -4,6 +4,7 @@ from typing import Dict, Tuple, List
 
 from core.model_router import pick_model, CallHints
 from core.llm_client import call_openai
+from utils.providers import get_active_model
 from app_builder.spec import AppSpec, PageSpec
 from app_builder.codegen import render_streamlit_app
 
@@ -29,13 +30,15 @@ Idea:
 """
 
 def plan_app_spec(idea: str, packages_extra: List[str] | None = None) -> AppSpec:
+    _prov, default_model = get_active_model("standard")
     sel = pick_model(CallHints(stage="plan", difficulty="normal"))
+    sel_model = sel.get("model") or default_model
     messages = [
         {"role": "system", "content": "You turn app ideas into minimal JSON specifications."},
         {"role": "user", "content": PROMPT.format(idea=idea)},
     ]
     result = call_openai(
-        model=sel["model"],
+        model=sel_model,
         messages=messages,
         **sel.get("params", {})
     )

--- a/pages/95_Providers.py
+++ b/pages/95_Providers.py
@@ -1,0 +1,64 @@
+import streamlit as st
+
+from utils import prefs
+from utils import providers
+from utils.validate_providers import quick_probe
+from utils.telemetry import log_event
+
+
+def _table_data():
+    rows = []
+    for prov, info in providers.available_providers().items():
+        secret = "✅" if providers.has_secrets(prov) else "⚠️"
+        for model in info.get("models", {}):
+            price = providers.model_price(prov, model)
+            rows.append(
+                {
+                    "Provider": prov,
+                    "Secret": secret,
+                    "Model": model,
+                    "In $/1k": price.get("input_per_1k", 0.0),
+                    "Out $/1k": price.get("output_per_1k", 0.0),
+                }
+            )
+    return rows
+
+
+def main():
+    log_event({"event": "providers_page_view"})
+    st.title("Providers & Models")
+
+    rows = _table_data()
+    st.dataframe(rows, hide_index=True)
+
+    prefs_data = prefs.load_prefs()
+    sel = providers.from_prefs_snapshot(
+        prefs_data.get("defaults", {}).get("provider_model", {})
+    ) or providers.default_model_for_mode("standard")
+    cur_provider, cur_model = sel
+
+    prov = st.selectbox("Provider", list(providers.available_providers().keys()), index=list(providers.available_providers().keys()).index(cur_provider))
+    models = list(providers.list_models(prov).keys())
+    model_idx = models.index(cur_model) if cur_model in models else 0
+    mdl = st.selectbox("Model", models, index=model_idx)
+
+    status = st.empty()
+    col1, col2 = st.columns(2)
+    with col1:
+        if st.button("Validate"):
+            result = quick_probe(prov, mdl)
+            log_event({"event": "provider_validated", "provider": prov, "model": mdl, "status": result.get("status")})
+            status.write(result.get("status"))
+    with col2:
+        if st.button("Save as default"):
+            snap = providers.to_prefs_snapshot(prov, mdl)
+            prefs_data["defaults"]["provider_model"] = snap
+            prefs.save_prefs(prefs_data)
+            log_event({"event": "provider_default_changed", "provider": prov, "model": mdl})
+            status.success("Saved")
+
+    st.caption("Orchestrators read this selection by default; runs may override via mode or advanced settings.")
+
+
+if __name__ == "__main__":
+    main()

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T15:44:40.154571Z'
-git_sha: 56f842f5a402ff64b4f80ddfe6c8fd24fbf708ea
+generated_at: '2025-08-30T15:51:08.048798Z'
+git_sha: 425bf0dd3ea78e5d38e7cee9e5e84e46a48f6f92
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -184,7 +184,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/spec_builder.py
+- path: orchestrators/plan_utils.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -198,20 +198,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/__init__.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/plan_utils.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/qa_router.py
   role: Orchestrator
   responsibilities: []
@@ -219,14 +205,21 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/schemas.py
-  role: Summarization
+- path: orchestrators/spec_builder.py
+  role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
+- path: orchestrators/__init__.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -240,7 +233,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
+- path: core/summarization/schemas.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/integrator.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -1,0 +1,7 @@
+from utils import pricing
+
+
+def test_table_has_defaults():
+    tbl = pricing.table()
+    assert tbl["openai:gpt-4o-mini"]["input_per_1k"] == 0.15
+    assert pricing.get("anthropic:claude-3-5-sonnet") == {"input_per_1k": 3.0, "output_per_1k": 15.0}

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,13 @@
+from utils import providers
+
+
+def test_has_secrets_false(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    assert providers.has_secrets("openai") is False
+
+
+def test_defaults_and_snapshot():
+    prov, model = providers.default_model_for_mode("standard")
+    assert prov == "openai" and model == "gpt-4o-mini"
+    snap = providers.to_prefs_snapshot(prov, model)
+    assert providers.from_prefs_snapshot(snap) == (prov, model)

--- a/tests/test_validate_providers.py
+++ b/tests/test_validate_providers.py
@@ -1,0 +1,36 @@
+import types
+import sys
+
+from utils import validate_providers
+
+
+def test_no_net(monkeypatch):
+    monkeypatch.setenv("NO_NET", "1")
+    out = validate_providers.quick_probe("openai", "gpt-4o-mini")
+    assert out["status"] == "skip"
+
+
+def test_probe_mock(monkeypatch):
+    monkeypatch.delenv("NO_NET", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    class FakeClient:
+        def __init__(self, *a, **k):
+            self.models = self
+
+        def retrieve(self, model):
+            return {"id": model}
+
+    openai_mod = types.SimpleNamespace(OpenAI=FakeClient)
+    monkeypatch.setitem(sys.modules, "openai", openai_mod)
+    out = validate_providers.quick_probe("openai", "m")
+    assert out["status"] == "pass"
+
+    class BoomClient(FakeClient):
+        def __init__(self, *a, **k):
+            raise RuntimeError("boom")
+
+    openai_mod2 = types.SimpleNamespace(OpenAI=BoomClient)
+    monkeypatch.setitem(sys.modules, "openai", openai_mod2)
+    out = validate_providers.quick_probe("openai", "m")
+    assert out["status"] == "fail"

--- a/utils/prefs.py
+++ b/utils/prefs.py
@@ -17,6 +17,7 @@ DEFAULT_PREFS: dict[str, Any] = {
         "budget_limit_usd": None,
         "max_tokens": None,
         "knowledge_sources": ["samples"],
+        "provider_model": {"provider": "openai", "model": "gpt-4o-mini"},
     },
     "ui": {
         "show_trace_by_default": True,
@@ -76,6 +77,17 @@ def _validate(raw: Mapping[str, Any] | None) -> dict:
             if key not in prefs[section]:
                 continue
             _coerce(section, key, value)
+
+    # Validate provider/model snapshot
+    try:
+        from . import providers as _providers
+
+        snap = raw.get("defaults", {}).get("provider_model") if isinstance(raw, Mapping) else None
+        sel = _providers.from_prefs_snapshot(snap) if snap else None
+        if sel:
+            prefs["defaults"]["provider_model"] = _providers.to_prefs_snapshot(*sel)
+    except Exception:
+        pass
 
     # Clamp trace_page_size
     tps = prefs["ui"]["trace_page_size"]

--- a/utils/pricing.py
+++ b/utils/pricing.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+import yaml
+
+PRICING_PATH = Path('pricing.yaml')
+
+DEFAULTS: Dict[str, Dict[str, float]] = {
+    "openai:gpt-4o-mini": {"input_per_1k": 0.15, "output_per_1k": 0.60},
+    "openai:gpt-4o": {"input_per_1k": 5.00, "output_per_1k": 15.00},
+    "anthropic:claude-3-5-sonnet": {"input_per_1k": 3.00, "output_per_1k": 15.00},
+}
+
+_cache: Dict[str, Dict[str, float]] | None = None
+
+def _load() -> Dict[str, Dict[str, float]]:
+    global _cache
+    if _cache is not None:
+        return _cache
+    data = dict(DEFAULTS)
+    if PRICING_PATH.exists():
+        try:
+            with PRICING_PATH.open('r', encoding='utf-8') as fh:
+                extra = yaml.safe_load(fh) or {}
+            if isinstance(extra, dict):
+                for k, v in extra.items():
+                    try:
+                        inp = float(v.get('input_per_1k'))
+                        out = float(v.get('output_per_1k'))
+                        data[k] = {"input_per_1k": inp, "output_per_1k": out}
+                    except Exception:
+                        continue
+        except Exception:
+            pass
+    _cache = data
+    return data
+
+
+def table() -> Dict[str, Dict[str, float]]:
+    """Return mapping of model_key -> pricing info."""
+    return dict(_load())
+
+
+def get(model_key: str) -> Dict[str, float]:
+    """Return pricing for ``model_key`` or empty dict if unknown."""
+    return dict(_load().get(model_key, {}))
+

--- a/utils/providers.py
+++ b/utils/providers.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Dict, Optional, Tuple
+
+from .secrets import get as secret_get
+from .pricing import get as price_get, table as price_table
+from .prefs import load_prefs
+
+REGISTRY: Dict[str, Dict] = {
+    "openai": {
+        "env_keys": ["OPENAI_API_KEY"],
+        "models": {"gpt-4o-mini": {}, "gpt-4o": {}},
+        "default_by_mode": {"standard": "gpt-4o-mini", "demo": "gpt-4o-mini"},
+    },
+    "anthropic": {
+        "env_keys": ["ANTHROPIC_API_KEY"],
+        "models": {"claude-3-5-sonnet": {}},
+        "default_by_mode": {"standard": "claude-3-5-sonnet"},
+    },
+}
+
+
+def available_providers() -> Dict[str, Dict]:
+    return REGISTRY
+
+
+def has_secrets(provider: str) -> bool:
+    info = REGISTRY.get(provider, {})
+    keys = info.get("env_keys", [])
+    for k in keys:
+        if not secret_get(k):
+            return False
+    return True
+
+
+def list_models(provider: str) -> Dict[str, Dict]:
+    return REGISTRY.get(provider, {}).get("models", {})
+
+
+def model_key(provider: str, model: str) -> str:
+    return f"{provider}:{model}"
+
+
+def model_price(provider: str, model: str) -> Dict[str, float]:
+    return price_get(model_key(provider, model))
+
+
+def default_model_for_mode(mode: str) -> Tuple[str, str]:
+    for prov, info in REGISTRY.items():
+        default = info.get("default_by_mode", {}).get(mode)
+        if default:
+            return prov, default
+    # fallback to first provider/model
+    prov = next(iter(REGISTRY.keys()))
+    mdl = next(iter(REGISTRY[prov]["models"].keys()))
+    return prov, mdl
+
+
+def from_prefs_snapshot(s: Dict) -> Optional[Tuple[str, str]]:
+    if not isinstance(s, dict):
+        return None
+    prov = s.get("provider")
+    mdl = s.get("model")
+    if prov in REGISTRY and mdl in REGISTRY[prov]["models"]:
+        return prov, mdl
+    return None
+
+
+def to_prefs_snapshot(provider: str, model: str) -> Dict:
+    if provider not in REGISTRY or model not in REGISTRY[provider]["models"]:
+        raise KeyError("unknown provider/model")
+    return {"provider": provider, "model": model}
+
+
+def get_active_model(mode: str, override: Optional[Tuple[str, str]] = None) -> Tuple[str, str]:
+    if override:
+        return override
+    prefs = load_prefs()
+    snap = prefs.get("defaults", {}).get("provider_model")
+    sel = from_prefs_snapshot(snap) if isinstance(snap, dict) else None
+    if sel:
+        return sel
+    return default_model_for_mode(mode)
+
+
+def pricing_table() -> Dict[str, Dict[str, float]]:
+    return price_table()
+

--- a/utils/validate_providers.py
+++ b/utils/validate_providers.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import os
+import time
+from typing import Dict
+
+from .secrets import get as secret_get
+
+
+def quick_probe(provider: str, model: str, timeout_sec: float = 2.0) -> Dict:
+    """Light connectivity/credentials check for provider/model."""
+    if os.getenv("NO_NET") == "1":
+        return {"status": "skip"}
+    start = time.time()
+    try:
+        if provider == "openai":
+            try:
+                from openai import OpenAI
+            except Exception:
+                return {"status": "warn"}
+            key = secret_get("OPENAI_API_KEY")
+            if not key:
+                return {"status": "fail"}
+            client = OpenAI(api_key=key, timeout=timeout_sec)
+            client.models.retrieve(model)
+            return {"status": "pass"}
+        if provider == "anthropic":
+            try:
+                import anthropic
+            except Exception:
+                return {"status": "warn"}
+            key = secret_get("ANTHROPIC_API_KEY")
+            if not key:
+                return {"status": "fail"}
+            client = anthropic.Anthropic(api_key=key, timeout=timeout_sec)
+            client.models.retrieve(model)
+            return {"status": "pass"}
+    except Exception:
+        return {"status": "fail"}
+    finally:
+        _ = time.time() - start
+    return {"status": "warn"}
+


### PR DESCRIPTION
## Summary
- add provider pricing loader and registry utilities
- expose Providers & Models page with selection and validation
- persist provider defaults in prefs and orchestrators read active model

## Testing
- `pytest tests/test_pricing.py tests/test_providers.py tests/test_validate_providers.py`


------
https://chatgpt.com/codex/tasks/task_e_68b31cd86774832c84c4333db432fa93