### PR TITLE
Add Playwright E2E tests for critical UI flows

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,25 @@
+name: e2e
+on:
+  pull_request: {}
+  workflow_dispatch: {}
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install deps
+        run: |
+          python -m pip install -U pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install -r requirements-dev.txt
+          python -m playwright install --with-deps chromium
+      - name: Start app and run E2E
+        env:
+          APP_EXTERNAL: "0"
+          APP_BASE_URL: "http://localhost:8501"
+          APP_START_CMD: "streamlit run app.py --server.port 8501 --server.headless true"
+        run: |
+          pytest -q e2e

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,3 +9,20 @@
 
 ## Utilities
 - `scripts/cleanup_runs.py` — remove old run artifacts (`--keep N` or `--max-bytes M`)
+
+## E2E tests
+Run the Playwright end-to-end tests either against a locally started app or a deployed URL.
+
+Local app:
+
+```
+APP_BASE_URL=http://localhost:8501 APP_EXTERNAL=0 \
+pytest -q e2e
+```
+
+Against deployed app:
+
+```
+APP_EXTERNAL=1 APP_BASE_URL=https://dr-rnd.streamlit.app \
+pytest -q e2e
+```

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T16:37:52.793216Z from commit d2d4f75_
+_Last generated at 2025-08-30T16:48:14.772016Z from commit 9d48052_

--- a/e2e/config.py
+++ b/e2e/config.py
@@ -1,0 +1,8 @@
+import os
+
+APP_BASE_URL = os.getenv("APP_BASE_URL", "http://localhost:8501")
+APP_START_CMD = os.getenv(
+    "APP_START_CMD",
+    "streamlit run app.py --server.port 8501 --server.headless true",
+)
+APP_START_TIMEOUT_SEC = int(os.getenv("APP_START_TIMEOUT_SEC", "90"))

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -1,0 +1,44 @@
+import os
+import subprocess
+import time
+
+import pytest
+import requests
+
+from e2e.config import APP_BASE_URL, APP_START_CMD, APP_START_TIMEOUT_SEC
+
+
+def _wait_ready(url: str, timeout: int) -> None:
+    t0 = time.time()
+    while time.time() - t0 < timeout:
+        try:
+            r = requests.get(url, timeout=2)
+            if r.status_code in (200, 403):
+                return
+        except Exception:
+            pass
+        time.sleep(1)
+    raise RuntimeError("app not ready")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def app_server():
+    ext = os.getenv("APP_EXTERNAL", "0") == "1"
+    if ext:
+        yield
+        return
+    proc = subprocess.Popen(APP_START_CMD, shell=True)
+    try:
+        _wait_ready(APP_BASE_URL, APP_START_TIMEOUT_SEC)
+        yield
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except Exception:
+            proc.kill()
+
+
+@pytest.fixture(scope="session")
+def base_url():
+    return APP_BASE_URL

--- a/e2e/test_command_palette.py
+++ b/e2e/test_command_palette.py
@@ -1,0 +1,9 @@
+def test_command_palette_open_and_navigate(page, base_url):
+    page.goto(f"{base_url}/?cmd=1")
+    page.get_by_text("Command palette").wait_for()
+    # Search for Trace
+    page.get_by_role("textbox").fill("Trace")
+    # Select first result
+    page.get_by_role("button", name="Select").first.click()
+    # Should navigate or set params to Trace
+    page.wait_for_url("**view=trace**")

--- a/e2e/test_demo_run.py
+++ b/e2e/test_demo_run.py
@@ -1,0 +1,10 @@
+def test_demo_run_end_to_end(page, base_url):
+    page.goto(f"{base_url}/")
+    page.get_by_role("button", name="Run demo").click()
+    # Expect quick completion and a Trace entrypoint
+    page.get_by_text("Trace").wait_for(timeout=60_000)
+    # Navigate to Trace page
+    page.goto(f"{base_url}/?view=trace")
+    page.get_by_text("Trace Viewer").wait_for()
+    # Basic assertions: at least one step rendered
+    assert page.locator("text=Step 1").first.is_visible()

--- a/e2e/test_navigation_exports.py
+++ b/e2e/test_navigation_exports.py
@@ -1,0 +1,6 @@
+def test_reports_exports_visible(page, base_url):
+    page.goto(f"{base_url}/?view=reports")
+    page.get_by_text("Reports & Exports").wait_for()
+    page.get_by_role("button", name="Download report (.md)").wait_for()
+    page.get_by_role("button", name="Download report (.html)").wait_for()
+    page.get_by_role("button", name="Download artifact bundle (.zip)").wait_for()

--- a/e2e/test_settings_language.py
+++ b/e2e/test_settings_language.py
@@ -1,0 +1,6 @@
+def test_set_language_english(page, base_url):
+    page.goto(f"{base_url}/?view=settings")
+    page.get_by_text("Settings").wait_for()
+    # Force English to stabilize text selectors
+    page.get_by_label("Language").select_option("en")
+    page.get_by_role("button", name="Apply language").click()

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T16:37:52.793216Z'
-git_sha: d2d4f75a3a49ebe57a092c25f9444aa962369553
+generated_at: '2025-08-30T16:48:14.772016Z'
+git_sha: 9d48052b80f710db8ec168090f60823e3c0648e6
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -191,14 +191,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/__init__.py
+- path: orchestrators/app_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/spec_builder.py
+- path: orchestrators/__init__.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -212,15 +212,8 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
+- path: orchestrators/spec_builder.py
   role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: core/summarization/__init__.py
-  role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
@@ -233,7 +226,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/schemas.py
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -241,6 +234,13 @@ modules:
   invoked_by: []
   invokes: []
 - path: core/summarization/role_summarizer.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ ruff==0.6.9
 mypy
 pytest
 pytest-cov
+pytest-playwright
 requests
 tomli; python_version<'3.11'
 pre-commit

--- a/scripts/start_app_ci.py
+++ b/scripts/start_app_ci.py
@@ -1,0 +1,22 @@
+import os
+import subprocess
+import sys
+import time
+
+import requests
+
+from e2e.config import APP_BASE_URL, APP_START_CMD, APP_START_TIMEOUT_SEC
+
+
+if __name__ == "__main__":
+    proc = subprocess.Popen(APP_START_CMD, shell=True)
+    t0 = time.time()
+    while time.time() - t0 < APP_START_TIMEOUT_SEC:
+        try:
+            if requests.get(APP_BASE_URL, timeout=2).status_code in (200, 403):
+                print("app ready")
+                sys.exit(0)
+        except Exception:
+            time.sleep(1)
+    proc.terminate()
+    sys.exit(1)


### PR DESCRIPTION
## Summary
- add Playwright-based E2E tests for demo run, navigation, command palette, and settings
- wire up CI workflow and startup helper
- document E2E usage and include pytest-playwright in dev deps

## Testing
- `python scripts/generate_repo_map.py`
- `python -m pip install -r requirements-dev.txt`
- `python -m playwright install --with-deps chromium` *(fails: Domain forbidden)*
- `pytest -q e2e` *(fails: UI elements not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b32a84aa38832c9cfd73b5110e9dc2