### PR TITLE
feat: add notification integrations

### DIFF
--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -1,0 +1,39 @@
+# Integrations
+
+Configure optional notification channels for Slack, email, or a generic webhook.
+
+## Slack
+1. Create an *Incoming Webhook* in Slack and copy the URL.
+2. Store the value in `SLACK_WEBHOOK_URL` via environment variable or `st.secrets`.
+3. In the Notifications page, enable Slack and optionally set a mention such as `@here`.
+
+## Email
+1. Provide SMTP credentials via secrets:
+   - `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `SMTP_FROM`
+   - Optional `SMTP_TLS=1` to enable TLS (default).
+2. Add recipient addresses in preferences. Up to ten addresses are allowed.
+
+## Webhook
+1. Set `WEBHOOK_URL` to receive JSON payloads of run events.
+2. Optionally set `WEBHOOK_SECRET` to sign requests. The body HMAC SHA-256 is sent in `X-DRRD-Signature`.
+
+### Security
+Secrets should be stored in environment variables or `st.secrets`; they are never written to prefs. Webhooks should verify the `X-DRRD-Signature` header when a secret is configured.
+
+### Examples
+Slack messages use block kit and include run ID, status, mode, and cost. Webhook payload example:
+```json
+{
+  "ts": 1234567890.0,
+  "event": "run_completed",
+  "run_id": "r1",
+  "status": "success",
+  "mode": "standard",
+  "totals": {"tokens": 1000, "cost_usd": 0.02}
+}
+```
+
+### Troubleshooting
+- Ensure network egress to Slack/SMTP/webhook endpoints.
+- Check rate limits for external services.
+- Use the "Send test" buttons in the Notifications settings page.

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T17:47:23.289829Z from commit 6cc0309_
+_Last generated at 2025-08-30T18:04:26.466305Z from commit 910ed92_

--- a/pages/97_Notifications.py
+++ b/pages/97_Notifications.py
@@ -1,0 +1,67 @@
+import streamlit as st
+
+from utils.prefs import load_prefs, save_prefs
+from utils.notify import Note, dispatch as notify_dispatch
+from utils.telemetry import notifications_saved, notification_test_sent
+from utils.secrets import get as get_secret
+
+st.set_page_config(page_title="Notifications")
+
+st.title("Notifications")
+
+prefs = load_prefs()
+np = prefs.get("notifications", {})
+
+enabled = st.checkbox("Enabled", value=np.get("enabled", True))
+channels = st.multiselect("Channels", ["slack", "email", "webhook"], default=np.get("channels", []))
+slack_mention = st.text_input("Slack mention", np.get("slack_mention", ""))
+email_to_str = ", ".join(np.get("email_to", []))
+email_to_input = st.text_input("Email recipients", email_to_str)
+
+slack_hint = "✅ Slack webhook configured" if get_secret("SLACK_WEBHOOK_URL") else "⚠️ Slack webhook not set"
+st.caption(slack_hint)
+smtp_ok = all(get_secret(k) for k in ["SMTP_HOST", "SMTP_FROM"])
+st.caption("✅ SMTP configured" if smtp_ok else "⚠️ SMTP incomplete")
+webhook_hint = "✅ Webhook URL set" if get_secret("WEBHOOK_URL") else "⚠️ Webhook URL missing"
+st.caption(webhook_hint)
+
+events = {}
+for ev in [
+    "run_completed",
+    "run_failed",
+    "run_cancelled",
+    "timeout",
+    "budget_exceeded",
+    "safety_blocked",
+]:
+    label = ev.replace("_", " ").title()
+    events[ev] = st.checkbox(label, value=np.get("events", {}).get(ev, True))
+
+if st.button("Save"):
+    updated = prefs.copy()
+    updated["notifications"] = {
+        "enabled": bool(enabled),
+        "channels": channels,
+        "email_to": [e.strip() for e in email_to_input.split(",") if e.strip()][:10],
+        "slack_mention": slack_mention,
+        "events": events,
+    }
+    save_prefs(updated)
+    notifications_saved(channels, sum(events.values()))
+    st.success("Saved")
+
+for ch in ["slack", "email", "webhook"]:
+    if st.button(f"Send test {ch}"):
+        note = Note(event="test", run_id="test", status="success", mode="test", idea_preview="test")
+        tmp_prefs = {
+            "notifications": {
+                "enabled": True,
+                "channels": [ch],
+                "email_to": [e.strip() for e in email_to_input.split(",") if e.strip()][:10],
+                "slack_mention": slack_mention,
+                "events": {"test": True},
+            }
+        }
+        ok = bool(notify_dispatch(note, tmp_prefs).get(ch))
+        notification_test_sent(ch, ok)
+        st.toast(f"{ch} {'sent' if ok else 'failed'}")

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T17:47:23.289829Z'
-git_sha: 6cc0309a14308effe280f913fe5589c035a36320
+generated_at: '2025-08-30T18:04:26.466305Z'
+git_sha: 910ed920b679c5240027ea706d99e5dab6586761
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -191,7 +191,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/plan_utils.py
+- path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -205,13 +205,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/spec_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/qa_router.py
   role: Orchestrator
   responsibilities: []
@@ -219,8 +212,8 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
-  role: Summarization
+- path: orchestrators/plan_utils.py
+  role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
@@ -234,6 +227,13 @@ modules:
   invoked_by: []
   invokes: []
 - path: core/summarization/__init__.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/integrator.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -1,0 +1,66 @@
+import urllib.request
+
+import utils.notify as notify
+
+
+def test_format_plain_redacts():
+    note = notify.Note(
+        event="run_completed",
+        run_id="r1",
+        status="success",
+        mode="m",
+        idea_preview="secret sk-123456789012345678901234",
+    )
+    out = notify._format_plain(note)
+    assert "sk-12345" not in out
+
+
+def test_dispatch_missing_secrets(monkeypatch):
+    note = notify.Note(
+        event="run_completed",
+        run_id="r1",
+        status="success",
+        mode="m",
+        idea_preview="x",
+    )
+    monkeypatch.setattr(notify, "get_secret", lambda k: None)
+    prefs = {
+        "notifications": {
+            "enabled": True,
+            "channels": ["slack", "email", "webhook"],
+            "email_to": ["a@example.com"],
+            "slack_mention": "",
+            "events": {"run_completed": True},
+        }
+    }
+    res = notify.dispatch(note, prefs)
+    assert res == {"slack": False, "email": False, "webhook": False}
+
+
+def test_webhook_hmac_header(monkeypatch):
+    captured = {}
+
+    class Dummy:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    def fake_urlopen(req, timeout=5):
+        captured["headers"] = dict(req.header_items())
+        captured["data"] = req.data
+        return Dummy()
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    secrets = {"WEBHOOK_URL": "http://example.com", "WEBHOOK_SECRET": "abc"}
+    monkeypatch.setattr(notify, "get_secret", lambda k: secrets.get(k))
+    note = notify.Note(
+        event="run_completed",
+        run_id="r1",
+        status="success",
+        mode="m",
+        idea_preview="x",
+    )
+    assert notify._webhook_send(note) is True
+    assert any(k.lower() == "x-drrd-signature" for k in captured["headers"])

--- a/utils/notify.py
+++ b/utils/notify.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Any, List
+import hmac
+import hashlib
+import json
+import smtplib
+import ssl
+import time
+import textwrap
+import urllib.request
+from email.message import EmailMessage
+
+from .secrets import get as get_secret
+from .redaction import redact_text
+from .pricing import get as price_get  # optional for cost formatting
+
+
+@dataclass(frozen=True)
+class Note:
+    event: str            # e.g., "run_completed"
+    run_id: str
+    status: str           # "success"|"error"|"cancelled"|"timeout"
+    mode: str
+    idea_preview: str
+    totals: Dict[str, Any] | None = None   # {tokens, cost_usd, duration_s}
+    url: str | None = None                 # deep link if available
+    extra: Dict[str, Any] | None = None    # errors, safety categories
+
+
+def _format_plain(note: Note) -> str:
+    t = note.totals or {}
+    cost = f"${t.get('cost_usd', 0):.2f}" if 'cost_usd' in t else "n/a"
+    dur = f"{int(t.get('duration_s', 0))}s"
+    preview = redact_text((note.idea_preview or "")[:160])
+    return textwrap.dedent(
+        f"""
+        DR RD — {note.event.replace('_',' ').title()}
+        Run: {note.run_id}  Status: {note.status}  Mode: {note.mode}
+        Totals: tokens={t.get('tokens','n/a')}  cost={cost}  duration={dur}
+        Idea: {preview}
+        Link: {note.url or 'n/a'}
+        """
+    ).strip()
+
+
+def _slack_send(note: Note, mention: str = "") -> bool:
+    url = get_secret("SLACK_WEBHOOK_URL")
+    if not url:
+        return False
+    cost = (
+        f"${note.totals.get('cost_usd'):.2f}"
+        if note.totals and 'cost_usd' in note.totals
+        else "n/a"
+    )
+    blocks: List[Dict[str, Any]] = [
+        {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": f"*DR RD — {note.event.replace('_',' ').title()}*"},
+        },
+        {
+            "type": "section",
+            "fields": [
+                {"type": "mrkdwn", "text": f"*Run ID:*\n`{note.run_id}`"},
+                {"type": "mrkdwn", "text": f"*Status:*\n{note.status}"},
+                {"type": "mrkdwn", "text": f"*Mode:*\n{note.mode}"},
+                {"type": "mrkdwn", "text": f"*Cost:*\n{cost}"},
+            ],
+        },
+    ]
+    if note.url:
+        blocks.append(
+            {
+                "type": "actions",
+                "elements": [
+                    {
+                        "type": "button",
+                        "text": {"type": "plain_text", "text": "Open Trace"},
+                        "url": note.url,
+                    }
+                ],
+            }
+        )
+    if mention:
+        blocks.insert(0, {"type": "section", "text": {"type": "mrkdwn", "text": mention}})
+    body = json.dumps({"blocks": blocks}).encode("utf-8")
+    req = urllib.request.Request(url, data=body, headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=5):
+        return True
+
+
+def _email_send(note: Note, to_list: List[str]) -> bool:
+    host = get_secret("SMTP_HOST")
+    port = int(get_secret("SMTP_PORT") or 587)
+    user = get_secret("SMTP_USER")
+    pwd = get_secret("SMTP_PASS")
+    sender = get_secret("SMTP_FROM")
+    if not (host and port and sender and to_list):
+        return False
+    msg = EmailMessage()
+    msg["Subject"] = f"[DR RD] {note.event.replace('_',' ').title()} — {note.run_id}"
+    msg["From"] = sender
+    msg["To"] = ", ".join(to_list)
+    msg.set_content(_format_plain(note))
+    ctx = ssl.create_default_context()
+    with smtplib.SMTP(host, port, timeout=8) as s:
+        if (get_secret("SMTP_TLS") or "1") != "0":
+            s.starttls(context=ctx)
+        if user and pwd:
+            s.login(user, pwd)
+        s.send_message(msg)
+    return True
+
+
+def _webhook_send(note: Note) -> bool:
+    url = get_secret("WEBHOOK_URL")
+    if not url:
+        return False
+    payload = {
+        "ts": time.time(),
+        "event": note.event,
+        "run_id": note.run_id,
+        "status": note.status,
+        "mode": note.mode,
+        "totals": note.totals,
+        "url": note.url,
+    }
+    body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    secret = get_secret("WEBHOOK_SECRET")
+    if secret:
+        sig = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+        headers["X-DRRD-Signature"] = sig
+    req = urllib.request.Request(url, data=body, headers=headers)
+    with urllib.request.urlopen(req, timeout=5):
+        return True
+
+
+def dispatch(note: Note, prefs: Dict[str, Any]) -> Dict[str, bool]:
+    np = prefs.get("notifications", {})
+    if not np.get("enabled"):
+        return {"enabled": False}
+    if note.event != "test" and not np.get("events", {}).get(note.event, False):
+        return {"enabled": False}
+    chans = set(np.get("channels", []))
+    results: Dict[str, bool] = {}
+    try:
+        if "slack" in chans:
+            results["slack"] = _slack_send(note, np.get("slack_mention", ""))
+    except Exception:
+        results["slack"] = False
+    try:
+        if "email" in chans:
+            to_list = np.get("email_to") or []
+            results["email"] = _email_send(note, to_list)
+    except Exception:
+        results["email"] = False
+    try:
+        if "webhook" in chans:
+            results["webhook"] = _webhook_send(note)
+    except Exception:
+        results["webhook"] = False
+    return results
+
+
+__all__ = ["Note", "dispatch"]

--- a/utils/telemetry.py
+++ b/utils/telemetry.py
@@ -459,6 +459,18 @@ def eval_completed(items: int, pass_rate: float, mean_final: float) -> None:
     )
 
 
+
+
+def notification_sent(run_id: str, status: str, channels: list[str], ok: bool) -> None:
+    log_event({"event": "notification_sent", "run_id": run_id, "status": status, "channels": channels, "ok": bool(ok)})
+
+
+def notifications_saved(channels: list[str], events_count: int) -> None:
+    log_event({"event": "notifications_saved", "channels": channels, "events_count": events_count})
+
+
+def notification_test_sent(channel: str, ok: bool) -> None:
+    log_event({"event": "notification_test_sent", "channel": channel, "ok": bool(ok)})
 __all__ = [
     "log_event",
     "list_files",
@@ -493,4 +505,7 @@ __all__ = [
     "eval_started",
     "eval_item_completed",
     "eval_completed",
+    "notification_sent",
+    "notifications_saved",
+    "notification_test_sent",
 ]

--- a/utils/telemetry_schema.py
+++ b/utils/telemetry_schema.py
@@ -37,6 +37,9 @@ _SCHEMAS: Dict[str, List[str]] = {
     "knowledge_removed": ["id"],
     "palette_opened": [],
     "palette_executed": ["command"],
+    "notification_sent": ["run_id"],
+    "notifications_saved": ["channels"],
+    "notification_test_sent": ["channel"],
 }
 
 # Keys that should never be persisted. This is a simple heuristic to strip


### PR DESCRIPTION
## Summary
- add notification utilities for Slack, email and generic webhooks
- surface notification settings UI and dispatch hooks
- document integration setup and cover with tests

## Testing
- `python scripts/generate_repo_map.py`
- `pytest tests/test_notify.py`


------
https://chatgpt.com/codex/tasks/task_e_68b33b5a2778832c89b178e212020e55