### PR TITLE
feat: resilient llm client with retries and failover

### DIFF
--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T16:06:14.784601Z from commit 75c4aeb_
+_Last generated at 2025-08-30T16:13:36.946156Z from commit 80ffb60_

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T16:06:14.784601Z'
-git_sha: 75c4aeb53cc87e7cc10472bb4d4b13223b2a8ffa
+generated_at: '2025-08-30T16:13:36.946156Z'
+git_sha: 80ffb6023460627f20679f297e567b9ad38bd419
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -184,14 +184,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/plan_utils.py
+- path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/__init__.py
+- path: orchestrators/plan_utils.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -205,14 +205,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/qa_router.py
+- path: orchestrators/__init__.py
   role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/spec_builder.py
+- path: orchestrators/qa_router.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -226,14 +226,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
+- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/schemas.py
+- path: core/summarization/integrator.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -1,0 +1,17 @@
+import time
+from pathlib import Path
+from utils import circuit
+
+
+def test_circuit_open_half_close(tmp_path, monkeypatch):
+    monkeypatch.setattr(circuit, 'STATE', tmp_path / 'c.json')
+    monkeypatch.setattr(circuit, 'WINDOW_SEC', 0.1)
+    key = 'p:model'
+    for _ in range(3):
+        circuit.record_failure(key)
+    assert circuit.status(key) == 'open'
+    time.sleep(0.15)
+    assert circuit.allow_half_open(key)
+    assert circuit.status(key) == 'half'
+    circuit.record_success(key)
+    assert circuit.status(key) == 'closed'

--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -1,0 +1,19 @@
+import time
+from utils import idempotency
+
+
+def test_key_consistent():
+    p = {"messages": [{"role": "user", "content": "hi"}]}
+    k1 = idempotency.key('openai', 'gpt', p)
+    k2 = idempotency.key('openai', 'gpt', p)
+    assert k1 == k2
+
+
+def test_cache_ttl(tmp_path, monkeypatch):
+    monkeypatch.setattr(idempotency, 'ROOT', tmp_path)
+    idempotency.ROOT.mkdir(parents=True, exist_ok=True)
+    k = 'abc'
+    idempotency.put(k, {'a':1})
+    assert idempotency.get(k, ttl_sec=1) == {'a':1}
+    time.sleep(1.2)
+    assert idempotency.get(k, ttl_sec=1) is None

--- a/tests/test_llm_client_failover.py
+++ b/tests/test_llm_client_failover.py
@@ -1,0 +1,57 @@
+from types import SimpleNamespace
+
+from utils import llm_client
+
+
+class RateLimitError(Exception):
+    pass
+
+
+class AuthError(Exception):
+    pass
+
+
+def _noop(*a, **k):
+    return None
+
+
+def test_retry_on_rate_limit(monkeypatch):
+    calls = {'n':0}
+    def fake_call(prov, model, payload, stream=False):
+        calls['n'] += 1
+        if calls['n'] < 3:
+            raise RateLimitError('rate limit')
+        return {'ok': True}
+    monkeypatch.setattr(llm_client, '_call_provider', fake_call)
+    monkeypatch.setattr(llm_client, 'fallback_chain', lambda mode: [('p','m')])
+    monkeypatch.setattr(llm_client, 'cache_get', lambda *a, **k: None)
+    monkeypatch.setattr(llm_client, 'cache_put', _noop)
+    monkeypatch.setattr(llm_client, 'status', lambda k: 'closed')
+    monkeypatch.setattr(llm_client, 'record_failure', _noop)
+    monkeypatch.setattr(llm_client, 'record_success', _noop)
+    monkeypatch.setattr(llm_client, 'allow_half_open', lambda k: True)
+    monkeypatch.setattr(llm_client, 'log_event', _noop)
+    resp = llm_client.chat({'messages':[]}, mode='x')
+    assert resp == {'ok': True}
+    assert calls['n'] == 3
+
+
+def test_fallback_on_auth(monkeypatch):
+    calls = []
+    def fake_call(prov, model, payload, stream=False):
+        calls.append(prov)
+        if prov == 'p1':
+            raise AuthError('bad')
+        return {'ok': True}
+    monkeypatch.setattr(llm_client, '_call_provider', fake_call)
+    monkeypatch.setattr(llm_client, 'fallback_chain', lambda mode: [('p1','m1'),('p2','m2')])
+    monkeypatch.setattr(llm_client, 'cache_get', lambda *a, **k: None)
+    monkeypatch.setattr(llm_client, 'cache_put', _noop)
+    monkeypatch.setattr(llm_client, 'status', lambda k: 'closed')
+    monkeypatch.setattr(llm_client, 'record_failure', _noop)
+    monkeypatch.setattr(llm_client, 'record_success', _noop)
+    monkeypatch.setattr(llm_client, 'allow_half_open', lambda k: True)
+    monkeypatch.setattr(llm_client, 'log_event', _noop)
+    resp = llm_client.chat({'messages':[]}, mode='x')
+    assert resp == {'ok': True}
+    assert calls == ['p1','p2']

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,20 @@
+from utils.retry import backoff, should_retry
+
+
+def test_backoff_monotonic():
+    vals = [backoff(i, jitter=0.0) for i in range(1,5)]
+    assert vals == sorted(vals)
+
+
+def test_should_retry_truth_table():
+    cases = {
+        "rate_limit": True,
+        "transient": True,
+        "timeout": True,
+        "auth": False,
+        "quota": False,
+        "validation": False,
+        "unknown": False,
+    }
+    for k, v in cases.items():
+        assert should_retry(k) is v

--- a/utils/circuit.py
+++ b/utils/circuit.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+import json, time
+from typing import Literal
+
+STATE = Path('.dr_rd/circuits.json')
+WINDOW_SEC = 60
+THRESH_FAILS = 3
+
+def _load() -> dict:
+    try:
+        return json.loads(STATE.read_text('utf-8'))
+    except Exception:
+        return {}
+
+def _save(d: dict) -> None:
+    STATE.parent.mkdir(parents=True, exist_ok=True)
+    STATE.write_text(json.dumps(d, ensure_ascii=False), encoding='utf-8')
+
+def status(key: str) -> Literal['closed','open','half']:
+    d = _load().get(key) or {}
+    until = d.get('until', 0)
+    if time.time() < until:
+        return 'open'
+    if d.get('half', False):
+        return 'half'
+    return 'closed'
+
+def record_failure(key: str) -> str:
+    d = _load()
+    e = d.get(key, {'fails':0})
+    e['fails'] = e.get('fails',0) + 1
+    if e['fails'] >= THRESH_FAILS:
+        e['until'] = time.time() + WINDOW_SEC
+        e['half'] = False
+        state = 'open'
+    else:
+        state = 'closed'
+    d[key] = e
+    _save(d)
+    return state
+
+def allow_half_open(key: str) -> bool:
+    d = _load()
+    e = d.get(key, {})
+    if e.get('until',0) <= time.time():
+        e['half'] = True
+        d[key] = e
+        _save(d)
+        return True
+    return False
+
+def record_success(key: str) -> None:
+    d = _load()
+    d[key] = {'fails':0}
+    _save(d)

--- a/utils/errors.py
+++ b/utils/errors.py
@@ -41,6 +41,23 @@ def classify(exc: Exception) -> str:
     return "unknown"
 
 
+def classify_provider_error(exc: Exception) -> str:
+    """Map provider SDK exceptions to canonical kinds."""
+    name = exc.__class__.__name__.lower()
+    msg = str(exc).lower()
+    if "rate" in name or "rate" in msg and "limit" in msg:
+        return "rate_limit"
+    if "timeout" in name or "timed" in msg:
+        return "timeout"
+    if "auth" in name or "unauthorized" in msg or "api key" in msg:
+        return "auth"
+    if "quota" in name or "billing" in msg:
+        return "quota"
+    if isinstance(exc, (ValueError, KeyError, TypeError)) or "validation" in name:
+        return "validation"
+    return "transient"
+
+
 MAX_CHARS = 2000
 
 

--- a/utils/idempotency.py
+++ b/utils/idempotency.py
@@ -1,0 +1,32 @@
+import hashlib, json, time
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+ROOT = Path('.dr_rd/cache/llm')
+ROOT.mkdir(parents=True, exist_ok=True)
+
+def canonical_payload(prompt: Mapping[str, Any]) -> bytes:
+    return json.dumps(prompt, separators=(',',':'), sort_keys=True, ensure_ascii=False).encode('utf-8')
+
+def key(provider: str, model: str, payload: Mapping[str, Any]) -> str:
+    h = hashlib.sha256()
+    h.update(provider.encode())
+    h.update(b':')
+    h.update(model.encode())
+    h.update(canonical_payload(payload))
+    return h.hexdigest()
+
+def get(k: str, ttl_sec: Optional[int]=None) -> Optional[dict]:
+    p = ROOT / f"{k}.json"
+    if not p.exists():
+        return None
+    if ttl_sec is not None and (time.time() - p.stat().st_mtime) > ttl_sec:
+        return None
+    try:
+        return json.loads(p.read_text('utf-8'))
+    except Exception:
+        return None
+
+def put(k: str, resp: Mapping[str, Any]) -> None:
+    p = ROOT / f"{k}.json"
+    p.write_text(json.dumps(resp, ensure_ascii=False), encoding='utf-8')

--- a/utils/llm_client.py
+++ b/utils/llm_client.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, Iterator, Mapping, Optional
+
+from .providers import fallback_chain, model_key
+from .retry import backoff, classify_error, should_retry
+from .circuit import status, record_failure, record_success, allow_half_open
+from .idempotency import key as idem_key, get as cache_get, put as cache_put
+from .telemetry import log_event
+
+
+def _call_provider(prov: str, model: str, payload: Mapping[str, Any], *, stream: bool) -> Any:
+    """Minimal provider dispatch. Supports OpenAI chat API."""
+    if prov == 'openai':
+        try:
+            from openai import OpenAI
+        except Exception as exc:  # pragma: no cover - environment guard
+            raise RuntimeError('openai sdk missing') from exc
+        client = OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
+        messages = payload.get('messages') or []
+        if stream:
+            return client.chat.completions.create(model=model, messages=messages, stream=True)
+        return client.chat.completions.create(model=model, messages=messages)
+    raise NotImplementedError(f'provider {prov} not supported')
+
+
+def chat(payload: Mapping[str, Any], *, mode: str, stream: bool = False,
+         run_id: str | None = None, step_id: str | None = None,
+         cache_ttl_sec: Optional[int] = 300) -> Any | Iterator[Any]:
+    chain = fallback_chain(mode)
+    for prov, model in chain:
+        ck = model_key(prov, model)
+        k = idem_key(prov, model, payload)
+        if not stream:
+            cached = cache_get(k, ttl_sec=cache_ttl_sec)
+            if cached is not None:
+                log_event({"event": "llm_cache_hit", "provider": prov, "model": model,
+                           "run_id": run_id, "step_id": step_id})
+                return cached
+        st = status(ck)
+        if st == 'open' and not allow_half_open(ck):
+            log_event({"event": "circuit_skipped", "provider": prov, "model": model})
+            continue
+        attempt = 0
+        while True:
+            attempt += 1
+            try:
+                log_event({"event": "llm_call_started", "provider": prov, "model": model,
+                           "attempt": attempt, "run_id": run_id, "step_id": step_id})
+                resp = _call_provider(prov, model, payload, stream=stream)
+                record_success(ck)
+                log_event({"event": "llm_call_succeeded", "provider": prov, "model": model,
+                           "attempt": attempt, "run_id": run_id, "step_id": step_id})
+                if stream:
+                    return resp
+                cache_put(k, resp)
+                return resp
+            except Exception as exc:
+                kind = classify_error(exc)
+                log_event({"event": "llm_call_failed", "provider": prov, "model": model,
+                           "attempt": attempt, "kind": kind,
+                           "run_id": run_id, "step_id": step_id})
+                if not should_retry(kind) or attempt >= 5:
+                    if kind in {"rate_limit", "transient", "timeout"}:
+                        record_failure(ck)
+                    break
+                time.sleep(backoff(attempt))
+        log_event({"event": "llm_fallback", "provider": prov, "model": model})
+    raise RuntimeError("All providers/models failed")

--- a/utils/retry.py
+++ b/utils/retry.py
@@ -1,0 +1,37 @@
+import random
+import time
+from typing import Callable, Tuple
+
+DEFAULTS = dict(max_attempts=5, base=0.25, cap=8.0, jitter=0.25)
+
+def backoff(attempt: int, *, base: float = 0.25, cap: float = 8.0, jitter: float = 0.25) -> float:
+    """Return delay seconds for the given *attempt* using exponential backoff with jitter."""
+    delay = min(cap, base * (2 ** max(0, attempt - 1)))
+    return max(0.0, delay * (1.0 - jitter + random.random() * jitter * 2))
+
+
+def classify_error(exc: Exception) -> str:
+    """Return canonical error kind for provider exceptions."""
+    try:
+        from .errors import classify_provider_error
+    except Exception:  # pragma: no cover - defensive
+        classify_provider_error = None  # type: ignore
+    if classify_provider_error:
+        return classify_provider_error(exc)
+    name = exc.__class__.__name__.lower()
+    if "rate" in name and "limit" in name:
+        return "rate_limit"
+    if "timeout" in name:
+        return "timeout"
+    if "auth" in name or "key" in name:
+        return "auth"
+    if "quota" in name:
+        return "quota"
+    if isinstance(exc, (ValueError, TypeError)) or "validation" in name:
+        return "validation"
+    return "transient"
+
+
+def should_retry(kind: str) -> bool:
+    """Return True if errors of *kind* are retryable."""
+    return kind in {"rate_limit", "transient", "timeout"}

--- a/utils/telemetry.py
+++ b/utils/telemetry.py
@@ -118,6 +118,55 @@ def read_events(limit: int | None = None, days: int = 7) -> list[dict]:
 # Convenience event wrappers remain largely unchanged below.
 
 
+def llm_call_started(provider: str, model: str, attempt: int, run_id: str | None = None, step_id: str | None = None) -> None:
+    ev = {"event": "llm_call_started", "provider": provider, "model": model, "attempt": attempt}
+    if run_id:
+        ev["run_id"] = run_id
+    if step_id:
+        ev["step_id"] = step_id
+    log_event(ev)
+
+
+def llm_call_succeeded(provider: str, model: str, attempt: int, run_id: str | None = None, step_id: str | None = None) -> None:
+    ev = {"event": "llm_call_succeeded", "provider": provider, "model": model, "attempt": attempt}
+    if run_id:
+        ev["run_id"] = run_id
+    if step_id:
+        ev["step_id"] = step_id
+    log_event(ev)
+
+
+def llm_call_failed(provider: str, model: str, attempt: int, kind: str, run_id: str | None = None, step_id: str | None = None) -> None:
+    ev = {"event": "llm_call_failed", "provider": provider, "model": model, "attempt": attempt, "kind": kind}
+    if run_id:
+        ev["run_id"] = run_id
+    if step_id:
+        ev["step_id"] = step_id
+    log_event(ev)
+
+
+def llm_fallback(provider: str, model: str, run_id: str | None = None, step_id: str | None = None) -> None:
+    ev = {"event": "llm_fallback", "provider": provider, "model": model}
+    if run_id:
+        ev["run_id"] = run_id
+    if step_id:
+        ev["step_id"] = step_id
+    log_event(ev)
+
+
+def llm_cache_hit(provider: str, model: str, run_id: str | None = None, step_id: str | None = None) -> None:
+    ev = {"event": "llm_cache_hit", "provider": provider, "model": model}
+    if run_id:
+        ev["run_id"] = run_id
+    if step_id:
+        ev["step_id"] = step_id
+    log_event(ev)
+
+
+def circuit_skipped(provider: str, model: str) -> None:
+    log_event({"event": "circuit_skipped", "provider": provider, "model": model})
+
+
 def flag_checked(name: str, value: bool) -> None:
     if os.getenv("TELEMETRY_DEBUG") == "1":
         log_event({"event": "flag_checked", "flag": name, "value": value})


### PR DESCRIPTION
## Summary
- add generic retry utilities, per-model circuit breakers, on-disk idempotent caching and high-level LLM client with provider fallback
- extend providers registry, error classification, telemetry events and orchestrator integration
- cover resilience features with new unit tests

## Testing
- `pytest tests/test_retry.py tests/test_circuit.py tests/test_idempotency.py tests/test_llm_client_failover.py`
- `python scripts/generate_repo_map.py`


------
https://chatgpt.com/codex/tasks/task_e_68b322798ff8832c8297167c5a4f8302