### PR TITLE
feat: add lightweight RAG index and citations

### DIFF
--- a/app/ui/knowledge.py
+++ b/app/ui/knowledge.py
@@ -12,8 +12,9 @@ def _fmt_size(size: int) -> str:
 def table(items: list[dict]):
     removed: list[str] = []
     tag_updates: dict[str, list[str]] = {}
+    reindex: list[str] = []
     for it in items:
-        cols = st.columns([3, 1, 1, 2, 2, 1, 1])
+        cols = st.columns([3, 1, 1, 2, 2, 1, 1, 1])
         cols[0].write(it["name"])
         if it.get("pii_flag"):
             cols[0].caption("Possible PII detected")
@@ -23,11 +24,13 @@ def table(items: list[dict]):
         if new_tags != it.get("tags", []):
             tag_updates[it["id"]] = new_tags
         cols[4].write(datetime.fromtimestamp(it["created_at"]).strftime("%Y-%m-%d %H:%M"))
-        if cols[5].button("Remove", key=f"rm_{it['id']}"):
+        if cols[5].button("Reindex", key=f"rx_{it['id']}"):
+            reindex.append(it["id"])
+        if cols[6].button("Remove", key=f"rm_{it['id']}"):
             removed.append(it["id"])
         with open(it["path"], "rb") as fh:
-            cols[6].download_button("Download", fh, file_name=it["name"], key=f"dl_{it['id']}")
-    return removed, tag_updates
+            cols[7].download_button("Download", fh, file_name=it["name"], key=f"dl_{it['id']}")
+    return removed, tag_updates, reindex
 
 
 def uploader():

--- a/app/ui/trace_viewer.py
+++ b/app/ui/trace_viewer.py
@@ -212,6 +212,11 @@ def render_trace(
                         st.json(raw)
                     else:
                         st.code("" if raw is None else str(raw), language=None)
+                if step.get("citations"):
+                    with st.expander("Sources"):
+                        for c in step.get("citations", []):
+                            st.markdown(
+                                f"- Doc {c.get('doc_id')} — {c.get('snippet','')}")
 
     if not show_all and shown < len(filtered_steps):
         if st.button("Load more", key=f"more_{run_id}", use_container_width=True):

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T18:16:59.780607Z from commit 5f341d3_
+_Last generated at 2025-08-30T18:23:32.671079Z from commit b127914_

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T18:16:59.780607Z'
-git_sha: 5f341d37c438d61a6747fd603e310ba7eb58a6eb
+generated_at: '2025-08-30T18:23:32.671079Z'
+git_sha: b127914e6d4da9eeb1d8c0c3f648c15ba4734a9e
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -191,14 +191,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/plan_utils.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/spec_builder.py
+- path: orchestrators/app_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -212,7 +205,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
+- path: orchestrators/spec_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/plan_utils.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -226,14 +226,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
+- path: core/summarization/integrator.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,0 +1,21 @@
+import os
+import pytest
+
+from utils.embeddings import embed_texts
+
+
+def test_openai_no_key(monkeypatch):
+    if os.getenv("OPENAI_API_KEY"):
+        pytest.skip("OPENAI_API_KEY set")
+    out = embed_texts(["hi"], provider="openai", model="x")
+    assert out is None
+
+
+def test_local_no_pkg():
+    try:
+        import sentence_transformers  # type: ignore
+        pytest.skip("sentence_transformers installed")
+    except Exception:
+        pass
+    out = embed_texts(["hi"], provider="local", model="")
+    assert out is None

--- a/tests/test_rag_index.py
+++ b/tests/test_rag_index.py
@@ -1,0 +1,24 @@
+import sqlite3
+
+from utils.rag import index, textsplit, search
+
+def setup_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(index, "ROOT", tmp_path)
+    monkeypatch.setattr(index, "DB", tmp_path / "test.sqlite")
+    index.init()
+
+
+def test_upsert_and_search(tmp_path, monkeypatch):
+    setup_db(tmp_path, monkeypatch)
+    text = "hello world\nthis is a test"
+    chunks = textsplit.split(text, size=10, overlap=0)
+    index.upsert_document("doc1", {"name": "d1", "tags": [], "path": ""}, chunks)
+    with index._conn() as c:
+        docs = c.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
+        ch = c.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
+        fts = c.execute("SELECT COUNT(*) FROM chunks_fts").fetchone()[0]
+    assert docs == 1
+    assert ch == len(chunks)
+    assert fts == len(chunks)
+    res = search.keyword_search("hello")
+    assert res and res[0]["chunk_id"] == "doc1:0"

--- a/tests/test_rag_search.py
+++ b/tests/test_rag_search.py
@@ -1,0 +1,29 @@
+from utils.rag import index, search, textsplit
+
+
+def setup_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(index, "ROOT", tmp_path)
+    monkeypatch.setattr(index, "DB", tmp_path / "test.sqlite")
+    index.init()
+
+
+def test_hybrid_merges(tmp_path, monkeypatch):
+    setup_db(tmp_path, monkeypatch)
+    chunks1 = textsplit.split("alpha beta", size=50, overlap=0)
+    chunks2 = textsplit.split("beta gamma", size=50, overlap=0)
+
+    def emb1(chs):
+        return [[0.0, 1.0] for _ in chs]
+
+    def emb2(chs):
+        return [[1.0, 0.0] for _ in chs]
+
+    index.upsert_document("d1", {"name": ""}, chunks1, embedder=emb1)
+    index.upsert_document("d2", {"name": ""}, chunks2, embedder=emb2)
+
+    kw = search.keyword_search("alpha")
+    assert kw and kw[0]["chunk_id"] == "d1:0"
+
+    res = search.hybrid("alpha", [1.0, 0.0], k=2)
+    ids = {r["chunk_id"] for r in res}
+    assert {"d1:0", "d2:0"} <= ids

--- a/utils/embeddings.py
+++ b/utils/embeddings.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Iterable, List, Optional
+
+from utils.lazy_import import local_import
+from utils.secrets import get as get_secret
+
+
+def embed_texts(texts: Iterable[str], *, provider: str, model: str) -> Optional[list[list[float]]]:
+    """
+    Returns list of vectors or None if embeddings unavailable. Never raises on missing deps.
+    provider: "openai" uses OPENAI_API_KEY; "local" uses sentence-transformers if installed; else None.
+    """
+    texts = list(texts)
+    if provider == "openai":
+        key = get_secret("OPENAI_API_KEY")
+        if not key:
+            return None
+        try:
+            openai = local_import("openai")
+            client = openai.OpenAI(api_key=key)  # lazy
+            out = client.embeddings.create(model=model, input=texts)
+            return [d.embedding for d in out.data]
+        except Exception:
+            return None
+    if provider == "local":
+        try:
+            st = local_import("sentence_transformers")
+            model = st.SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")
+            return model.encode(texts, normalize_embeddings=True).tolist()
+        except Exception:
+            return None
+    return None

--- a/utils/prefs.py
+++ b/utils/prefs.py
@@ -52,11 +52,22 @@ DEFAULT_PREFS: dict[str, Any] = {
     },
     "storage": {"backend": "local", "bucket": "", "prefix": "dr_rd", "signed_url_ttl_sec": 600},
 
+    "retrieval": {
+        "enabled": True,
+        "top_k": 4,
+        "chunk_size": 800,
+        "chunk_overlap": 120,
+        "use_embeddings": True,
+        "embedding_provider": "openai",
+        "embedding_model": "text-embedding-3-small",
+        "max_chars_per_doc": 200000,
+    },
+
 
 
 }
 
-_ALLOWED_SECTIONS = {"defaults", "ui", "privacy", "notifications", "storage", "version"}
+_ALLOWED_SECTIONS = {"defaults", "ui", "privacy", "notifications", "storage", "retrieval", "version"}
 
 
 def _validate(raw: Mapping[str, Any] | None) -> dict:
@@ -120,7 +131,7 @@ def _validate(raw: Mapping[str, Any] | None) -> dict:
         for k, v in np["events"].items():
             events[k] = bool(raw_ev.get(k, v))
         np["events"] = events
-    for section in ("defaults", "ui", "privacy"):
+    for section in ("defaults", "ui", "privacy", "retrieval"):
         raw_section = raw.get(section)
         if not isinstance(raw_section, Mapping):
             continue

--- a/utils/rag/__init__.py
+++ b/utils/rag/__init__.py
@@ -1,0 +1,1 @@
+"""Lightweight RAG utilities: text splitting, indexing, search."""

--- a/utils/rag/index.py
+++ b/utils/rag/index.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+ROOT = Path(".dr_rd/index")
+ROOT.mkdir(parents=True, exist_ok=True)
+DB = ROOT / "knowledge.sqlite"
+
+DDL = """
+PRAGMA journal_mode=WAL;
+CREATE TABLE IF NOT EXISTS documents (id TEXT PRIMARY KEY, name TEXT, tags TEXT, item_path TEXT, created_at REAL);
+CREATE TABLE IF NOT EXISTS chunks (id TEXT PRIMARY KEY, doc_id TEXT, ord INTEGER, text TEXT);
+CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts USING fts5(text, content='chunks', content_rowid='rowid');
+CREATE TABLE IF NOT EXISTS embeddings (chunk_id TEXT PRIMARY KEY, vec TEXT);
+"""
+
+
+def _conn():
+    c = sqlite3.connect(DB)
+    c.execute("PRAGMA foreign_keys=ON")
+    return c
+
+
+def init() -> None:
+    c = _conn()
+    for stmt in filter(None, DDL.split(";")):
+        s = stmt.strip()
+        if s:
+            c.execute(s)
+    c.commit()
+    c.close()
+
+
+def upsert_document(doc_id: str, meta: Dict[str, Any], chunks: Iterable[str], *, embedder=None) -> int:
+    """
+    meta: {'name':..., 'tags': [...], 'path': ...}
+    embedder: callable(list[str]) -> list[list[float]] | None
+    """
+    init()
+    chunks = list(chunks)
+    now = time.time()
+    with _conn() as c:
+        c.execute(
+            "INSERT OR REPLACE INTO documents(id,name,tags,item_path,created_at) VALUES(?,?,?,?,?)",
+            (doc_id, meta.get("name", ""), json.dumps(meta.get("tags", [])), meta.get("path", ""), now),
+        )
+        # remove existing chunks and fts entries
+        c.execute(
+            "DELETE FROM chunks_fts WHERE rowid IN (SELECT rowid FROM chunks WHERE doc_id=?)",
+            (doc_id,),
+        )
+        c.execute("DELETE FROM chunks WHERE doc_id=?", (doc_id,))
+        # remove old embeddings
+        c.execute("DELETE FROM embeddings WHERE chunk_id LIKE ?", (f"{doc_id}:%",))
+        # insert chunks
+        for i, t in enumerate(chunks):
+            cid = f"{doc_id}:{i}"
+            cur = c.execute(
+                "INSERT OR REPLACE INTO chunks(id,doc_id,ord,text) VALUES(?,?,?,?)",
+                (cid, doc_id, i, t),
+            )
+            rowid = cur.lastrowid
+            c.execute("INSERT INTO chunks_fts(rowid, text) VALUES(?, ?)", (rowid, t))
+        # embeddings
+        if embedder:
+            vecs = embedder(chunks) or []
+            if vecs:
+                rows = [(f"{doc_id}:{i}", json.dumps(vec)) for i, vec in enumerate(vecs)]
+                c.executemany(
+                    "INSERT OR REPLACE INTO embeddings(chunk_id, vec) VALUES(?, ?)",
+                    rows,
+                )
+    return len(chunks)

--- a/utils/rag/search.py
+++ b/utils/rag/search.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+import math
+from typing import Any, Dict, List
+
+from .index import _conn
+
+
+def keyword_search(query: str, limit: int = 20) -> List[Dict[str, Any]]:
+    with _conn() as c:
+        rows = c.execute(
+            "SELECT chunks.id, chunks.doc_id, bm25(chunks_fts) AS score, chunks.text "
+            "FROM chunks_fts JOIN chunks ON chunks_fts.rowid = chunks.rowid "
+            "WHERE chunks_fts MATCH ? ORDER BY score LIMIT ?",
+            (query, limit),
+        ).fetchall()
+    return [
+        {"chunk_id": r[0], "doc_id": r[1], "score": float(r[2]), "text": r[3]} for r in rows
+    ]
+
+
+def embed_search(query_vec: list[float], limit: int = 20) -> List[Dict[str, Any]]:
+    with _conn() as c:
+        rows = c.execute("SELECT chunk_id, vec FROM embeddings").fetchall()
+    scored = []
+    for cid, vec_json in rows:
+        v = json.loads(vec_json)
+        dot = sum(a * b for a, b in zip(query_vec, v))
+        na = math.sqrt(sum(a * a for a in query_vec)) or 1.0
+        nb = math.sqrt(sum(b * b for b in v)) or 1.0
+        scored.append((cid, dot / (na * nb)))
+    scored.sort(key=lambda x: x[1], reverse=True)
+    out = []
+    with _conn() as c:
+        for cid, s in scored[:limit]:
+            row = c.execute("SELECT doc_id, text FROM chunks WHERE id=?", (cid,)).fetchone()
+            if row:
+                out.append(
+                    {
+                        "chunk_id": cid,
+                        "doc_id": row[0],
+                        "score": float(s),
+                        "text": row[1],
+                    }
+                )
+    return out
+
+
+def hybrid(query: str, query_vec: list[float] | None, k: int = 4) -> List[Dict[str, Any]]:
+    kw = keyword_search(query, limit=max(20, k * 5))
+    if query_vec is None:
+        return kw[:k]
+    emb = embed_search(query_vec, limit=max(20, k * 5))
+
+    def rrf(rank: int) -> float:
+        return 1.0 / (50.0 + rank)
+
+    combined: list[tuple[str, float, Dict[str, Any]]] = []
+    seen: set[str] = set()
+    for L in (kw, emb):
+        for r, item in enumerate(L):
+            key = item["chunk_id"]
+            if key not in seen:
+                seen.add(key)
+                combined.append((key, rrf(r + 1), item))
+            else:
+                for j, (k2, score, it2) in enumerate(combined):
+                    if k2 == key:
+                        combined[j] = (k2, score + rrf(r + 1), it2)
+                        break
+    combined.sort(key=lambda x: x[1], reverse=True)
+    return [it for _, __, it in combined[:k]]

--- a/utils/rag/textsplit.py
+++ b/utils/rag/textsplit.py
@@ -1,0 +1,18 @@
+import re, textwrap
+
+def clean(text: str) -> str:
+    s = text.replace("\x00", "")
+    s = re.sub(r"\s+\n", "\n", s)
+    return s.strip()
+
+def split(text: str, *, size=800, overlap=120) -> list[str]:
+    text = clean(text)
+    chunks, i = [], 0
+    while i < len(text):
+        j = min(len(text), i + size)
+        k = text.rfind("\n", i + int(size * 0.6), j)
+        if k == -1:
+            k = j
+        chunks.append(text[i:k].strip())
+        i = max(k - overlap, i + 1)
+    return [c for c in chunks if c]

--- a/utils/report_builder.py
+++ b/utils/report_builder.py
@@ -108,6 +108,17 @@ def build_markdown_report(
     lines.append(trace_table(rows))
     lines.append("")
 
+    citations: list[str] = []
+    for step in trace:
+        for c in step.get("citations", []) or []:
+            snippet = (c.get("snippet", "") or "").replace("\n", " ")[:120]
+            citations.append(f"Doc {c.get('doc_id')} — {snippet}")
+    if citations:
+        lines.append("## Sources")
+        for c in citations:
+            lines.append(f"- {c}")
+        lines.append("")
+
     errors = [step for step in trace if step.get("status") == "error"]
     if errors:
         lines.append("## Errors")

--- a/utils/telemetry.py
+++ b/utils/telemetry.py
@@ -471,6 +471,22 @@ def notifications_saved(channels: list[str], events_count: int) -> None:
 
 def notification_test_sent(channel: str, ok: bool) -> None:
     log_event({"event": "notification_test_sent", "channel": channel, "ok": bool(ok)})
+
+
+def index_built(items: int, chunks: int) -> None:
+    log_event({"event": "index_built", "items": items, "chunks": chunks})
+
+
+def item_reindexed(id: str, chunks: int) -> None:
+    log_event({"event": "item_reindexed", "id": id, "chunks": chunks})
+
+
+def retrieval_query(q_len: int) -> None:
+    log_event({"event": "retrieval_query", "q_len": q_len})
+
+
+def retrieval_used(run_id: str, step_id: str, k: int, provider: str) -> None:
+    log_event({"event": "retrieval_used", "run_id": run_id, "step_id": step_id, "k": k, "provider": provider})
 __all__ = [
     "log_event",
     "list_files",
@@ -494,10 +510,14 @@ __all__ = [
     "knowledge_added",
     "knowledge_removed",
     "knowledge_tags_updated",
+    "index_built",
+    "item_reindexed",
     "safety_warned",
     "safety_blocked",
     "safety_flagged_step",
     "safety_export_blocked",
+    "retrieval_query",
+    "retrieval_used",
     "history_filter_changed",
     "history_export_clicked",
     "run_annotated",

--- a/utils/trace_export.py
+++ b/utils/trace_export.py
@@ -35,6 +35,7 @@ def flatten_trace_rows(trace: Sequence[TraceStep]) -> list[dict]:
                 "tokens": step.get("tokens"),
                 "cost": step.get("cost"),
                 "summary": step.get("summary"),
+                "citations": step.get("citations"),
             }
         )
     return rows
@@ -64,6 +65,7 @@ def to_csv(
         "tokens",
         "cost",
         "summary_80chars",
+        "citations_json",
     ])
     for row in rows:
         writer.writerow([
@@ -76,6 +78,7 @@ def to_csv(
             row.get("tokens"),
             row.get("cost"),
             _safe_summary(sanitizer(row.get("summary")) if sanitizer else row.get("summary")),
+            json.dumps(row.get("citations", []), ensure_ascii=False),
         ])
     return output.getvalue().encode("utf-8")
 


### PR DESCRIPTION
## Summary
- add pluggable embeddings wrapper with OpenAI and local fallbacks
- implement SQLite FTS5 knowledge index, text splitter, and hybrid search
- expose knowledge ingestion and UI controls with citation export and telemetry hooks

## Testing
- `python -m pytest tests/test_embeddings.py tests/test_rag_index.py tests/test_rag_search.py`
- `python scripts/generate_repo_map.py`

------
https://chatgpt.com/codex/tasks/task_e_68b340cf824c832ca5b96f6fd6a6aadd