### PR TITLE
Add trace graph viewer with critical path analysis

### DIFF
--- a/app/ui/graph.py
+++ b/app/ui/graph.py
@@ -1,0 +1,8 @@
+import streamlit as st
+
+def render_dot(dot: str, *, height: int = 520):
+    """Render a Graphviz DOT string in Streamlit."""
+    try:
+        st.graphviz_chart(dot, use_container_width=True, height=height)
+    except Exception:
+        st.code(dot, language="dot")

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T18:37:22.237985Z from commit 8ffc0f7_
+_Last generated at 2025-08-30T18:58:12.660200Z from commit c89a50a_

--- a/pages/13_Graph.py
+++ b/pages/13_Graph.py
@@ -1,0 +1,88 @@
+"""Trace Graph viewer."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+import streamlit as st
+
+try:  # thin import; avoid heavy failures
+    from app.ui.graph import render_dot
+except Exception:  # pragma: no cover
+    def render_dot(dot: str, *, height: int = 520) -> None:  # type: ignore
+        st.code(dot, language="dot")
+
+from utils.graph.trace_graph import build_graph, critical_path, to_dot
+try:
+    from utils.paths import artifact_path
+except Exception:  # pragma: no cover
+    from pathlib import Path
+
+    def artifact_path(run_id: str, name: str, ext: str) -> Path:
+        return Path(".dr_rd") / "runs" / run_id / f"{name}.{ext}"
+
+try:
+    from utils.runs import list_runs, last_run_id
+except Exception:  # pragma: no cover
+    def list_runs(limit: int = 100) -> list:  # type: ignore
+        return []
+
+    def last_run_id() -> str | None:  # type: ignore
+        return None
+
+from utils.trace_export import flatten_trace_rows
+from utils.telemetry import log_event, graph_view_opened, graph_export_clicked
+
+st.title("Trace Graph")
+log_event({"event": "nav_page_view", "page": "graph"})
+
+runs = list_runs(limit=100)
+if not runs:
+    st.info("No runs found.")
+else:
+    labels = {
+        r["run_id"]: f"{r['run_id']} — {datetime.fromtimestamp(r['started_at']).isoformat()}" for r in runs
+    }
+    options = list(labels.keys())
+    run_id = last_run_id() or (options[0] if options else "")
+    index = options.index(run_id) if run_id in options else 0
+    selected = st.selectbox("Run", options, index=index, format_func=lambda x: labels[x])
+    run_id = selected
+
+    trace_path = artifact_path(run_id, "trace", "json")
+    trace = json.loads(trace_path.read_text("utf-8")) if trace_path.exists() else []
+    rows = flatten_trace_rows(trace)
+
+    nodes, edges = build_graph(rows)
+    phases = sorted({n.phase for n in nodes if n.phase})
+    sel_phases = st.multiselect("Phases", phases, default=phases)
+    show_data = st.checkbox("Show data edges", value=True)
+    hi_cp = st.checkbox("Highlight critical path", value=False)
+
+    nodes = [n for n in nodes if n.phase in sel_phases]
+    node_ids = {n.id for n in nodes}
+    edges = [e for e in edges if e.src in node_ids and e.dst in node_ids and (show_data or e.kind != "data")]
+
+    highlight = critical_path(nodes, edges) if hi_cp else []
+    dot = to_dot(nodes, edges, highlight=highlight)
+    render_dot(dot)
+
+    graph_view_opened(run_id)
+
+    col1, col2 = st.columns(2)
+    with col1:
+        if st.download_button("Download .dot", dot, file_name=f"{run_id}_graph.dot", mime="text/vnd.graphviz"):
+            graph_export_clicked(run_id, "dot")
+    with col2:
+        png_bytes = None
+        try:
+            import graphviz
+
+            png_bytes = graphviz.Source(dot).pipe(format="png")
+        except Exception:
+            png_bytes = None
+        if png_bytes and st.download_button(
+            "Download .png", png_bytes, file_name=f"{run_id}_graph.png", mime="image/png"
+        ):
+            graph_export_clicked(run_id, "png")

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T18:37:22.237985Z'
-git_sha: 8ffc0f7d4d182cbbaed6e2bf858c8fa43d3aad29
+generated_at: '2025-08-30T18:58:12.660200Z'
+git_sha: c89a50abb1e5fb123d05ad6a4abc41f5a0424c03
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -184,7 +184,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/__init__.py
+- path: orchestrators/plan_utils.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -198,20 +198,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/spec_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/plan_utils.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/qa_router.py
   role: Orchestrator
   responsibilities: []
@@ -219,8 +205,15 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/__init__.py
-  role: Summarization
+- path: orchestrators/__init__.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/spec_builder.py
+  role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
@@ -234,6 +227,13 @@ modules:
   invoked_by: []
   invokes: []
 - path: core/summarization/schemas.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_graph_page_import.py
+++ b/tests/test_graph_page_import.py
@@ -1,0 +1,9 @@
+import importlib.util
+from pathlib import Path
+
+
+def test_import_graph_page():
+    path = Path("pages/13_Graph.py")
+    spec = importlib.util.spec_from_file_location("graph_page", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[attr-defined]

--- a/tests/test_trace_graph.py
+++ b/tests/test_trace_graph.py
@@ -1,0 +1,21 @@
+from utils.graph.trace_graph import build_graph, critical_path, to_dot
+
+
+def test_build_and_critical_path():
+    trace = [
+        {"i": 1, "phase": "plan", "name": "a", "status": "success", "duration_ms": 10},
+        {"i": 2, "phase": "plan", "name": "b", "status": "success", "duration_ms": 20},
+        {"i": 3, "phase": "exec", "name": "c", "status": "warn", "duration_ms": 30, "parents": ["s2"]},
+        {"i": 4, "phase": "exec", "name": "d", "status": "error", "duration_ms": 40},
+        {"i": 5, "phase": "synth", "name": "e", "status": "success", "duration_ms": 50, "parents": ["s4"]},
+    ]
+    nodes, edges = build_graph(trace)
+    assert len(nodes) == 5
+    assert len(edges) == 4
+
+    path = critical_path(nodes, edges)
+    assert path == ["s1", "s2", "s3", "s4", "s5"]
+
+    dot = to_dot(nodes, edges, highlight=path)
+    assert "label=\"plan\"" in dot
+    assert "\"s3\"" in dot

--- a/utils/graph/__init__.py
+++ b/utils/graph/__init__.py
@@ -1,0 +1,1 @@
+# Utilities for graph processing

--- a/utils/graph/trace_graph.py
+++ b/utils/graph/trace_graph.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+from typing import List, Dict, Any, Tuple, Iterable, Optional
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class Node:
+    id: str
+    label: str
+    phase: str
+    status: str
+    dur_ms: int
+
+@dataclass(frozen=True)
+class Edge:
+    src: str
+    dst: str
+    kind: str  # "seq" | "data"
+
+STATUS_COLOR = {
+    "success": "#16a34a",
+    "warn":    "#d97706",
+    "error":   "#dc2626",
+    "cancelled":"#6b7280",
+    "timeout": "#9333ea",
+    "running": "#0ea5e9",
+    "unknown": "#64748b",
+}
+
+def build_graph(rows: List[Dict[str, Any]]) -> Tuple[List[Node], List[Edge]]:
+    """
+    rows: flatten_trace_rows(trace) items with keys:
+      i, id?, phase, name, status, duration_ms, parents? (list[str])
+    If 'id' missing, synthesize 's{i}'. If 'parents' missing, add sequential edges within each phase.
+    """
+    nodes: List[Node] = []
+    edges: List[Edge] = []
+    # Build nodes
+    for r in rows:
+        sid = str(r.get("id") or f"s{r['i']}")
+        status = str(r.get("status") or "unknown")
+        nodes.append(Node(
+            id=sid,
+            label=f"{r.get('name','step')}\\n{int(r.get('duration_ms',0))/1000:.1f}s",
+            phase=str(r.get("phase","")),
+            status=status,
+            dur_ms=int(r.get("duration_ms",0)),
+        ))
+    # Index by phase for sequential edges
+    by_phase: Dict[str, List[Node]] = {}
+    for n in nodes:
+        by_phase.setdefault(n.phase, []).append(n)
+    for ph, L in by_phase.items():
+        L.sort(key=lambda n: int(n.id.replace("s","")) if n.id.startswith("s") else 0)
+        for a, b in zip(L, L[1:]):
+            edges.append(Edge(src=a.id, dst=b.id, kind="seq"))
+    # Explicit parents if present
+    id_map = {n.id: n for n in nodes}
+    for r in rows:
+        sid = str(r.get("id") or f"s{r['i']}")
+        for p in r.get("parents", []) or []:
+            if p in id_map:
+                edges.append(Edge(src=p, dst=sid, kind="data"))
+    return nodes, edges
+
+def critical_path(nodes: List[Node], edges: List[Edge]) -> List[str]:
+    """
+    Longest-duration path (ms) in DAG. If cycles exist, ignore offending edges.
+    Returns list of node ids on the critical path in order.
+    """
+    # Topo sort
+    adj: Dict[str, List[str]] = {}
+    indeg: Dict[str, int] = {n.id: 0 for n in nodes}
+    for e in edges:
+        adj.setdefault(e.src, []).append(e.dst)
+        if e.dst in indeg: indeg[e.dst] += 1
+    q = [nid for nid, d in indeg.items() if d == 0]
+    order: List[str] = []
+    while q:
+        u = q.pop(0)
+        order.append(u)
+        for v in adj.get(u, []):
+            indeg[v] -= 1
+            if indeg[v] == 0: q.append(v)
+    # DP longest path by dur_ms
+    dur = {n.id: n.dur_ms for n in nodes}
+    best = {nid: (dur.get(nid,0), None) for nid in order}  # (cost, prev)
+    for u in order:
+        for v in adj.get(u, []):
+            cand = best[u][0] + dur.get(v,0)
+            if cand > best.get(v,(0,None))[0]:
+                best[v] = (cand, u)
+    # Pick end with max cost
+    end = max(best.items(), key=lambda kv: kv[0] in order and kv[1][0] or 0)[0]
+    # Reconstruct
+    path = []
+    cur = end
+    seen = set()
+    while cur and cur not in seen:
+        path.append(cur); seen.add(cur)
+        cur = best.get(cur,(0,None))[1]
+    path.reverse()
+    return path
+
+def to_dot(nodes: List[Node], edges: List[Edge], *, highlight: Iterable[str] = ()) -> str:
+    hi = set(highlight or [])
+    lines = ["digraph G {", 'rankdir=LR;', 'node [shape=box, style="rounded,filled", fontname="Inter,Arial"];']
+    # clusters by phase
+    by_phase: Dict[str, List[Node]] = {}
+    for n in nodes: by_phase.setdefault(n.phase or "phase", []).append(n)
+    for i,(ph,L) in enumerate(by_phase.items()):
+        lines.append(f'subgraph cluster_{i} {{ label="{ph}"; color="#e5e7eb";')
+        for n in L:
+            col = STATUS_COLOR.get(n.status, STATUS_COLOR["unknown"])
+            pen = "#111827" if n.id in hi else "#6b7280"
+            lines.append(f'"{n.id}" [label="{n.label}", fillcolor="{col}22", color="{pen}"];')
+        lines.append("}")
+    for e in edges:
+        style = "bold" if e.kind == "data" else "solid"
+        color = "#64748b" if e.kind == "seq" else "#0ea5e9"
+        lines.append(f'"{e.src}" -> "{e.dst}" [color="{color}", style="{style}"];')
+    lines.append("}")
+    return "\n".join(lines)

--- a/utils/telemetry.py
+++ b/utils/telemetry.py
@@ -435,6 +435,16 @@ def history_export_clicked(count: int) -> None:
     log_event({"event": "history_export_clicked", "count": count})
 
 
+def graph_view_opened(run_id: str) -> None:
+    """Emit a graph_view_opened telemetry event."""
+    log_event({"event": "graph_view_opened", "run_id": run_id})
+
+
+def graph_export_clicked(run_id: str, fmt: str) -> None:
+    """Emit a graph_export_clicked telemetry event."""
+    log_event({"event": "graph_export_clicked", "run_id": run_id, "format": fmt})
+
+
 def run_annotated(
     run_id: str, title_len: int, tags_count: int, note_len: int, favorite: bool
 ) -> None:
@@ -542,6 +552,8 @@ __all__ = [
     "retrieval_used",
     "history_filter_changed",
     "history_export_clicked",
+    "graph_view_opened",
+    "graph_export_clicked",
     "run_annotated",
     "run_favorited",
     "eval_started",

--- a/utils/trace_export.py
+++ b/utils/trace_export.py
@@ -21,13 +21,16 @@ def _safe_summary(text: str | None, max_len: int = 80) -> str:
 def flatten_trace_rows(trace: Sequence[TraceStep]) -> list[dict]:
     """Return normalized rows for tabular exports.
 
-    Each row contains the fields: i, phase, name, status, duration_ms, tokens, cost, summary.
+    Each row contains the fields: i, id, parents, phase, name, status,
+    duration_ms, tokens, cost, summary, citations.
     """
     rows: list[dict] = []
     for idx, step in enumerate(trace, 1):
         rows.append(
             {
                 "i": idx,
+                "id": step.get("id"),
+                "parents": step.get("parent_ids") or step.get("parents"),
                 "phase": step.get("phase"),
                 "name": step.get("name"),
                 "status": step.get("status"),


### PR DESCRIPTION
## Summary
- Build DAG from trace rows and compute critical path
- Expose run graph in Streamlit with phase filtering and export options
- Emit graph view/export telemetry events

## Testing
- `pytest tests/test_trace_graph.py tests/test_graph_page_import.py`
- `python scripts/generate_repo_map.py`

------
https://chatgpt.com/codex/tasks/task_e_68b34887b178832c90b10ad81bae760e