### PR TITLE
feat: add OpenTelemetry tracing with fallback

### DIFF
--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -1,0 +1,46 @@
+# Observability
+
+This repository emits OpenTelemetry traces for runs, phases, steps, and model
+calls. Tracing is enabled by default and gracefully degrades to a local JSONL
+log when the OpenTelemetry SDK is not installed.
+
+## Enabling OpenTelemetry
+
+Tracing is controlled by environment variables:
+
+- `DRRD_OTEL_ENABLED` (default `1`): disable by setting to `0`.
+- `OTEL_EXPORTER_OTLP_ENDPOINT`: HTTP collector endpoint for OTLP span export.
+- `DRRD_OTEL_CONSOLE` (default `0`): set to `1` to always emit console spans.
+
+When the SDK is present and an OTLP endpoint is configured, spans are exported
+using a `BatchSpanProcessor`. If the SDK is missing or tracing is disabled,
+span records are appended to `.dr_rd/otel/spans.jsonl`.
+
+## Span taxonomy
+
+Spans nest to reflect the execution pipeline:
+
+```
+run
+  ├─ phase.planner
+  │   └─ step.planner
+  ├─ phase.executor
+  │   └─ step.executor (per task)
+  └─ phase.synth
+      └─ step.synth
+```
+
+LLM provider calls appear as `llm.call` spans under their respective steps.
+
+## Correlation
+
+Telemetry events and structured errors automatically include `trace_id` and
+`span_id` when available. These identifiers can be used to correlate logs with
+traces in external systems.
+
+## Viewing traces
+
+To view traces, point `OTEL_EXPORTER_OTLP_ENDPOINT` to a collector such as
+Tempo, Jaeger, or the OpenTelemetry Collector. Without an endpoint, spans are
+written to `.dr_rd/otel/spans.jsonl`, which can be inspected with standard
+JSON tools.

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T17:26:30.473416Z from commit f646a2f_
+_Last generated at 2025-08-30T17:37:22.480375Z from commit 3e21977_

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T17:26:30.473416Z'
-git_sha: f646a2f49a64b04f9e4fb64221802e619cbf6692
+generated_at: '2025-08-30T17:37:22.480375Z'
+git_sha: 3e219775f5169a69f0038b2471cdc8e6f1b4b3d9
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -191,14 +191,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/plan_utils.py
+- path: orchestrators/app_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/__init__.py
+- path: orchestrators/plan_utils.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -212,7 +212,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
+- path: orchestrators/__init__.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -220,6 +220,13 @@ modules:
   invoked_by: []
   invokes: []
 - path: core/summarization/role_summarizer.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -234,13 +241,6 @@ modules:
   invoked_by: []
   invokes: []
 - path: core/summarization/__init__.py
-  role: Summarization
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -1,0 +1,28 @@
+import json
+from utils import otel
+
+
+def test_trace_id_from_run():
+    tid = otel.trace_id_from_run("run123")
+    assert len(tid) == 32
+    int(tid, 16)
+
+
+def test_configure_without_sdk(monkeypatch):
+    monkeypatch.setattr(otel, "_trace", None)
+    otel._tracer = None
+    otel.configure()
+    assert otel._tracer is None
+
+
+def test_start_span_fallback_writes(tmp_path, monkeypatch):
+    monkeypatch.setattr(otel, "_trace", None)
+    otel._tracer = None
+    monkeypatch.setattr(otel, "_FALLBACK_DIR", tmp_path)
+    with otel.start_span("demo", attrs={"a": 1}, run_id="r1"):
+        pass
+    lines = (tmp_path / "spans.jsonl").read_text().strip().splitlines()
+    assert lines
+    rec = json.loads(lines[-1])
+    assert rec["name"] == "demo"
+    assert rec["attrs"]["a"] == 1

--- a/tests/test_otel_integration.py
+++ b/tests/test_otel_integration.py
@@ -1,0 +1,20 @@
+import json
+from types import SimpleNamespace
+from utils import otel
+import core.orchestrator as orch
+
+
+def test_run_stream_writes_spans(tmp_path, monkeypatch):
+    monkeypatch.setattr(otel, "_trace", None)
+    otel._tracer = None
+    monkeypatch.setattr(otel, "_FALLBACK_DIR", tmp_path)
+    monkeypatch.setattr(orch.safety_utils, "check_text", lambda text: SimpleNamespace(findings=[]))
+    monkeypatch.setattr(orch.trace_writer, "append_step", lambda *a, **k: None)
+    monkeypatch.setattr(orch, "generate_plan", lambda *a, **k: [])
+    monkeypatch.setattr(orch, "execute_plan", lambda *a, **k: {})
+    monkeypatch.setattr(orch, "compose_final_proposal", lambda *a, **k: "ok")
+    monkeypatch.setattr(orch.st, "session_state", {})
+    list(orch.run_stream("idea", run_id="r123"))
+    lines = (tmp_path / "spans.jsonl").read_text().strip().splitlines()
+    records = [json.loads(l) for l in lines]
+    assert any(r["name"] == "run" and r["attrs"].get("run_id") == "r123" for r in records)

--- a/utils/errors.py
+++ b/utils/errors.py
@@ -80,7 +80,7 @@ def make_safe_error(
         context["phase"] = phase
     if step_id:
         context["step_id"] = step_id
-    return SafeError(
+    safe = SafeError(
         kind=kind,
         user_message=KIND_MESSAGES.get(kind, KIND_MESSAGES["unknown"]),
         tech_message=tech_message,
@@ -88,6 +88,16 @@ def make_safe_error(
         support_id=support_id,
         context=context,
     )
+    try:
+        from utils.otel import current_ids
+
+        ids = current_ids()
+        if ids:
+            safe.context["trace_id"] = ids.get("trace_id")
+            safe.context["span_id"] = ids.get("span_id")
+    except Exception:
+        pass
+    return safe
 
 
 def as_json(safe: SafeError) -> bytes:

--- a/utils/otel.py
+++ b/utils/otel.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterator, Optional
+
+_ENABLED = os.getenv("DRRD_OTEL_ENABLED", "1") == "1"
+_FALLBACK_DIR = Path(".dr_rd/otel")
+_FALLBACK_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _maybe_import():
+    try:
+        from opentelemetry import trace
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+        return trace, TracerProvider, Resource, BatchSpanProcessor, ConsoleSpanExporter, OTLPSpanExporter
+    except Exception:
+        return None
+
+
+def trace_id_from_run(run_id: str) -> str:
+    # 16 byte (32 hex) deterministic id
+    return hashlib.sha256(run_id.encode("utf-8")).hexdigest()[:32]
+
+
+_trace, _TracerProvider, _Resource, _Batch, _Console, _OTLP = _maybe_import() or (None,) * 6
+_tracer = None
+
+
+def configure(service_name: str = "dr-rd") -> None:
+    global _tracer
+    if not _ENABLED or _trace is None:
+        _tracer = None
+        return
+    if _tracer is not None:
+        return
+    provider = _TracerProvider(resource=_Resource.create({"service.name": service_name}))
+    endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+    if endpoint:
+        provider.add_span_processor(_Batch(_OTLP(endpoint=endpoint)))
+    if os.getenv("DRRD_OTEL_CONSOLE", "0") == "1" or not endpoint:
+        provider.add_span_processor(_Batch(_Console()))
+    _trace.set_tracer_provider(provider)
+    _tracer = _trace.get_tracer(service_name)
+
+
+@contextlib.contextmanager
+def start_span(
+    name: str,
+    *,
+    attrs: Optional[Dict[str, Any]] = None,
+    run_id: str | None = None,
+) -> Iterator[Any]:
+    """
+    If OTel available → real span. Else write a fallback span record to JSONL.
+    Yields a small handle with .set_attribute(), .add_event(), .record_exception(), .get_span_context()
+    """
+    if _ENABLED and _tracer is not None:
+        with _tracer.start_as_current_span(name) as span:
+            if attrs:
+                for k, v in attrs.items():
+                    span.set_attribute(k, v)
+            try:
+                yield span
+            except Exception as exc:  # pragma: no cover - defensive
+                span.record_exception(exc)
+                span.set_attribute("error", True)
+                raise
+    else:
+        start = time.time()
+        rec: Dict[str, Any] = {"name": name, "attrs": attrs or {}, "run_id": run_id, "t0": start}
+        try:
+            yield _FallbackSpan(rec)
+        except Exception as exc:  # pragma: no cover - defensive
+            rec["error"] = True
+            rec["exc"] = str(exc)
+            raise
+        finally:
+            rec["t1"] = time.time()
+            (_FALLBACK_DIR / "spans.jsonl").open("a", encoding="utf-8").write(json.dumps(rec, ensure_ascii=False) + "\n")
+
+
+@dataclass
+class _FallbackSpan:
+    _rec: Dict[str, Any]
+
+    def set_attribute(self, k: str, v: Any) -> None:
+        self._rec.setdefault("attrs", {})[k] = v
+
+    def add_event(self, name: str, attrs: Optional[Dict[str, Any]] = None) -> None:
+        ev = {"name": name, "attrs": attrs or {}, "t": time.time()}
+        self._rec.setdefault("events", []).append(ev)
+
+    def record_exception(self, exc: Exception) -> None:
+        self._rec["exc"] = str(exc)
+
+    def get_span_context(self) -> None:
+        return None
+
+
+def current_ids() -> Dict[str, str] | None:
+    if _trace is None or _tracer is None:
+        return None
+    try:
+        span = _trace.get_current_span()
+        ctx = span.get_span_context()
+        return {
+            "trace_id": format(ctx.trace_id, "032x"),
+            "span_id": format(ctx.span_id, "016x"),
+        }
+    except Exception:
+        return None

--- a/utils/telemetry.py
+++ b/utils/telemetry.py
@@ -62,6 +62,15 @@ def log_event(ev: dict) -> None:
         ev.setdefault("session_id", get_session_id() or None)
     except Exception:
         pass
+    try:
+        from utils.otel import current_ids
+
+        ids = current_ids()
+        if ids:
+            ev.setdefault("trace_id", ids.get("trace_id"))
+            ev.setdefault("span_id", ids.get("span_id"))
+    except Exception:
+        pass
     ev = validate(ev)
     ev.setdefault("schema_version", CURRENT_SCHEMA_VERSION)
     ev.setdefault("ts", time.time())


### PR DESCRIPTION
## Summary
- introduce optional utils.otel tracing module with JSONL fallback
- instrument orchestrator phases/steps and LLM calls with spans
- propagate trace IDs into telemetry and errors; document observability setup

## Testing
- `pytest tests/test_otel.py tests/test_otel_integration.py -q`
- `python scripts/generate_repo_map.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3355ebc18832c8ccc9b203bb4b363