### PR TITLE
Add evaluation harness and scoring utilities

### DIFF
--- a/docs/EVAL.md
+++ b/docs/EVAL.md
@@ -1,0 +1,49 @@
+# Evaluation Harness
+
+This harness runs **golden tasks** end-to-end through the same orchestrator used by the UI, scores the outputs, and builds a scoreboard.
+
+## Datasets
+- Place datasets under `eval/datasets/`.
+- JSONL format is preferred; CSV files are auto-mapped.
+- Each line represents one task with fields:
+```json
+{
+  "id": "t001",
+  "idea": "Summarize the DR RD pipeline in 5 bullets.",
+  "mode": "standard",
+  "limits": {"budget_usd": 0.10, "max_tokens": 2000},
+  "expected_keywords": ["planner", "executor"],
+  "forbidden_keywords": ["password"],
+  "min_words": 40,
+  "max_words": 200,
+  "tags": ["smoke"],
+  "seed": 42
+}
+```
+Unknown top‑level keys are ignored.
+
+## Running
+### Streamlit page
+Use **Evaluation** page to pick a dataset, optionally enable *Use LLM rubric*, and run. Results are saved under `.dr_rd/eval/{timestamp}`.
+
+### CLI
+```
+python scripts/eval_run.py --dataset eval/datasets/default.jsonl
+```
+Additional flags: `--use-llm`, `--concurrency N`, `--out DIR`.
+The command exits 0 only if all items succeed and pass‑rate ≥ 0.7.
+
+## Scores
+- **heuristic** – keyword coverage with penalties for forbidden terms, out-of-bounds length, or errors.
+- **llm** – optional rubric score from `utils.llm_client`.
+- **final** – average of heuristic and llm when available.
+
+Scoreboard files:
+- `scoreboard.csv` – raw table.
+- `scoreboard.md` – table plus highlights and aggregates.
+
+## Determinism & Cost
+- Use `seed` in datasets for reproducible runs.
+- Adjust provider/model or budget limits to control spend.
+
+Artifacts live under `.dr_rd/eval/{timestamp}/`.

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T17:04:07.585859Z from commit 72e1e08_
+_Last generated at 2025-08-30T17:16:19.978723Z from commit b2233c1_

--- a/eval/datasets/default.jsonl
+++ b/eval/datasets/default.jsonl
@@ -1,0 +1,1 @@
+{"id":"t001","idea":"Summarize the DR RD pipeline in 5 bullets.","mode":"standard","limits":{"budget_usd":0.10,"max_tokens":2000},"expected_keywords":["planner","executor","synthesizer"],"forbidden_keywords":["password","api_key"],"min_words":40,"max_words":200,"tags":["smoke","summary"],"seed":42}

--- a/pages/35_Eval.py
+++ b/pages/35_Eval.py
@@ -1,0 +1,35 @@
+"""Dataset evaluation runner."""
+
+import pandas as pd
+import streamlit as st
+from pathlib import Path
+
+from utils.eval import datasets, runner
+
+st.set_page_config(page_title="Evaluation", page_icon=":material/analytics:")
+
+st.title("Evaluation")
+
+DATASET_DIR = Path("eval/datasets")
+files = sorted(DATASET_DIR.glob("*.jsonl")) + sorted(DATASET_DIR.glob("*.csv"))
+file_names = [f.name for f in files]
+selected = st.selectbox("Dataset", file_names)
+use_llm = st.checkbox("Use LLM rubric", help="Costs tokens")
+
+if st.button("Run evaluation"):
+    path = DATASET_DIR / selected
+    if path.suffix == ".jsonl":
+        items = datasets.normalize(datasets.load_jsonl(str(path)))
+    else:
+        items = datasets.normalize(datasets.load_csv(str(path)))
+    summary = runner.run_eval(items, use_llm=use_llm)
+    st.session_state["eval_summary"] = summary
+
+summary = st.session_state.get("eval_summary")
+if summary:
+    st.write(f"Last run: {summary['out_dir']}")
+    st.dataframe(pd.DataFrame(summary["rows"]))
+    with open(summary["csv"], "r", encoding="utf-8") as f:
+        st.download_button("Download CSV", f.read(), file_name="scoreboard.csv")
+    with open(summary["md"], "r", encoding="utf-8") as f:
+        st.download_button("Download Markdown", f.read(), file_name="scoreboard.md")

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T17:04:07.585859Z'
-git_sha: 72e1e0863286c2dbfbb7da784121a6f485f8ed97
+generated_at: '2025-08-30T17:16:19.978723Z'
+git_sha: b2233c14747ce5f2aa3a79e2619c81bf65d2b945
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -184,27 +184,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/qa_router.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/spec_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/__init__.py
   role: Orchestrator
   responsibilities: []
@@ -219,8 +198,22 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/schemas.py
-  role: Summarization
+- path: orchestrators/spec_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/app_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/qa_router.py
+  role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
@@ -234,6 +227,13 @@ modules:
   invoked_by: []
   invokes: []
 - path: core/summarization/__init__.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/scripts/eval_run.py
+++ b/scripts/eval_run.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+"""Headless evaluation runner CLI."""
+
+import argparse
+import sys
+from pathlib import Path
+
+from utils.eval import datasets, runner
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dataset", required=True)
+    ap.add_argument("--use-llm", action="store_true")
+    ap.add_argument("--concurrency", type=int, default=1)
+    ap.add_argument("--out")
+    args = ap.parse_args()
+
+    path = Path(args.dataset)
+    if path.suffix == ".jsonl":
+        items = datasets.normalize(datasets.load_jsonl(str(path)))
+    else:
+        items = datasets.normalize(datasets.load_csv(str(path)))
+    summary = runner.run_eval(items, use_llm=args.use_llm, concurrency=args.concurrency, out_dir=args.out)
+    print(
+        f"Ran {len(items)} items: pass_rate={summary['pass_rate']:.2f} mean_final={summary['mean_final']:.2f}"
+    )
+    ok = all(r["status"] == "success" for r in summary["rows"]) and summary["pass_rate"] >= 0.7
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_eval_datasets.py
+++ b/tests/test_eval_datasets.py
@@ -1,0 +1,33 @@
+from utils.eval import datasets
+import json
+
+
+def test_load_and_normalize_jsonl(tmp_path):
+    p = tmp_path / "d.jsonl"
+    with p.open("w", encoding="utf-8") as f:
+        f.write(json.dumps({"id": "a", "idea": "hi", "expected_keywords": "foo,bar"}) + "\n")
+    items = datasets.load_jsonl(str(p))
+    norm = datasets.normalize(items)
+    assert norm[0]["id"] == "a"
+    assert norm[0]["mode"] == "standard"
+    assert norm[0]["expected_keywords"] == ["foo", "bar"]
+
+
+def test_load_and_normalize_csv(tmp_path):
+    p = tmp_path / "d.csv"
+    with p.open("w", encoding="utf-8") as f:
+        f.write("id,idea,expected_keywords\n")
+        f.write('a,hi,"foo,bar"\n')
+    items = datasets.load_csv(str(p))
+    norm = datasets.normalize(items)
+    assert norm[0]["id"] == "a"
+    assert norm[0]["expected_keywords"] == ["foo", "bar"]
+
+
+def test_duplicate_ids_rejected():
+    items = [{"id": "a"}, {"id": "a"}]
+    try:
+        datasets.normalize(items)
+    except ValueError:
+        return
+    assert False, "duplicate id not detected"

--- a/tests/test_eval_report.py
+++ b/tests/test_eval_report.py
@@ -1,0 +1,25 @@
+from utils.eval import report
+
+
+def test_report_outputs(tmp_path):
+    rows = [
+        {
+            "id": "t1",
+            "tags": ["a"],
+            "status": "success",
+            "heuristic": 1.0,
+            "llm": None,
+            "final": 1.0,
+            "tokens": 2,
+            "cost_usd": 0.01,
+            "duration_s": 0.5,
+            "run_id": "r1",
+        }
+    ]
+    summary = report.write_scoreboard(tmp_path, rows)
+    csv_path = tmp_path / "scoreboard.csv"
+    md_path = tmp_path / "scoreboard.md"
+    assert csv_path.exists() and md_path.exists()
+    txt = md_path.read_text(encoding="utf-8")
+    assert "Mean final" in txt and "Pass rate" in txt
+    assert summary["pass_rate"] == 1.0

--- a/tests/test_eval_runner.py
+++ b/tests/test_eval_runner.py
@@ -1,0 +1,17 @@
+from utils.eval import runner
+from utils.stream_events import Event
+
+
+def fake_run_stream(idea, run_id, agents):
+    yield Event("summary", phase="synth", text="foo")
+    yield Event("usage_delta", meta={"prompt_tokens": 1, "completion_tokens": 1, "cost_usd": 0.01})
+    yield Event("done")
+
+
+def test_run_eval_writes_results(tmp_path, monkeypatch):
+    monkeypatch.setattr(runner, "run_stream", fake_run_stream)
+    monkeypatch.setattr(runner, "get_agents", lambda: {})
+    items = [{"id": "t1", "idea": "hi", "expected_keywords": ["foo"], "limits": {}}]
+    summary = runner.run_eval(items, out_dir=str(tmp_path))
+    assert (tmp_path / "results" / "t1.json").exists()
+    assert summary["pass_rate"] == 1.0

--- a/tests/test_eval_scoring.py
+++ b/tests/test_eval_scoring.py
@@ -1,0 +1,31 @@
+from utils.eval import scoring
+
+
+SPEC = {
+    "id": "t1",
+    "expected_keywords": ["foo", "bar"],
+    "forbidden_keywords": ["bad"],
+    "min_words": 1,
+    "max_words": 10,
+}
+
+
+def test_heuristics_and_penalties():
+    meta = {"status": "success"}
+    out = scoring.score_item("foo baz", meta, SPEC)
+    assert out["heuristic"] == 0.5
+    out2 = scoring.score_item("foo bad", meta, SPEC)
+    assert out2["heuristic"] == 0
+    assert "forbidden" in out2["flags"]
+    out3 = scoring.score_item("", {"status": "error"}, SPEC)
+    assert out3["heuristic"] == 0
+    assert "error" in out3["flags"]
+
+
+def test_llm_path_skipped(monkeypatch):
+    monkeypatch.setenv("NO_NET", "1")
+    meta = {"status": "success"}
+    spec = {**SPEC, "rubric": "score"}
+    out = scoring.score_item("foo", meta, spec, use_llm=True)
+    assert out["llm"] is None
+    assert out["final"] == out["heuristic"]

--- a/utils/eval/datasets.py
+++ b/utils/eval/datasets.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+"""Utilities for loading and normalizing evaluation datasets."""
+
+from typing import Iterable, Dict, Any, List
+import csv
+import json
+from pathlib import Path
+
+ALLOWED_KEYS = {
+    "id",
+    "idea",
+    "mode",
+    "limits",
+    "expected_keywords",
+    "forbidden_keywords",
+    "min_words",
+    "max_words",
+    "tags",
+    "seed",
+    "rubric",
+}
+
+
+def load_jsonl(path: str) -> List[Dict[str, Any]]:
+    items: List[Dict[str, Any]] = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            items.append(json.loads(line))
+    return items
+
+
+def load_csv(path: str) -> List[Dict[str, Any]]:
+    items: List[Dict[str, Any]] = []
+    with open(path, "r", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            items.append({k: v for k, v in row.items() if v != ""})
+    return items
+
+
+def _split_list(val: Any) -> List[str]:
+    if isinstance(val, list):
+        return [str(v).strip() for v in val if str(v).strip()]
+    if isinstance(val, str):
+        return [v.strip() for v in val.split(",") if v.strip()]
+    return []
+
+
+def normalize(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    seen: set[str] = set()
+    norm: List[Dict[str, Any]] = []
+    for raw in items:
+        item = {k: raw[k] for k in raw.keys() & ALLOWED_KEYS}
+        if unknown := set(raw) - ALLOWED_KEYS:
+            # drop unknown keys silently
+            pass
+        _id = str(item.get("id") or "").strip()
+        if not _id:
+            raise ValueError("missing id")
+        if _id in seen:
+            raise ValueError(f"duplicate id: {_id}")
+        seen.add(_id)
+        item["id"] = _id
+        item["idea"] = str(item.get("idea") or "").strip()
+        item["mode"] = str(item.get("mode") or "standard")
+        limits = item.get("limits") or {}
+        if not isinstance(limits, dict):
+            limits = {}
+        budget = limits.get("budget_usd") or raw.get("budget_usd")
+        max_toks = limits.get("max_tokens") or raw.get("max_tokens")
+        item["limits"] = {
+            "budget_usd": float(budget) if budget is not None else None,
+            "max_tokens": int(max_toks) if max_toks is not None else None,
+        }
+        item["expected_keywords"] = _split_list(raw.get("expected_keywords"))
+        item["forbidden_keywords"] = _split_list(raw.get("forbidden_keywords"))
+        item["tags"] = _split_list(raw.get("tags"))
+        for k in ("min_words", "max_words", "seed"):
+            if k in raw and raw[k] is not None and raw[k] != "":
+                item[k] = int(raw[k])
+        if "rubric" in raw:
+            item["rubric"] = str(raw["rubric"])
+        norm.append(item)
+    return norm
+
+
+def save_jsonl(path: str, items: Iterable[Dict[str, Any]]) -> None:
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        for it in items:
+            f.write(json.dumps(it, ensure_ascii=False) + "\n")

--- a/utils/eval/report.py
+++ b/utils/eval/report.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+"""Aggregate evaluation results into scoreboards."""
+
+from typing import List, Dict, Any
+import csv
+from pathlib import Path
+import statistics
+
+
+def write_scoreboard(out_dir: Path, rows: List[Dict[str, Any]]) -> Dict[str, Any]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = out_dir / "scoreboard.csv"
+    fields = ["id", "tags", "status", "heuristic", "llm", "final", "tokens", "cost_usd", "duration_s", "run_id"]
+    with csv_path.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fields)
+        writer.writeheader()
+        for r in rows:
+            writer.writerow({k: r.get(k) for k in fields})
+    md_path = out_dir / "scoreboard.md"
+    pass_rate = 0.0
+    mean_final = 0.0
+    if rows:
+        finals = [r["final"] for r in rows]
+        mean_final = statistics.mean(finals)
+        pass_rate = sum(1 for v in finals if v >= 0.7) / len(finals)
+    with md_path.open("w", encoding="utf-8") as f:
+        f.write("| id | tags | status | heuristic | llm | final | tokens | cost_usd | duration_s | run_id |\n")
+        f.write("| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |\n")
+        for r in rows:
+            f.write(
+                f"| {r['id']} | {','.join(r.get('tags', []))} | {r['status']} | {r['heuristic']:.3f} | "
+                f"{r['llm'] if r['llm'] is not None else ''} | {r['final']:.3f} | {r['tokens']} | {r['cost_usd']:.4f} | {r['duration_s']:.2f} | {r['run_id']} |\n"
+            )
+        f.write("\n")
+        f.write(f"Mean final: {mean_final:.3f}\n\n")
+        f.write(f"Pass rate@0.7: {pass_rate:.1%}\n\n")
+        top = sorted(rows, key=lambda r: r['final'], reverse=True)[:5]
+        bottom = sorted(rows, key=lambda r: r['final'])[:5]
+        if top:
+            f.write("Top 5:\n")
+            for r in top:
+                f.write(f"- {r['id']} {r['final']:.3f}\n")
+            f.write("\n")
+        if bottom:
+            f.write("Bottom 5:\n")
+            for r in bottom:
+                f.write(f"- {r['id']} {r['final']:.3f}\n")
+            f.write("\n")
+    return {"csv": str(csv_path), "md": str(md_path), "pass_rate": pass_rate, "mean_final": mean_final}

--- a/utils/eval/runner.py
+++ b/utils/eval/runner.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+"""Run evaluation datasets and collect artifacts."""
+
+from typing import List, Dict, Any
+import os
+import time
+import json
+from pathlib import Path
+
+import streamlit as st
+
+from utils.run_id import new_run_id
+from app.init import get_agents
+from core.orchestrator import run_stream
+from utils.telemetry import eval_started, eval_item_completed, eval_completed
+from . import scoring, report
+
+BASE_DIR = Path(".dr_rd/eval")
+
+
+def _collect_events(events) -> tuple[str, Dict[str, Any], str]:
+    text = ""
+    usage = {"prompt_tokens": 0, "completion_tokens": 0, "cost_usd": 0.0}
+    status = "error"
+    for ev in events:
+        if ev.kind == "summary" and ev.phase == "synth":
+            text = ev.text or ""
+        elif ev.kind == "usage_delta" and ev.meta:
+            meta = ev.meta
+            usage["prompt_tokens"] += int(meta.get("prompt_tokens", 0))
+            usage["completion_tokens"] += int(meta.get("completion_tokens", 0))
+            usage["cost_usd"] += float(meta.get("cost_usd", 0.0))
+        elif ev.kind == "done":
+            status = "success"
+        elif ev.kind == "error":
+            status = "error"
+    return text, usage, status
+
+
+def run_eval(items: List[Dict[str, Any]], *, use_llm: bool = False, concurrency: int = 1, out_dir: str | None = None) -> Dict[str, Any]:
+    if concurrency != 1:
+        raise NotImplementedError("concurrency >1 not supported yet")
+    ts = time.strftime("%Y%m%d_%H%M%S")
+    out_base = Path(out_dir) if out_dir else BASE_DIR / ts
+    results_dir = out_base / "results"
+    results_dir.mkdir(parents=True, exist_ok=True)
+    eval_started(len(items), use_llm)
+    rows = []
+    for spec in items:
+        start = time.time()
+        run_id = new_run_id()
+        st.session_state["budget_limit_usd"] = spec.get("limits", {}).get("budget_usd")
+        st.session_state["max_tokens"] = spec.get("limits", {}).get("max_tokens")
+        st.session_state["mode"] = spec.get("mode", "standard")
+        if spec.get("seed") is not None:
+            os.environ["DRRD_SEED"] = str(spec["seed"])
+        else:
+            os.environ.pop("DRRD_SEED", None)
+        agents = get_agents()
+        events = run_stream(spec["idea"], run_id=run_id, agents=agents)
+        text, usage, status = _collect_events(events)
+        duration = time.time() - start
+        score = scoring.score_item(text, {"status": status, "usage": usage}, spec, use_llm=use_llm)
+        row = {
+            "id": spec["id"],
+            "tags": spec.get("tags", []),
+            "status": status,
+            "heuristic": score["heuristic"],
+            "llm": score["llm"],
+            "final": score["final"],
+            "tokens": usage["prompt_tokens"] + usage["completion_tokens"],
+            "cost_usd": usage["cost_usd"],
+            "duration_s": duration,
+            "run_id": run_id,
+            "flags": score["flags"],
+        }
+        rows.append(row)
+        with (results_dir / f"{spec['id']}.json").open("w", encoding="utf-8") as f:
+            json.dump({**row, "usage": usage}, f, ensure_ascii=False, indent=2)
+        eval_item_completed(spec["id"], status, score["final"], run_id=run_id)
+    summary = report.write_scoreboard(out_base, rows)
+    eval_completed(len(items), summary["pass_rate"], summary["mean_final"])
+    return {**summary, "rows": rows, "out_dir": str(out_base)}

--- a/utils/eval/scoring.py
+++ b/utils/eval/scoring.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+"""Scoring helpers for evaluation runs."""
+
+from typing import Any, Dict, List
+import os
+import re
+from utils import llm_client
+
+
+_keyword_re = re.compile(r"\b\w+\b")
+
+
+def _word_count(text: str) -> int:
+    return len(_keyword_re.findall(text))
+
+
+def score_with_llm(text: str, rubric: str, *, mode: str, budget_ms: int = 1200) -> float | None:
+    if os.getenv("NO_NET") == "1":
+        return None
+    payload = {
+        "messages": [
+            {
+                "role": "system",
+                "content": "Score the text 0..1 according to the rubric. Reply with a float only.",
+            },
+            {
+                "role": "user",
+                "content": f"Rubric:\n{rubric}\n\nText:\n{text}\nScore:",
+            },
+        ]
+    }
+    try:
+        resp = llm_client.chat(payload, mode=mode, cache_ttl_sec=0)
+        content = resp["choices"][0]["message"]["content"].strip()
+        return max(0.0, min(1.0, float(content)))
+    except Exception:
+        return None
+
+
+def score_item(output_text: str, meta: Dict[str, Any], spec: Dict[str, Any], *, use_llm: bool = False) -> Dict[str, Any]:
+    txt = output_text or ""
+    flags: List[str] = []
+    exp = [k.lower() for k in spec.get("expected_keywords", [])]
+    forb = [k.lower() for k in spec.get("forbidden_keywords", [])]
+    lower = txt.lower()
+    coverage = 1.0
+    if exp:
+        found = sum(1 for k in exp if k in lower)
+        coverage = found / len(exp)
+    heuristic = coverage
+    if any(k in lower for k in forb):
+        heuristic = 0.0
+        flags.append("forbidden")
+    wc = _word_count(txt)
+    if spec.get("min_words") and wc < int(spec["min_words"]):
+        heuristic = 0.0
+        flags.append("too_short")
+    if spec.get("max_words") and wc > int(spec["max_words"]):
+        heuristic = 0.0
+        flags.append("too_long")
+    if meta.get("status") != "success":
+        heuristic = 0.0
+        flags.append("error")
+    llm_score = None
+    if use_llm and spec.get("rubric"):
+        llm_score = score_with_llm(txt, spec["rubric"], mode=spec.get("mode", "standard"))
+    if llm_score is not None:
+        final = (heuristic + llm_score) / 2
+    else:
+        final = heuristic
+    return {
+        "id": spec.get("id"),
+        "heuristic": round(heuristic, 3),
+        "llm": llm_score,
+        "final": round(final, 3),
+        "flags": flags,
+    }

--- a/utils/telemetry.py
+++ b/utils/telemetry.py
@@ -418,6 +418,31 @@ def run_favorited(run_id: str, favorite: bool) -> None:
     log_event({"event": "run_favorited", "run_id": run_id, "favorite": bool(favorite)})
 
 
+def eval_started(items: int, use_llm: bool) -> None:
+    """Emit an eval_started telemetry event."""
+    log_event({"event": "eval_started", "items": items, "use_llm": use_llm})
+
+
+def eval_item_completed(id: str, status: str, final: float, *, run_id: str | None = None) -> None:
+    """Emit an eval_item_completed telemetry event."""
+    ev = {"event": "eval_item_completed", "id": id, "status": status, "final": final}
+    if run_id:
+        ev["run_id"] = run_id
+    log_event(ev)
+
+
+def eval_completed(items: int, pass_rate: float, mean_final: float) -> None:
+    """Emit an eval_completed telemetry event."""
+    log_event(
+        {
+            "event": "eval_completed",
+            "items": items,
+            "pass_rate": pass_rate,
+            "mean_final": mean_final,
+        }
+    )
+
+
 __all__ = [
     "log_event",
     "list_files",
@@ -449,4 +474,7 @@ __all__ = [
     "history_export_clicked",
     "run_annotated",
     "run_favorited",
+    "eval_started",
+    "eval_item_completed",
+    "eval_completed",
 ]


### PR DESCRIPTION
## Summary
- add evaluation dataset loaders, runner, scoring, and report generation
- expose eval telemetry and Streamlit/CLI entry points
- document evaluation workflow and include starter dataset

## Testing
- `pytest tests/test_eval_datasets.py tests/test_eval_scoring.py tests/test_eval_runner.py tests/test_eval_report.py`
- `python scripts/generate_repo_map.py`


------
https://chatgpt.com/codex/tasks/task_e_68b33108f818832caaae23fa5b054e0b