### PR TITLE
Add profile management utilities

### DIFF
--- a/docs/PROFILES.md
+++ b/docs/PROFILES.md
@@ -1,0 +1,16 @@
+# Profiles
+
+Profiles let you save named presets for the run form so common settings are one click away. Each profile stores only non‑secret knobs such as mode, provider/model, budgets, token limits, retrieval and safety flags, knowledge source IDs, and feature flags.
+
+## Managing Profiles
+- **Create:** Configure the run form then use *Save current as profile* and supply a name.
+- **Apply:** Pick a profile from the dropdown on the main page or from the Profiles page. Applying a profile updates form fields but never overwrites free‑text idea inputs.
+- **Delete / Rename / Edit:** Visit the Profiles page from the sidebar to manage existing profiles. Edits use a raw JSON view with validation.
+- **Default:** Set a profile as default from the Profiles page. The default (or last used) profile preselects on next load.
+
+## Query Parameter and CLI
+- The main page accepts `?profile=name` to prefill the run form for reproducible links.
+- The CLI supports `--profile NAME` which applies the profile before other flags.
+
+## Tips
+Create multiple presets such as **fast-mini** for quick inexpensive runs, **quality-sonnet** for higher quality results, or **strict-safety** when reviewing sensitive content.

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T19:10:11.536374Z from commit 66027f9_
+_Last generated at 2025-08-30T19:47:08.274774Z from commit 200558b_

--- a/pages/16_Profiles.py
+++ b/pages/16_Profiles.py
@@ -1,0 +1,67 @@
+import json
+import time
+
+import streamlit as st
+
+from utils import prefs, profiles
+from utils.telemetry import (
+    log_event,
+    profile_applied,
+    profile_deleted,
+    profile_saved,
+    profile_set_default,
+)
+
+log_event({"event": "nav_page_view", "page": "profiles"})
+
+st.title("Profiles")
+
+profs = profiles.list_profiles()
+for pr in profs:
+    defaults = pr.data.get("defaults", {})
+    pm = defaults.get("provider_model", {})
+    summary = {
+        "mode": defaults.get("mode"),
+        "provider": pm.get("provider"),
+        "model": pm.get("model"),
+        "budget": defaults.get("budget_limit_usd"),
+    }
+    with st.expander(pr.name, expanded=False):
+        st.write(pr.data.get("description", ""))
+        st.write(time.strftime("%Y-%m-%d %H:%M", time.gmtime(pr.data.get("updated_at", 0))))
+        st.json(summary)
+        c1, c2, c3, c4, c5 = st.columns(5)
+        if c1.button("Apply", key=f"ap_{pr.name}"):
+            st.query_params["profile"] = pr.name
+            profile_applied(pr.name)
+            st.switch_page("app.py")
+        new_nm = c2.text_input("Rename", pr.name, key=f"rn_{pr.name}")
+        if c2.button("Save", key=f"rn_btn_{pr.name}") and new_nm and new_nm != pr.name:
+            profiles.save(new_nm, defaults, pr.data.get("description", ""))
+            profiles.delete(pr.name)
+            profile_saved(new_nm)
+            profile_deleted(pr.name)
+            st.experimental_rerun()
+        raw = c3.text_area("Edit JSON", json.dumps(pr.data, indent=2), key=f"ed_{pr.name}")
+        if c3.button("Update", key=f"ed_btn_{pr.name}"):
+            try:
+                obj = json.loads(raw)
+                profiles.save(pr.name, obj.get("defaults", {}), obj.get("description", ""))
+                profile_saved(pr.name)
+                st.experimental_rerun()
+            except Exception:
+                c3.error("Invalid JSON")
+        if st.session_state.get(f"del_{pr.name}"):
+            if c4.button("Confirm delete", key=f"del_c_{pr.name}"):
+                profiles.delete(pr.name)
+                profile_deleted(pr.name)
+                st.session_state.pop(f"del_{pr.name}")
+                st.experimental_rerun()
+        elif c4.button("Delete", key=f"del_{pr.name}"):
+            st.session_state[f"del_{pr.name}"] = True
+        if c5.button("Set as default", key=f"def_{pr.name}"):
+            pf = prefs.load_prefs()
+            pf.setdefault("defaults", {})["profile"] = pr.name
+            prefs.save_prefs(pf)
+            profile_set_default(pr.name)
+            st.success("Default updated")

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T19:10:11.536374Z'
-git_sha: 66027f95ef6e0177084c2a65d9e47dc454026688
+generated_at: '2025-08-30T19:47:08.274774Z'
+git_sha: 200558b4a29d749eac8225ee7c290cb5251a8beb
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -184,7 +184,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/qa_router.py
+- path: orchestrators/__init__.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -198,7 +198,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/__init__.py
+- path: orchestrators/qa_router.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -233,14 +233,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
+- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/schemas.py
+- path: core/summarization/integrator.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+from utils import profiles
+
+
+def _patch_root(tmp_path: Path, monkeypatch):
+    root = tmp_path / "profiles"
+    monkeypatch.setattr(profiles, "ROOT", root)
+    root.mkdir(parents=True, exist_ok=True)
+
+
+def test_save_list_load_apply(tmp_path, monkeypatch):
+    _patch_root(tmp_path, monkeypatch)
+    profiles.save("fast", {"mode": "standard", "budget_limit_usd": 0.5})
+    lst = profiles.list_profiles()
+    assert lst and lst[0].name == "fast"
+    obj = profiles.load("fast")
+    cfg = {"mode": "", "budget_limit_usd": None, "idea": "x"}
+    merged = profiles.apply_to_config(cfg, obj)
+    assert merged["mode"] == "standard"
+    assert merged["budget_limit_usd"] == 0.5
+    assert merged["idea"] == "x"
+
+
+def test_update_clamp_delete(tmp_path, monkeypatch):
+    _patch_root(tmp_path, monkeypatch)
+    profiles.save("fast", {"mode": "standard", "max_tokens": 100})
+    profiles.update("fast", {"max_tokens": 0, "budget_limit_usd": -5})
+    obj = profiles.load("fast")
+    assert obj["defaults"]["max_tokens"] == 1
+    assert obj["defaults"]["budget_limit_usd"] == 0.0
+    assert profiles.delete("fast") is True
+    assert not (profiles.ROOT / "fast.json").exists()
+
+
+def test_safe_name(tmp_path, monkeypatch):
+    _patch_root(tmp_path, monkeypatch)
+    profiles.save("My Profile!!", {})
+    assert (profiles.ROOT / "my-profile-.json").exists()
+    loaded = profiles.load("My Profile!!")
+    assert loaded["name"] == "my-profile-"

--- a/utils/cli.py
+++ b/utils/cli.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Mapping
 
 
-def load_config(path: str | None, lockfile: str | None) -> Mapping:
+def load_config(path: str | None, lockfile: str | None, profile: str | None = None) -> Mapping:
     """Load a run configuration mapping.
 
     Parameters
@@ -25,8 +25,8 @@ def load_config(path: str | None, lockfile: str | None) -> Mapping:
         except Exception as exc:  # pragma: no cover - argument errors
             print(f"failed to read lockfile: {exc}", file=sys.stderr)
             sys.exit(1)
-        return run_config_io.from_lockfile(data)
-    if path:
+        cfg: Mapping = run_config_io.from_lockfile(data)
+    elif path:
         try:
             data = json.loads(Path(path).read_text(encoding="utf-8"))
         except Exception as exc:  # pragma: no cover - argument errors
@@ -35,11 +35,21 @@ def load_config(path: str | None, lockfile: str | None) -> Mapping:
         if not isinstance(data, Mapping):
             print("config JSON must be an object", file=sys.stderr)
             sys.exit(1)
-        return data
-    return {}
+        cfg = data
+    else:
+        cfg = {}
+    if profile:
+        try:
+            from utils.profiles import apply_to_config
+            from utils.profiles import load as load_profile
+
+            cfg = apply_to_config(cfg, load_profile(profile))
+        except Exception as exc:  # pragma: no cover - profile errors
+            print(f"failed to apply profile {profile}: {exc}", file=sys.stderr)
+    return cfg
 
 
-def print_summary(meta: Mapping, totals: Mapping | None) -> None:
+def print_summary(meta: Mapping, totals: Mapping | None, *, profile: str | None = None) -> None:
     """Print a one-line summary of a run to stdout."""
     run_id = meta.get("run_id", "")
     status = meta.get("status", "")
@@ -54,7 +64,8 @@ def print_summary(meta: Mapping, totals: Mapping | None) -> None:
     else:
         tokens = int(meta.get("tokens") or 0)
         cost = float(meta.get("cost_usd") or 0.0)
-    print(f"{run_id} {status} {duration} {tokens} {cost}")
+    extra = f" {profile}" if profile else ""
+    print(f"{run_id} {status} {duration} {tokens} {cost}{extra}")
 
 
 def exit_code(status: str) -> int:

--- a/utils/prefs.py
+++ b/utils/prefs.py
@@ -1,4 +1,5 @@
 """Helpers for persisted user preferences."""
+
 from __future__ import annotations
 
 import json
@@ -18,6 +19,7 @@ DEFAULT_PREFS: dict[str, Any] = {
         "max_tokens": None,
         "knowledge_sources": ["samples"],
         "provider_model": {"provider": "openai", "model": "gpt-4o-mini"},
+        "profile": "",
     },
     "ui": {
         "show_trace_by_default": True,
@@ -32,10 +34,9 @@ DEFAULT_PREFS: dict[str, Any] = {
         "retention_days_runs": 60,
         "safety_mode": "warn",
         "safety_use_llm": False,
-        "safety_block_categories": ["exfil","malicious_instruction"],
+        "safety_block_categories": ["exfil", "malicious_instruction"],
         "safety_high_threshold": 0.8,
     },
-
     "notifications": {
         "enabled": True,
         "channels": [],
@@ -51,7 +52,6 @@ DEFAULT_PREFS: dict[str, Any] = {
         },
     },
     "storage": {"backend": "local", "bucket": "", "prefix": "dr_rd", "signed_url_ttl_sec": 600},
-
     "retrieval": {
         "enabled": True,
         "top_k": 4,
@@ -62,18 +62,23 @@ DEFAULT_PREFS: dict[str, Any] = {
         "embedding_model": "text-embedding-3-small",
         "max_chars_per_doc": 200000,
     },
-
     "sharing": {
         "default_ttl_sec": 604800,
         "default_scopes": ["trace", "reports", "artifacts"],
         "allow_scopes": ["trace", "reports", "artifacts"],
     },
-
-
-
 }
 
-_ALLOWED_SECTIONS = {"defaults", "ui", "privacy", "notifications", "storage", "retrieval", "sharing", "version"}
+_ALLOWED_SECTIONS = {
+    "defaults",
+    "ui",
+    "privacy",
+    "notifications",
+    "storage",
+    "retrieval",
+    "sharing",
+    "version",
+}
 
 
 def _validate(raw: Mapping[str, Any] | None) -> dict:
@@ -110,9 +115,6 @@ def _validate(raw: Mapping[str, Any] | None) -> dict:
                 prefs[section][key] = [str(v) for v in value]
         else:
             prefs[section][key] = str(value)
-
-
-
 
     raw_not = raw.get("notifications")
     if isinstance(raw_not, Mapping):

--- a/utils/profiles.py
+++ b/utils/profiles.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(".dr_rd/profiles")
+ROOT.mkdir(parents=True, exist_ok=True)
+SAFE = re.compile(r"[^a-z0-9._-]+")
+
+
+@dataclass(frozen=True)
+class Profile:
+    name: str
+    path: Path
+    data: dict[str, Any]
+
+
+def _safe_name(name: str) -> str:
+    return SAFE.sub("-", name.strip().lower())[:64] or "profile"
+
+
+def _now() -> float:
+    return time.time()
+
+
+def list_profiles() -> list[Profile]:
+    out = []
+    for p in ROOT.glob("*.json"):
+        try:
+            out.append(Profile(p.stem, p, json.loads(p.read_text(encoding="utf-8"))))
+        except Exception:
+            continue
+    return sorted(out, key=lambda pr: pr.data.get("updated_at", 0), reverse=True)
+
+
+def load(name: str) -> dict[str, Any]:
+    p = ROOT / f"{_safe_name(name)}.json"
+    obj = json.loads(p.read_text(encoding="utf-8"))
+    return _validate(obj)
+
+
+def save(name: str, defaults: dict[str, Any], description: str = "") -> dict[str, Any]:
+    nm = _safe_name(name)
+    p = ROOT / f"{nm}.json"
+    obj = {
+        "version": 1,
+        "name": nm,
+        "description": description or "",
+        "created_at": _now(),
+        "updated_at": _now(),
+        "defaults": _filter_defaults(defaults),
+    }
+    p.write_text(json.dumps(obj, ensure_ascii=False, indent=2), encoding="utf-8")
+    return obj
+
+
+def update(name: str, updates: dict[str, Any]) -> dict[str, Any]:
+    p = ROOT / f"{_safe_name(name)}.json"
+    obj = json.loads(p.read_text(encoding="utf-8"))
+    obj["defaults"] = _filter_defaults({**obj.get("defaults", {}), **updates})
+    obj["updated_at"] = _now()
+    p.write_text(json.dumps(obj, ensure_ascii=False, indent=2), encoding="utf-8")
+    return obj
+
+
+def delete(name: str) -> bool:
+    p = ROOT / f"{_safe_name(name)}.json"
+    if p.exists():
+        p.unlink()
+        return True
+    return False
+
+
+def _filter_defaults(d: dict[str, Any]) -> dict[str, Any]:
+    allow = {
+        "mode",
+        "provider_model",
+        "budget_limit_usd",
+        "max_tokens",
+        "knowledge_sources",
+        "retrieval",
+        "safety",
+        "flags",
+    }
+    out = {k: d[k] for k in list(d.keys()) if k in allow}
+    # clamp and sanitize
+    if "budget_limit_usd" in out:
+        out["budget_limit_usd"] = max(0.0, float(out["budget_limit_usd"]))
+    if "max_tokens" in out:
+        out["max_tokens"] = max(1, int(out["max_tokens"]))
+    if "knowledge_sources" in out and not isinstance(out["knowledge_sources"], list):
+        out["knowledge_sources"] = []
+    return out
+
+
+def _validate(obj: dict[str, Any]) -> dict[str, Any]:
+    assert int(obj.get("version", 1)) == 1
+    assert "defaults" in obj
+    _filter_defaults(obj["defaults"])  # normalize
+    return obj
+
+
+def apply_to_config(config: dict[str, Any], prof: dict[str, Any]) -> dict[str, Any]:
+    d = {**config}
+    defaults = prof.get("defaults", {})
+    for k, v in defaults.items():
+        if d.get(k) in (None, "", [], {}):
+            d[k] = v
+    return d

--- a/utils/telemetry.py
+++ b/utils/telemetry.py
@@ -140,7 +140,9 @@ def read_events(limit: int | None = None, days: int = 7) -> list[dict]:
 # Convenience event wrappers remain largely unchanged below.
 
 
-def llm_call_started(provider: str, model: str, attempt: int, run_id: str | None = None, step_id: str | None = None) -> None:
+def llm_call_started(
+    provider: str, model: str, attempt: int, run_id: str | None = None, step_id: str | None = None
+) -> None:
     ev = {"event": "llm_call_started", "provider": provider, "model": model, "attempt": attempt}
     if run_id:
         ev["run_id"] = run_id
@@ -149,7 +151,9 @@ def llm_call_started(provider: str, model: str, attempt: int, run_id: str | None
     log_event(ev)
 
 
-def llm_call_succeeded(provider: str, model: str, attempt: int, run_id: str | None = None, step_id: str | None = None) -> None:
+def llm_call_succeeded(
+    provider: str, model: str, attempt: int, run_id: str | None = None, step_id: str | None = None
+) -> None:
     ev = {"event": "llm_call_succeeded", "provider": provider, "model": model, "attempt": attempt}
     if run_id:
         ev["run_id"] = run_id
@@ -158,8 +162,21 @@ def llm_call_succeeded(provider: str, model: str, attempt: int, run_id: str | No
     log_event(ev)
 
 
-def llm_call_failed(provider: str, model: str, attempt: int, kind: str, run_id: str | None = None, step_id: str | None = None) -> None:
-    ev = {"event": "llm_call_failed", "provider": provider, "model": model, "attempt": attempt, "kind": kind}
+def llm_call_failed(
+    provider: str,
+    model: str,
+    attempt: int,
+    kind: str,
+    run_id: str | None = None,
+    step_id: str | None = None,
+) -> None:
+    ev = {
+        "event": "llm_call_failed",
+        "provider": provider,
+        "model": model,
+        "attempt": attempt,
+        "kind": kind,
+    }
     if run_id:
         ev["run_id"] = run_id
     if step_id:
@@ -167,7 +184,9 @@ def llm_call_failed(provider: str, model: str, attempt: int, kind: str, run_id: 
     log_event(ev)
 
 
-def llm_fallback(provider: str, model: str, run_id: str | None = None, step_id: str | None = None) -> None:
+def llm_fallback(
+    provider: str, model: str, run_id: str | None = None, step_id: str | None = None
+) -> None:
     ev = {"event": "llm_fallback", "provider": provider, "model": model}
     if run_id:
         ev["run_id"] = run_id
@@ -176,7 +195,9 @@ def llm_fallback(provider: str, model: str, run_id: str | None = None, step_id: 
     log_event(ev)
 
 
-def llm_cache_hit(provider: str, model: str, run_id: str | None = None, step_id: str | None = None) -> None:
+def llm_cache_hit(
+    provider: str, model: str, run_id: str | None = None, step_id: str | None = None
+) -> None:
     ev = {"event": "llm_cache_hit", "provider": provider, "model": model}
     if run_id:
         ev["run_id"] = run_id
@@ -231,7 +252,9 @@ def prompt_edited(id_: str, version: str) -> None:
 
 
 def share_link_created(run_id: str, scopes: list[str], ttl_sec: int) -> None:
-    log_event({"event": "share_link_created", "run_id": run_id, "scopes": scopes, "ttl_sec": int(ttl_sec)})
+    log_event(
+        {"event": "share_link_created", "run_id": run_id, "scopes": scopes, "ttl_sec": int(ttl_sec)}
+    )
 
 
 def share_link_accessed(run_id: str | None, scopes: list[str]) -> None:
@@ -520,10 +543,16 @@ def eval_completed(items: int, pass_rate: float, mean_final: float) -> None:
     )
 
 
-
-
 def notification_sent(run_id: str, status: str, channels: list[str], ok: bool) -> None:
-    log_event({"event": "notification_sent", "run_id": run_id, "status": status, "channels": channels, "ok": bool(ok)})
+    log_event(
+        {
+            "event": "notification_sent",
+            "run_id": run_id,
+            "status": status,
+            "channels": channels,
+            "ok": bool(ok),
+        }
+    )
 
 
 def notifications_saved(channels: list[str], events_count: int) -> None:
@@ -547,7 +576,33 @@ def retrieval_query(q_len: int) -> None:
 
 
 def retrieval_used(run_id: str, step_id: str, k: int, provider: str) -> None:
-    log_event({"event": "retrieval_used", "run_id": run_id, "step_id": step_id, "k": k, "provider": provider})
+    log_event(
+        {
+            "event": "retrieval_used",
+            "run_id": run_id,
+            "step_id": step_id,
+            "k": k,
+            "provider": provider,
+        }
+    )
+
+
+def profile_saved(name: str) -> None:
+    log_event({"event": "profile_saved", "name": name})
+
+
+def profile_applied(name: str) -> None:
+    log_event({"event": "profile_applied", "name": name})
+
+
+def profile_deleted(name: str) -> None:
+    log_event({"event": "profile_deleted", "name": name})
+
+
+def profile_set_default(name: str) -> None:
+    log_event({"event": "profile_set_default", "name": name})
+
+
 __all__ = [
     "log_event",
     "list_files",
@@ -579,6 +634,10 @@ __all__ = [
     "safety_export_blocked",
     "retrieval_query",
     "retrieval_used",
+    "profile_saved",
+    "profile_applied",
+    "profile_deleted",
+    "profile_set_default",
     "history_filter_changed",
     "history_export_clicked",
     "graph_view_opened",
@@ -608,4 +667,6 @@ def storage_read(backend: str, key: str, bytes: int) -> None:
 
 
 def storage_error(backend: str, key: str, op: str, reason: str) -> None:
-    log_event({"event": "storage_error", "backend": backend, "key": key, "op": op, "reason": reason})
+    log_event(
+        {"event": "storage_error", "backend": backend, "key": key, "op": op, "reason": reason}
+    )


### PR DESCRIPTION
## Summary
- add profile CRUD utilities and management page
- support applying profiles via CLI
- document profile usage and telemetry events

## Testing
- `pre-commit run --files docs/PROFILES.md docs/REPO_MAP.md repo_map.yaml scripts/run_cli.py utils/cli.py utils/prefs.py utils/telemetry.py pages/16_Profiles.py tests/test_profiles.py utils/profiles.py`
- `pytest tests/test_profiles.py`

------
https://chatgpt.com/codex/tasks/task_e_68b35435ddfc832cad52e7edadefc740