### PR TITLE
Add accessibility baseline and tests

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -2,10 +2,10 @@
 fileWatcherType = "none"
 
 [theme]
-base = "light"
-primaryColor = "#0A63FF"
-backgroundColor = "#FFFFFF"
-secondaryBackgroundColor = "#F6F8FA"
-textColor = "#0A0A0A"
-font = "sans serif"
+base="light"
+primaryColor="#0B5FFF"
+backgroundColor="#FFFFFF"
+secondaryBackgroundColor="#F5F7FB"
+textColor="#0A0A0A"
+font="sans serif"
 # Contrast targets: WCAG AA requires 4.5:1 for normal text, 3:1 for large text.

--- a/app/ui/components.py
+++ b/app/ui/components.py
@@ -1,6 +1,9 @@
-import streamlit as st
+import json
 from contextlib import contextmanager
 
+import streamlit as st
+
+from app.ui.a11y import aria_live_region
 from utils.errors import SafeError, as_json
 
 
@@ -30,10 +33,15 @@ def stage_status(label: str, expanded: bool = False):
 
 def step_progress(total_steps: int):
     bar = st.progress(0, text="Run progress")
+    region_id = aria_live_region("progress")
 
     def update(i: int, text: str):
         pct = int(i * 100 / total_steps)
         bar.progress(pct, text=text)
+        st.markdown(
+            f"<script>document.getElementById('{region_id}').innerText = {json.dumps(text)};</script>",
+            unsafe_allow_html=True,
+        )
 
     return update
 

--- a/app/ui/static/a11y.css
+++ b/app/ui/static/a11y.css
@@ -1,0 +1,21 @@
+/* Visible focus ring */
+:where(a, button, [role="button"], input, select, textarea):focus {
+  outline: 3px solid #0B5FFF !important;
+  outline-offset: 2px !important;
+}
+/* Larger hit targets */
+:where(button, [role="button"]) { min-height: 36px; }
+/* Skip link */
+.skip-link {
+  position: absolute; left: 8px; top: -40px; padding: 8px 12px; background: #0B5FFF; color: #fff;
+}
+.skip-link:focus { top: 8px; z-index: 1000; }
+/* High-contrast chips/badges */
+.badge { background:#0B5FFF12; border:1px solid #0B5FFF66; padding:2px 8px; border-radius:12px; }
+/* Reduce motion */
+@media (prefers-reduced-motion: reduce) {
+  * { animation-duration: 0.001ms !important; animation-iteration-count: 1 !important; transition-duration: 0.001ms !important; }
+}
+/* Tables readability */
+table { border-collapse: collapse; }
+th, td { border-bottom: 1px solid #E3E8F0; padding: 8px 10px; }

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T17:37:22.480375Z from commit 3e21977_
+_Last generated at 2025-08-30T17:47:23.289829Z from commit 6cc0309_

--- a/e2e/test_a11y_basics.py
+++ b/e2e/test_a11y_basics.py
@@ -1,0 +1,9 @@
+def test_skip_link_and_focus(page, base_url):
+    page.goto(f"{base_url}/")
+    page.keyboard.press("Tab")
+    page.get_by_role("link", name="Skip to main content").press("Enter")
+    main = page.locator("#main")
+    assert main.is_visible()
+    snapshot = page.accessibility.snapshot()
+    names = [node.get("name", "") for node in snapshot.get("children", [])]
+    assert any("Start run" in n or "Run demo" in n for n in names)

--- a/pages/05_Health.py
+++ b/pages/05_Health.py
@@ -4,11 +4,16 @@ import os
 
 import streamlit as st
 
+from app.ui.a11y import aria_live_region, inject, main_start
 from app.ui.command_palette import open_palette
 from utils import health_check
 from utils.i18n import tr as t
 from utils.lazy_import import local_import
 from utils.telemetry import log_event
+
+inject()
+main_start()
+aria_live_region()
 
 # quick open via button
 if st.button(
@@ -49,7 +54,7 @@ if act:
 
 st.title(t("health_title"))
 
-if st.button("Run diagnostics"):
+if st.button("Run diagnostics", help="Run system diagnostics"):
     report = health_check.run_all()
     cols = st.columns(3)
     cols[0].metric("pass", report.summary.get("pass", 0))

--- a/pages/10_Trace.py
+++ b/pages/10_Trace.py
@@ -9,17 +9,22 @@ from urllib.parse import urlencode
 import streamlit as st
 
 from app.ui import empty_states
-from utils.i18n import tr as t
+from app.ui.a11y import aria_live_region, inject, main_start
+from app.ui.command_palette import open_palette
 from app.ui.trace_viewer import render_trace
 from utils import run_reproduce
+from utils.flags import is_enabled
+from utils.i18n import tr as t
 from utils.paths import artifact_path
 from utils.query_params import encode_config
 from utils.run_config import RunConfig, to_orchestrator_kwargs
-from utils.session_store import init_stores
 from utils.runs import last_run_id, list_runs
+from utils.session_store import init_stores
 from utils.telemetry import log_event
-from utils.flags import is_enabled
-from app.ui.command_palette import open_palette
+
+inject()
+main_start()
+aria_live_region()
 
 # quick open via button
 if st.button(

--- a/pages/12_History.py
+++ b/pages/12_History.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 import streamlit as st
 
+from app.ui.a11y import aria_live_region, inject, main_start
 from app.ui.command_palette import open_palette
 from utils import run_notes, runs_index
 from utils.i18n import tr as t
@@ -15,6 +16,10 @@ from utils.telemetry import (
     run_annotated,
     run_favorited,
 )
+
+inject()
+main_start()
+aria_live_region()
 
 # quick open via button
 if st.button(

--- a/pages/15_Knowledge.py
+++ b/pages/15_Knowledge.py
@@ -3,6 +3,7 @@
 import streamlit as st
 
 from app.ui import knowledge as ui
+from app.ui.a11y import aria_live_region, inject, main_start
 from app.ui.command_palette import open_palette
 from utils import knowledge_store, upload_scan, uploads
 from utils.i18n import tr as t
@@ -12,6 +13,10 @@ from utils.telemetry import (
     knowledge_tags_updated,
     log_event,
 )
+
+inject()
+main_start()
+aria_live_region()
 
 st.title(t("knowledge_title"))
 st.caption("Select sources in Sidebar → Knowledge.")

--- a/pages/35_Eval.py
+++ b/pages/35_Eval.py
@@ -1,12 +1,17 @@
 """Dataset evaluation runner."""
 
-import pandas as pd
-import streamlit as st
 from pathlib import Path
 
+import pandas as pd
+import streamlit as st
+
+from app.ui.a11y import aria_live_region, inject, main_start
 from utils.eval import datasets, runner
 
 st.set_page_config(page_title="Evaluation", page_icon=":material/analytics:")
+inject()
+main_start()
+aria_live_region()
 
 st.title("Evaluation")
 
@@ -29,7 +34,7 @@ summary = st.session_state.get("eval_summary")
 if summary:
     st.write(f"Last run: {summary['out_dir']}")
     st.dataframe(pd.DataFrame(summary["rows"]))
-    with open(summary["csv"], "r", encoding="utf-8") as f:
+    with open(summary["csv"], encoding="utf-8") as f:
         st.download_button("Download CSV", f.read(), file_name="scoreboard.csv")
-    with open(summary["md"], "r", encoding="utf-8") as f:
+    with open(summary["md"], encoding="utf-8") as f:
         st.download_button("Download Markdown", f.read(), file_name="scoreboard.md")

--- a/pages/90_Settings.py
+++ b/pages/90_Settings.py
@@ -5,6 +5,7 @@ import json
 
 import streamlit as st
 
+from app.ui.a11y import aria_live_region, inject, main_start
 from app.ui.command_palette import open_palette
 from utils.i18n import get_locale, set_locale
 from utils.i18n import tr as t
@@ -12,6 +13,10 @@ from utils.prefs import DEFAULT_PREFS, load_prefs, save_prefs
 from utils.telemetry import log_event
 
 # quick open via button
+inject()
+main_start()
+aria_live_region()
+
 if st.button(
     "⌘K Command palette",
     key="cmd_btn",
@@ -59,7 +64,7 @@ lang = st.selectbox(
     index=["en", "es"].index(get_locale()),
     help="UI language",
 )
-if st.button("Apply language"):
+if st.button("Apply language", help="Apply selected language"):
     set_locale(lang)
     prefs["ui"]["language"] = lang
     save_prefs(prefs)

--- a/pages/96_Privacy.py
+++ b/pages/96_Privacy.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 import streamlit as st
 
+from app.ui.a11y import aria_live_region, inject, main_start
 from app.ui.command_palette import open_palette
-from utils.telemetry import log_event
 from utils import consent as _consent
-from utils import retention, prefs, runs
+from utils import prefs, retention, runs
+from utils.telemetry import log_event
 
+inject()
+main_start()
+aria_live_region()
 
 # quick open via button
 if st.button(
@@ -135,4 +139,3 @@ st.subheader("Export")
 st.write(
     "Run `python scripts/privacy_export.py --run-id <id> --out <dir>` from the command line to export a run's data."
 )
-

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T17:37:22.480375Z'
-git_sha: 3e219775f5169a69f0038b2471cdc8e6f1b4b3d9
+generated_at: '2025-08-30T17:47:23.289829Z'
+git_sha: 6cc0309a14308effe280f913fe5589c035a36320
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -184,13 +184,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/spec_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/app_builder.py
   role: Orchestrator
   responsibilities: []
@@ -205,13 +198,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/qa_router.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/__init__.py
   role: Orchestrator
   responsibilities: []
@@ -219,7 +205,21 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
+- path: orchestrators/spec_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/qa_router.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/integrator.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -233,14 +233,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/__init__.py
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []


### PR DESCRIPTION
## Summary
- inject global skip link, focus CSS, and aria-live helpers
- update pages and theme for contrast and focus visibility
- add basic accessibility e2e test

## Testing
- `pre-commit run --files .streamlit/config.toml app/__init__.py app/ui/a11y.py app/ui/components.py app/ui/trace_viewer.py pages/05_Health.py pages/10_Trace.py pages/12_History.py pages/15_Knowledge.py pages/20_Reports.py pages/25_Compare.py pages/30_Metrics.py pages/35_Eval.py pages/90_Settings.py pages/95_Providers.py pages/96_Privacy.py tests/test_a11y_injection.py e2e/test_a11y_basics.py docs/REPO_MAP.md repo_map.yaml app/ui/static/a11y.css`
- `pytest tests/test_a11y_injection.py`
- `pytest e2e/test_a11y_basics.py` *(fails: BrowserType.launch: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68b3379ddb8c832cad448fefb502e0fc