### PR TITLE
Add pluggable artifact storage with local backend

### DIFF
--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -37,3 +37,10 @@ Slack messages use block kit and include run ID, status, mode, and cost. Webhook
 - Ensure network egress to Slack/SMTP/webhook endpoints.
 - Check rate limits for external services.
 - Use the "Send test" buttons in the Notifications settings page.
+
+
+## Artifact storage
+
+Configure storage backend for run artifacts. Supported backends are local filesystem, S3, and GCS.
+Set non-secret preferences under the Storage settings page. Secrets like credentials should be provided via environment variables or st.secrets.
+Signed download URLs are generated when supported, with lifetime controlled by `signed_url_ttl_sec`.

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T18:04:26.466305Z from commit 910ed92_
+_Last generated at 2025-08-30T18:16:59.780607Z from commit 5f341d3_

--- a/pages/98_Storage.py
+++ b/pages/98_Storage.py
@@ -1,0 +1,24 @@
+import streamlit as st
+
+from utils import prefs, storage
+
+st.title("Storage Settings")
+
+conf = prefs.load_prefs().get("storage", {})
+backend = st.selectbox("Backend", ["local", "s3", "gcs"], index=["local", "s3", "gcs"].index(conf.get("backend", "local")))
+bucket = st.text_input("Bucket", conf.get("bucket", ""))
+prefix = st.text_input("Prefix", conf.get("prefix", "dr_rd"))
+ttl = st.number_input("Signed URL TTL", value=int(conf.get("signed_url_ttl_sec", 600)))
+
+if st.button("Save"):
+    p = prefs.load_prefs()
+    p["storage"] = {
+        "backend": backend,
+        "bucket": bucket,
+        "prefix": prefix,
+        "signed_url_ttl_sec": int(ttl),
+    }
+    prefs.save_prefs(p)
+    st.success("Saved")
+
+st.write("Current backend:", storage.get_storage().backend)

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T18:04:26.466305Z'
-git_sha: 910ed920b679c5240027ea706d99e5dab6586761
+generated_at: '2025-08-30T18:16:59.780607Z'
+git_sha: 5f341d37c438d61a6747fd603e310ba7eb58a6eb
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -184,7 +184,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
+- path: orchestrators/qa_router.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/plan_utils.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -205,14 +212,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/qa_router.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/plan_utils.py
+- path: orchestrators/app_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -220,13 +220,6 @@ modules:
   invoked_by: []
   invokes: []
 - path: core/summarization/schemas.py
-  role: Summarization
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -241,6 +234,13 @@ modules:
   invoked_by: []
   invokes: []
 - path: core/summarization/role_summarizer.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/scripts/storage_migrate.py
+++ b/scripts/storage_migrate.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+"""Migrate artifacts between storage backends."""
+
+import argparse
+
+from utils.storage import _create_storage
+
+PREFIX_MAP = {
+    "runs": "runs",
+    "knowledge": "knowledge/uploads",
+    "all": "",
+}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--from", dest="src", choices=["local", "s3", "gcs"], required=True)
+    ap.add_argument("--to", dest="dst", choices=["local", "s3", "gcs"], required=True)
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--prefix", choices=["runs", "knowledge", "all"], default="all")
+    args = ap.parse_args()
+
+    src = _create_storage({"backend": args.src})
+    dst = _create_storage({"backend": args.dst})
+    prefix = PREFIX_MAP[args.prefix]
+    total = 0
+    for ref in src.list(prefix):
+        data = src.read_bytes(ref.key)
+        if not args.dry_run:
+            dst.write_bytes(ref.key, data)
+            dst_size = dst.read_bytes(ref.key)
+            if len(dst_size) != len(data):
+                print("mismatch", ref.key)
+                return 1
+        total += 1
+    print(f"copied {total} objects")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_storage_gcs.py
+++ b/tests/test_storage_gcs.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytest.skip("GCS backend tests require credentials", allow_module_level=True)

--- a/tests/test_storage_local.py
+++ b/tests/test_storage_local.py
@@ -1,0 +1,18 @@
+import shutil
+from utils.storage import _create_storage, key_run
+
+
+def test_local_roundtrip():
+    conf = {"backend": "local", "prefix": "test_storage"}
+    st = _create_storage(conf)
+    key = key_run("r1", "trace", "json")
+    data = b"hello"
+    st.write_bytes(key, data)
+    assert st.read_bytes(key) == data
+    assert st.exists(key)
+    refs = list(st.list("runs/r1"))
+    assert any(r.key == key for r in refs)
+    st.delete(key)
+    assert not st.exists(key)
+    assert st.url_for(key, 60) is None
+    shutil.rmtree(f".{conf['prefix']}", ignore_errors=True)

--- a/tests/test_storage_s3.py
+++ b/tests/test_storage_s3.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytest.skip("S3 backend tests require credentials", allow_module_level=True)

--- a/utils/paths.py
+++ b/utils/paths.py
@@ -1,33 +1,47 @@
 from __future__ import annotations
 
+"""Thin wrapper around storage for run artifacts."""
+
 from pathlib import Path
+from typing import Iterable
 
-RUNS_ROOT = Path(".dr_rd") / "runs"
-
-
-def run_root(run_id: str) -> Path:
-    """Return the root directory for a run."""
-    return RUNS_ROOT / run_id
+from .storage import get_storage, key_run
 
 
-def artifact_path(run_id: str, name: str, ext: str) -> Path:
-    """Return path for a named artifact within a run."""
-    return run_root(run_id) / f"{name}.{ext}"
+def artifact_key(run_id: str, name: str, ext: str) -> str:
+    return key_run(run_id, name, ext)
 
 
-def ensure_run_dirs(run_id: str) -> None:
-    """Ensure the run directory exists."""
-    run_root(run_id).mkdir(parents=True, exist_ok=True)
+def write_bytes(run_id: str, name: str, ext: str, data: bytes) -> str:
+    return get_storage().write_bytes(artifact_key(run_id, name, ext), data).key
 
 
-def write_bytes(run_id: str, name: str, ext: str, data: bytes) -> Path:
-    """Write bytes to a run artifact and return its path."""
-    ensure_run_dirs(run_id)
-    path = artifact_path(run_id, name, ext)
-    path.write_bytes(data)
-    return path
+def write_text(run_id: str, name: str, ext: str, text: str) -> str:
+    return get_storage().write_text(artifact_key(run_id, name, ext), text).key
 
 
-def write_text(run_id: str, name: str, ext: str, text: str, encoding: str = "utf-8") -> Path:
-    """Write text to a run artifact and return its path."""
-    return write_bytes(run_id, name, ext, text.encode(encoding))
+def read_bytes(run_id: str, name: str, ext: str) -> bytes:
+    return get_storage().read_bytes(artifact_key(run_id, name, ext))
+
+
+def read_text(run_id: str, name: str, ext: str) -> str:
+    return get_storage().read_text(artifact_key(run_id, name, ext))
+
+
+def exists(run_id: str, name: str, ext: str) -> bool:
+    return get_storage().exists(artifact_key(run_id, name, ext))
+
+
+def list_run(run_id: str) -> Iterable[str]:
+    prefix = f"runs/{run_id}"
+    for ref in get_storage().list(prefix):
+        yield ref.key
+
+
+def local_path_for_debug(key: str) -> Path | None:
+    storage = get_storage()
+    if storage.backend == "local":
+        from .storage_backends.localfs import LocalFSStorage
+        assert isinstance(storage, LocalFSStorage)
+        return storage.root / key
+    return None

--- a/utils/prefs.py
+++ b/utils/prefs.py
@@ -50,10 +50,13 @@ DEFAULT_PREFS: dict[str, Any] = {
             "safety_blocked": True,
         },
     },
+    "storage": {"backend": "local", "bucket": "", "prefix": "dr_rd", "signed_url_ttl_sec": 600},
+
+
 
 }
 
-_ALLOWED_SECTIONS = {"defaults", "ui", "privacy", "notifications", "version"}
+_ALLOWED_SECTIONS = {"defaults", "ui", "privacy", "notifications", "storage", "version"}
 
 
 def _validate(raw: Mapping[str, Any] | None) -> dict:

--- a/utils/storage.py
+++ b/utils/storage.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+"""Pluggable artifact storage interface and helpers."""
+
+from dataclasses import dataclass
+from typing import Iterable, Optional, Dict, Tuple
+
+from . import prefs
+
+
+@dataclass(frozen=True)
+class ObjRef:
+    key: str
+    size: Optional[int] = None
+    etag: Optional[str] = None
+    url: Optional[str] = None
+
+
+class Storage:
+    """Abstract storage backend."""
+
+    backend: str = "unknown"
+
+    def write_bytes(self, key: str, data: bytes, *, content_type: str = "application/octet-stream") -> ObjRef:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def write_text(self, key: str, text: str, *, content_type: str = "text/plain; charset=utf-8") -> ObjRef:  # pragma: no cover - interface
+        return self.write_bytes(key, text.encode("utf-8"), content_type=content_type)
+
+    def read_bytes(self, key: str) -> bytes:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def read_text(self, key: str) -> str:
+        return self.read_bytes(key).decode("utf-8")
+
+    def exists(self, key: str) -> bool:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def list(self, prefix: str) -> Iterable[ObjRef]:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def delete(self, key: str) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def url_for(self, key: str, ttl_sec: int) -> Optional[str]:  # pragma: no cover - interface
+        return None
+
+
+_STORAGE: Storage | None = None
+
+
+def _create_storage(conf: Dict | None) -> Storage:
+    backend = (conf or {}).get("backend", "local")
+    if backend == "s3":
+        from .storage_backends.s3 import S3Storage
+
+        return S3Storage(conf or {})
+    if backend == "gcs":
+        from .storage_backends.gcs import GCSStorage
+
+        return GCSStorage(conf or {})
+    from .storage_backends.localfs import LocalFSStorage
+
+    return LocalFSStorage(conf or {})
+
+
+def get_storage() -> Storage:
+    global _STORAGE
+    if _STORAGE is None:
+        conf = prefs.load_prefs().get("storage", {})
+        _STORAGE = _create_storage(conf)
+    return _STORAGE
+
+
+def key_run(run_id: str, name: str, ext: str) -> str:
+    return f"runs/{run_id}/{name}.{ext}"
+
+
+def key_knowledge(name: str) -> str:
+    return f"knowledge/uploads/{name}"

--- a/utils/storage_backends/gcs.py
+++ b/utils/storage_backends/gcs.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+"""GCS storage backend."""
+
+from datetime import timedelta
+from typing import Iterable, Optional
+
+try:
+    from google.cloud import storage as gcs  # type: ignore
+except Exception:  # pragma: no cover - optional
+    gcs = None
+
+from ..storage import ObjRef, Storage
+from .. import telemetry, secrets
+
+
+class GCSStorage(Storage):
+    backend = "gcs"
+
+    def __init__(self, conf: dict | None = None) -> None:
+        if gcs is None:  # pragma: no cover - optional
+            raise RuntimeError("google-cloud-storage not installed")
+        conf = conf or {}
+        self.bucket_name = conf.get("bucket") or secrets.get("GCS_BUCKET") or ""
+        self.prefix = conf.get("prefix", "dr_rd")
+        self.ttl = int(conf.get("signed_url_ttl_sec", 600))
+        if secrets.get("GCP_SERVICE_ACCOUNT"):
+            self.client = gcs.Client.from_service_account_info(secrets.get("GCP_SERVICE_ACCOUNT"))  # type: ignore
+        else:
+            self.client = gcs.Client()  # type: ignore
+        self.bucket = self.client.bucket(self.bucket_name)  # type: ignore
+
+    def _blob(self, key: str):
+        name = f"{self.prefix}/{key}" if self.prefix else key
+        return self.bucket.blob(name)
+
+    def write_bytes(self, key: str, data: bytes, *, content_type: str = "application/octet-stream") -> ObjRef:
+        blob = self._blob(key)
+        blob.upload_from_string(data, content_type=content_type)
+        telemetry.storage_write(self.backend, key, len(data))
+        return ObjRef(key=key, size=len(data))
+
+    def read_bytes(self, key: str) -> bytes:
+        blob = self._blob(key)
+        data = blob.download_as_bytes()
+        telemetry.storage_read(self.backend, key, len(data))
+        return data
+
+    def exists(self, key: str) -> bool:
+        return self._blob(key).exists()
+
+    def list(self, prefix: str) -> Iterable[ObjRef]:
+        path = f"{self.prefix}/{prefix}" if self.prefix else prefix
+        for blob in self.client.list_blobs(self.bucket_name, prefix=path):  # type: ignore
+            key = blob.name[len(self.prefix) + 1 :] if self.prefix else blob.name
+            yield ObjRef(key=key, size=blob.size)
+
+    def delete(self, key: str) -> None:
+        try:
+            self._blob(key).delete()
+        except Exception:
+            pass
+
+    def url_for(self, key: str, ttl_sec: int) -> Optional[str]:
+        try:
+            blob = self._blob(key)
+            return blob.generate_signed_url(expiration=timedelta(seconds=ttl_sec))  # type: ignore
+        except Exception:  # pragma: no cover - best effort
+            return None

--- a/utils/storage_backends/localfs.py
+++ b/utils/storage_backends/localfs.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+"""Local filesystem storage backend."""
+
+from pathlib import Path
+from typing import Iterable, Optional
+
+from ..storage import ObjRef, Storage
+from .. import telemetry
+
+
+class LocalFSStorage(Storage):
+    backend = "local"
+
+    def __init__(self, conf: dict | None = None) -> None:
+        prefix = (conf or {}).get("prefix", "dr_rd")
+        self.root = Path(f".{prefix}")
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def _resolve(self, key: str) -> Path:
+        return self.root / key
+
+    def write_bytes(self, key: str, data: bytes, *, content_type: str = "application/octet-stream") -> ObjRef:
+        path = self._resolve(key)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(data)
+        telemetry.storage_write(self.backend, key, len(data))
+        return ObjRef(key=key, size=len(data))
+
+    def read_bytes(self, key: str) -> bytes:
+        path = self._resolve(key)
+        data = path.read_bytes()
+        telemetry.storage_read(self.backend, key, len(data))
+        return data
+
+    def exists(self, key: str) -> bool:
+        return self._resolve(key).exists()
+
+    def list(self, prefix: str) -> Iterable[ObjRef]:
+        base = self._resolve(prefix)
+        if not base.exists():
+            return []
+        refs: list[ObjRef] = []
+        for p in base.rglob("*"):
+            if p.is_file():
+                rel = p.relative_to(self.root).as_posix()
+                refs.append(ObjRef(key=rel, size=p.stat().st_size))
+        return refs
+
+    def delete(self, key: str) -> None:
+        try:
+            self._resolve(key).unlink()
+        except FileNotFoundError:
+            pass
+
+    def url_for(self, key: str, ttl_sec: int) -> Optional[str]:
+        return None

--- a/utils/storage_backends/s3.py
+++ b/utils/storage_backends/s3.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+"""S3 storage backend (thin wrapper around boto3)."""
+
+from typing import Iterable, Optional
+
+try:
+    import boto3  # type: ignore
+except Exception:  # pragma: no cover - optional
+    boto3 = None
+
+from ..storage import ObjRef, Storage
+from .. import telemetry
+from .. import secrets
+
+
+class S3Storage(Storage):
+    backend = "s3"
+
+    def __init__(self, conf: dict | None = None) -> None:
+        if boto3 is None:  # pragma: no cover - optional
+            raise RuntimeError("boto3 not installed")
+        conf = conf or {}
+        self.bucket = conf.get("bucket") or secrets.get("S3_BUCKET") or ""
+        self.prefix = conf.get("prefix", "dr_rd")
+        self.ttl = int(conf.get("signed_url_ttl_sec", 600))
+        session = boto3.session.Session(
+            aws_access_key_id=secrets.get("AWS_ACCESS_KEY_ID"),
+            aws_secret_access_key=secrets.get("AWS_SECRET_ACCESS_KEY"),
+            region_name=secrets.get("AWS_REGION"),
+        )
+        endpoint = secrets.get("S3_ENDPOINT_URL")
+        self.client = session.client("s3", endpoint_url=endpoint)  # type: ignore
+
+    def _full_key(self, key: str) -> str:
+        return f"{self.prefix}/{key}" if self.prefix else key
+
+    def write_bytes(self, key: str, data: bytes, *, content_type: str = "application/octet-stream") -> ObjRef:
+        fk = self._full_key(key)
+        self.client.put_object(Bucket=self.bucket, Key=fk, Body=data, ContentType=content_type)  # type: ignore
+        telemetry.storage_write(self.backend, key, len(data))
+        return ObjRef(key=key, size=len(data))
+
+    def read_bytes(self, key: str) -> bytes:
+        fk = self._full_key(key)
+        resp = self.client.get_object(Bucket=self.bucket, Key=fk)  # type: ignore
+        data = resp["Body"].read()
+        telemetry.storage_read(self.backend, key, len(data))
+        return data
+
+    def exists(self, key: str) -> bool:
+        fk = self._full_key(key)
+        try:
+            self.client.head_object(Bucket=self.bucket, Key=fk)  # type: ignore
+            return True
+        except Exception:
+            return False
+
+    def list(self, prefix: str) -> Iterable[ObjRef]:
+        fk = self._full_key(prefix)
+        paginator = self.client.get_paginator("list_objects_v2")  # type: ignore
+        for page in paginator.paginate(Bucket=self.bucket, Prefix=fk):
+            for obj in page.get("Contents", []):
+                key = obj["Key"][len(self.prefix) + 1 :] if self.prefix else obj["Key"]
+                yield ObjRef(key=key, size=obj.get("Size"))
+
+    def delete(self, key: str) -> None:
+        fk = self._full_key(key)
+        self.client.delete_object(Bucket=self.bucket, Key=fk)  # type: ignore
+
+    def url_for(self, key: str, ttl_sec: int) -> Optional[str]:
+        fk = self._full_key(key)
+        try:
+            return self.client.generate_presigned_url(  # type: ignore
+                "get_object",
+                Params={"Bucket": self.bucket, "Key": fk},
+                ExpiresIn=ttl_sec,
+            )
+        except Exception:  # pragma: no cover - best effort
+            return None

--- a/utils/telemetry.py
+++ b/utils/telemetry.py
@@ -509,3 +509,15 @@ __all__ = [
     "notifications_saved",
     "notification_test_sent",
 ]
+
+
+def storage_write(backend: str, key: str, bytes: int) -> None:
+    log_event({"event": "storage_write", "backend": backend, "key": key, "bytes": bytes})
+
+
+def storage_read(backend: str, key: str, bytes: int) -> None:
+    log_event({"event": "storage_read", "backend": backend, "key": key, "bytes": bytes})
+
+
+def storage_error(backend: str, key: str, op: str, reason: str) -> None:
+    log_event({"event": "storage_error", "backend": backend, "key": key, "op": op, "reason": reason})


### PR DESCRIPTION
## Summary
- introduce generic `utils.storage` interface and pluggable backends
- implement local filesystem backend and wire paths to use storage keys
- add storage preference defaults, telemetry events, settings page, migration script, and docs

## Testing
- `pytest tests/test_storage_local.py tests/test_storage_s3.py tests/test_storage_gcs.py`
- `python scripts/generate_repo_map.py`

------
https://chatgpt.com/codex/tasks/task_e_68b33f17c320832cb54c04438752d67f