### PR TITLE
feat: add persistent SessionStore for cross-page state

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -11,6 +11,7 @@ import fitz
 import streamlit as st
 from markdown_pdf import MarkdownPdf, Section
 from utils.i18n import tr as t, set_locale, missing_keys
+from utils.session_store import init_stores, get_session_id  # noqa: F401
 
 st.set_page_config(
     page_title=t("app_title"),
@@ -44,6 +45,8 @@ from utils import session_guard
 
 inject_accessibility_baseline()
 live_region_container()
+
+run_store, view_store = init_stores()
 
 st.session_state.setdefault("active_run", None)
 st.session_state.setdefault("submit_token", None)

--- a/app/ui/command_palette.py
+++ b/app/ui/command_palette.py
@@ -2,9 +2,17 @@ import streamlit as st
 
 from utils.global_search import search, resolve_action
 from utils.telemetry import log_event
+from utils.session_store import SessionStore
 
 
 def open_palette():
+    view_store = SessionStore(
+        "view",
+        defaults={"trace_view": "summary", "trace_query": "", "palette_open": False},
+        persist_keys={"trace_view", "trace_query"},
+    )
+    view_store.set("palette_open", True)
+
     @st.dialog("Command palette")
     def _dlg():
         q = st.text_input("Type a command, page, run, or source", key="cmd_q")
@@ -20,3 +28,4 @@ def open_palette():
                     st.session_state["_cmd_action"] = act
                     st.rerun()
     _dlg()
+    view_store.set("palette_open", False)

--- a/app/ui/sidebar.py
+++ b/app/ui/sidebar.py
@@ -6,7 +6,8 @@ from typing import Any, Dict
 import streamlit as st
 
 from app.ui_presets import UI_PRESETS
-from utils.run_config import RunConfig, defaults, from_session, to_session
+from utils.run_config import RunConfig, defaults
+from utils.session_store import init_stores
 from utils.telemetry import log_event
 from utils import knowledge_store
 
@@ -14,12 +15,13 @@ from utils import knowledge_store
 def render_sidebar() -> RunConfig:
     """Render the sidebar and return the current :class:`RunConfig`."""
 
+    run_store, _ = init_stores()
+
     if not st.session_state.get("_sidebar_tip_shown"):
         st.sidebar.caption("Settings apply to the next run.")
         st.session_state["_sidebar_tip_shown"] = True
 
-    def _track_change(field: str) -> None:
-        value = st.session_state[field]
+    def _track_change(field: str, value: Any) -> None:
         prev_key = f"_{field}_prev"
         old = st.session_state.get(prev_key)
         if old is None:
@@ -39,7 +41,7 @@ def render_sidebar() -> RunConfig:
 
     def _reset() -> None:
         cfg = defaults()
-        to_session(cfg)
+        run_store.clear()
         for f in dataclasses.fields(RunConfig):
             st.session_state[f"_{f.name}_prev"] = getattr(cfg, f.name)
         st.session_state["temperature"] = 0.0
@@ -49,15 +51,19 @@ def render_sidebar() -> RunConfig:
 
     with st.sidebar:
         st.subheader("Run settings")
-        st.text_area(
+        idea = st.text_area(
             "Project idea",
+            value=run_store.get("idea", ""),
             key="idea",
             help="What should the agents work on?",
         )
-        _track_change("idea")
+        run_store.set("idea", idea)
+        _track_change("idea", idea)
         modes = list(UI_PRESETS.keys())
-        st.selectbox("Mode", modes, key="mode", help="Choose run mode")
-        _track_change("mode")
+        current_mode = run_store.get("mode", modes[0])
+        mode = st.selectbox("Mode", modes, index=modes.index(current_mode) if current_mode in modes else 0, key="mode", help="Choose run mode")
+        run_store.set("mode", mode)
+        _track_change("mode", mode)
 
         with st.expander("Knowledge"):
             knowledge_store.init_store()
@@ -65,42 +71,52 @@ def render_sidebar() -> RunConfig:
             choices = builtins + knowledge_store.as_choice_list()
             options = [c[1] for c in choices]
             labels = {c[1]: c[0] for c in choices}
-            st.multiselect(
+            sources = st.multiselect(
                 "Sources",
                 options,
+                default=run_store.get("knowledge_sources", []),
                 key="knowledge_sources",
                 format_func=lambda x: labels.get(x, x),
                 help="Select knowledge sources",
             )
-            _track_change("knowledge_sources")
+            run_store.set("knowledge_sources", sources)
+            _track_change("knowledge_sources", sources)
             with st.expander("Manage sources"):
                 st.caption("Manage advanced sources here.")
 
         with st.expander("Diagnostics"):
-            st.checkbox(
+            show_agent_trace = st.checkbox(
                 "Show agent trace",
+                value=run_store.get("show_agent_trace", False),
                 key="show_agent_trace",
                 help="Display detailed agent steps",
             )
-            _track_change("show_agent_trace")
-            st.checkbox(
+            run_store.set("show_agent_trace", show_agent_trace)
+            _track_change("show_agent_trace", show_agent_trace)
+            verbose_planner = st.checkbox(
                 "Verbose planner output",
+                value=run_store.get("verbose_planner", False),
                 key="verbose_planner",
                 help="Print planner debug info",
             )
-            _track_change("verbose_planner")
+            run_store.set("verbose_planner", verbose_planner)
+            _track_change("verbose_planner", verbose_planner)
 
         with st.expander("Exports"):
-            st.checkbox(
+            auto_export_trace = st.checkbox(
                 "Auto export trace on completion",
+                value=run_store.get("auto_export_trace", False),
                 key="auto_export_trace",
             )
-            _track_change("auto_export_trace")
-            st.checkbox(
+            run_store.set("auto_export_trace", auto_export_trace)
+            _track_change("auto_export_trace", auto_export_trace)
+            auto_export_report = st.checkbox(
                 "Auto export report on completion",
+                value=run_store.get("auto_export_report", False),
                 key="auto_export_report",
             )
-            _track_change("auto_export_report")
+            run_store.set("auto_export_report", auto_export_report)
+            _track_change("auto_export_report", auto_export_report)
 
         with st.expander("Advanced options"):
             st.session_state.setdefault("temperature", 0.0)
@@ -112,7 +128,7 @@ def render_sidebar() -> RunConfig:
                 key="temperature",
                 help="Sampling temperature",
             )
-            _track_change("temperature")
+            _track_change("temperature", st.session_state["temperature"])
             st.session_state.setdefault("retries", 0)
             st.number_input(
                 "Retries",
@@ -122,7 +138,7 @@ def render_sidebar() -> RunConfig:
                 key="retries",
                 help="Max retries for calls",
             )
-            _track_change("retries")
+            _track_change("retries", st.session_state["retries"])
             st.session_state.setdefault("timeout", 0)
             st.number_input(
                 "Timeout (s)",
@@ -132,16 +148,15 @@ def render_sidebar() -> RunConfig:
                 key="timeout",
                 help="Overall timeout in seconds",
             )
-            _track_change("timeout")
+            _track_change("timeout", st.session_state["timeout"])
 
         st.button("Reset to defaults", on_click=_reset, help="Restore default settings")
 
-    cfg = from_session()
+    data = run_store.as_dict()
     adv: Dict[str, Any] = {
         "temperature": st.session_state.get("temperature", 0.0),
         "retries": st.session_state.get("retries", 0),
         "timeout": st.session_state.get("timeout", 0),
     }
-    data = dataclasses.asdict(cfg)
     data["advanced"] = adv
     return RunConfig(**data)

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T16:25:35.819624Z from commit d4e9da2_
+_Last generated at 2025-08-30T16:37:52.793216Z from commit d2d4f75_

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T16:25:35.819624Z'
-git_sha: d4e9da2b44dc6acac15aca895b19ed1c1e99420e
+generated_at: '2025-08-30T16:37:52.793216Z'
+git_sha: d2d4f75a3a49ebe57a092c25f9444aa962369553
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -191,20 +191,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/qa_router.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/app_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/__init__.py
   role: Orchestrator
   responsibilities: []
@@ -219,7 +205,21 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
+- path: orchestrators/qa_router.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/app_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -240,7 +240,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/__init__.py
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/scripts/session_cleanup.py
+++ b/scripts/session_cleanup.py
@@ -1,0 +1,5 @@
+from utils.session_store import cleanup_expired
+
+if __name__ == "__main__":
+    removed = cleanup_expired()
+    print(f"removed {removed} session files")

--- a/tests/test_session_cleanup.py
+++ b/tests/test_session_cleanup.py
@@ -1,0 +1,17 @@
+import json
+import time
+
+from utils import session_store
+
+
+def test_cleanup_expired(tmp_path, monkeypatch):
+    monkeypatch.setattr(session_store, "SESS_DIR", tmp_path / "sess")
+    session_store.SESS_DIR.mkdir(parents=True, exist_ok=True)
+    old_json = session_store.SESS_DIR / "old_run.json"
+    old_json.write_text(json.dumps({"saved_at": time.time() - 100}))
+    old_touch = session_store.SESS_DIR / "old.touch"
+    old_touch.write_text(str(time.time() - 100))
+    removed = session_store.cleanup_expired(ttl_sec=10)
+    assert removed == 2
+    assert not old_json.exists()
+    assert not old_touch.exists()

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -1,0 +1,47 @@
+import json
+import time
+
+import streamlit as st
+
+from utils import session_store
+
+
+def test_snapshot_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setattr(session_store, "SESS_DIR", tmp_path / "sess")
+    session_store.SESS_DIR.mkdir(parents=True, exist_ok=True)
+    st.session_state.clear()
+    store = session_store.SessionStore("run", defaults={"foo": 0}, persist_keys={"foo"})
+    store.set("foo", 1)
+    snap = session_store.SESS_DIR / f"{store.sid}_run.json"
+    assert snap.exists()
+    sid = store.sid
+    st.session_state.clear()
+    st.session_state["session_id"] = sid
+    store2 = session_store.SessionStore("run", defaults={"foo": 0}, persist_keys={"foo"})
+    assert store2.get("foo") == 1
+
+
+def test_seed_missing_only(tmp_path, monkeypatch):
+    monkeypatch.setattr(session_store, "SESS_DIR", tmp_path / "sess2")
+    session_store.SESS_DIR.mkdir(parents=True, exist_ok=True)
+    st.session_state.clear()
+    store = session_store.SessionStore("run", defaults={"a": None, "b": 0})
+    store.seed({"a": 1, "b": 2})
+    assert store.get("a") == 1
+    assert store.get("b") == 0
+
+
+def test_ttl_logic(tmp_path, monkeypatch):
+    monkeypatch.setattr(session_store, "SESS_DIR", tmp_path / "sess3")
+    session_store.SESS_DIR.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(session_store, "TTL_SEC", 1)
+    st.session_state.clear()
+    store = session_store.SessionStore("run", defaults={"foo": 0}, persist_keys={"foo"})
+    store.set("foo", 1)
+    snap = session_store.SESS_DIR / f"{store.sid}_run.json"
+    obj = json.loads(snap.read_text())
+    obj["saved_at"] = time.time() - 2
+    snap.write_text(json.dumps(obj))
+    st.session_state.clear()
+    store2 = session_store.SessionStore("run", defaults={"foo": 0}, persist_keys={"foo"})
+    assert store2.get("foo") == 0

--- a/utils/session_store.py
+++ b/utils/session_store.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from pathlib import Path
+import json, os, time, uuid
+from typing import Any, Dict, Iterable, Mapping, Optional
+
+SESS_DIR = Path(".dr_rd/session")
+SESS_DIR.mkdir(parents=True, exist_ok=True)
+TTL_SEC = int(os.getenv("SESSION_TTL_SEC", 7 * 24 * 3600))  # 7 days
+
+@dataclass
+class SessionStore:
+    namespace: str
+    defaults: Mapping[str, Any] = field(default_factory=dict)
+    persist_keys: Iterable[str] = field(default_factory=tuple)
+
+    def __post_init__(self):
+        import streamlit as st
+        # One stable id per browser tab
+        if "session_id" not in st.session_state:
+            st.session_state["session_id"] = uuid.uuid4().hex
+        self.sid = st.session_state["session_id"]
+        # Namespaced bucket
+        key = self._nskey()
+        if key not in st.session_state:
+            st.session_state[key] = dict(self.defaults)
+            # merge from saved snapshot (if present)
+            snap = self._load_snapshot()
+            if snap:
+                st.session_state[key].update({k: v for k, v in snap.items() if k in self.defaults})
+        self._touch()
+
+    # ----- public API -----
+    def get(self, k: str, default: Any = None) -> Any:
+        import streamlit as st
+        return st.session_state[self._nskey()].get(k, self.defaults.get(k, default))
+
+    def set(self, k: str, v: Any) -> None:
+        import streamlit as st
+        st.session_state[self._nskey()][k] = v
+        if k in set(self.persist_keys):
+            self._save_snapshot()
+
+    def as_dict(self) -> Dict[str, Any]:
+        import streamlit as st
+        return dict(st.session_state[self._nskey()])
+
+    def seed(self, init: Mapping[str, Any]) -> None:
+        """Idempotent merge of initial values (used once on app load)."""
+        import streamlit as st
+        bucket = st.session_state[self._nskey()]
+        for k, v in init.items():
+            if k in self.defaults and bucket.get(k) is None:
+                bucket[k] = v
+        self._save_snapshot()
+
+    def clear(self, keys: Optional[Iterable[str]] = None) -> None:
+        import streamlit as st
+        bucket = st.session_state[self._nskey()]
+        if keys is None:
+            keys = list(bucket.keys())
+        for k in keys:
+            bucket.pop(k, None)
+        for k, v in self.defaults.items():
+            bucket.setdefault(k, v)
+        self._save_snapshot()
+
+    # ----- persistence -----
+    def _snap_path(self) -> Path:
+        return SESS_DIR / f"{self.sid}_{self.namespace}.json"
+
+    def _save_snapshot(self) -> None:
+        p = self._snap_path()
+        data = {k: v for k, v in self.as_dict().items() if k in set(self.persist_keys)}
+        p.write_text(json.dumps({"saved_at": time.time(), "data": data}, ensure_ascii=False), encoding="utf-8")
+
+    def _load_snapshot(self) -> Optional[Dict[str, Any]]:
+        p = self._snap_path()
+        if not p.exists():
+            return None
+        try:
+            obj = json.loads(p.read_text(encoding="utf-8"))
+            if time.time() - float(obj.get("saved_at", 0)) > TTL_SEC:
+                return None
+            return obj.get("data") or {}
+        except Exception:
+            return None
+
+    def _touch(self) -> None:
+        # update a heartbeat file for cleanup bookkeeping
+        (SESS_DIR / f"{self.sid}.touch").write_text(str(time.time()), encoding="utf-8")
+
+    def _nskey(self) -> str:
+        return f"_ns_{self.namespace}"
+
+def get_session_id() -> str:
+    import streamlit as st
+    return str(st.session_state.get("session_id", ""))
+
+def cleanup_expired(ttl_sec: int = TTL_SEC) -> int:
+    """Delete old snapshots and heartbeats. Return files removed."""
+    removed = 0
+    now = time.time()
+    for p in SESS_DIR.glob("*.json"):
+        try:
+            obj = json.loads(p.read_text(encoding="utf-8"))
+            if now - float(obj.get("saved_at", 0)) > ttl_sec:
+                p.unlink(missing_ok=True); removed += 1
+        except Exception:
+            p.unlink(missing_ok=True); removed += 1
+    for t in SESS_DIR.glob("*.touch"):
+        try:
+            ts = float(t.read_text(encoding="utf-8"))
+            if now - ts > ttl_sec:
+                t.unlink(missing_ok=True); removed += 1
+        except Exception:
+            t.unlink(missing_ok=True); removed += 1
+    return removed
+
+
+def init_stores() -> tuple[SessionStore, SessionStore]:
+    import streamlit as st
+    from .query_params import decode_config, view_state_from_params
+    from .run_config import defaults as run_defaults
+
+    run_store = SessionStore(
+        "run",
+        defaults=run_defaults().__dict__ if hasattr(run_defaults(), "__dict__") else {},
+        persist_keys={"idea", "mode", "knowledge_sources", "budget_limit_usd", "max_tokens"},
+    )
+    if not st.session_state.get("_qp_seeded", False):
+        decoded = decode_config(dict(st.query_params))
+        run_store.seed(decoded)
+        st.session_state["_qp_seeded"] = True
+
+    view_store = SessionStore(
+        "view",
+        defaults={"trace_view": "summary", "trace_query": "", "palette_open": False},
+        persist_keys={"trace_view", "trace_query"},
+    )
+    if not st.session_state.get("_view_seeded", False):
+        vs = view_state_from_params(dict(st.query_params))
+        view_store.set("trace_view", vs["trace_view"])
+        view_store.set("trace_query", vs["trace_query"])
+        st.session_state["_view_seeded"] = True
+
+    return run_store, view_store

--- a/utils/telemetry.py
+++ b/utils/telemetry.py
@@ -49,6 +49,12 @@ def _rollover(p: Path) -> Path:
 
 def log_event(ev: dict) -> None:
     """Validate, version, and append a telemetry event."""
+    try:
+        from utils.session_store import get_session_id
+
+        ev.setdefault("session_id", get_session_id() or None)
+    except Exception:
+        pass
     ev = validate(ev)
     ev.setdefault("schema_version", CURRENT_SCHEMA_VERSION)
     ev.setdefault("ts", time.time())


### PR DESCRIPTION
## Summary
- add typed `SessionStore` with disk persistence and cleanup helpers
- wire run and view state through SessionStore across app components
- include session id in telemetry events

## Testing
- `pytest tests/test_session_store.py tests/test_session_cleanup.py -q`
- `python scripts/generate_repo_map.py`

------
https://chatgpt.com/codex/tasks/task_e_68b327671ed0832c8f3a44f46fb1c202