### PR TITLE
feat: add notebook export

### DIFF
--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T20:03:44.903466Z from commit 6818a45_
+_Last generated at 2025-08-30T20:18:44.821716Z from commit f4624ec_

--- a/docs/UI_SPEC.md
+++ b/docs/UI_SPEC.md
@@ -52,7 +52,9 @@ log_event("start_run", run_id)
 Runs can be downloaded as self contained Jupyter notebooks from the
 Reports page. The notebook captures the run configuration, prompts,
 summaries and citations. Large binary artifacts are referenced by key
-rather than embedded. All free text is redacted for safe sharing.
+rather than embedded. All free text is redacted for safe sharing and the
+resulting `.ipynb` can be opened locally in any Jupyter viewer without
+network access.
 
 ## Wireframes
 ### Main Page

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T20:03:44.903466Z'
-git_sha: 6818a45132d17945a004d7da3dbc57dcd39ef812
+generated_at: '2025-08-30T20:18:44.821716Z'
+git_sha: f4624ec6693fec58c4bf56827c99ca8928817234
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -184,28 +184,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/__init__.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/plan_utils.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/qa_router.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -219,15 +198,22 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/__init__.py
-  role: Summarization
+- path: orchestrators/spec_builder.py
+  role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
-  role: Summarization
+- path: orchestrators/plan_utils.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/__init__.py
+  role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
@@ -241,6 +227,20 @@ modules:
   invoked_by: []
   invokes: []
 - path: core/summarization/schemas.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/role_summarizer.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_trace_export_rows.py
+++ b/tests/test_trace_export_rows.py
@@ -20,6 +20,8 @@ def test_flatten_trace_rows():
     assert rows[1]["status"] == "error"
     assert set(rows[0].keys()) == {
         "i",
+        "id",
+        "parents",
         "phase",
         "name",
         "status",
@@ -27,4 +29,6 @@ def test_flatten_trace_rows():
         "tokens",
         "cost",
         "summary",
+        "prompt",
+        "citations",
     }

--- a/utils/notebook_export.py
+++ b/utils/notebook_export.py
@@ -1,15 +1,51 @@
-"""Notebook export helpers."""
-
 from __future__ import annotations
 
 import json
 import platform
-from typing import Mapping, Sequence, Optional, Tuple
+from pathlib import Path
+from typing import Mapping, Sequence, Optional
 
 import nbformat
 from nbformat.v4 import new_notebook, new_markdown_cell, new_code_cell
 
 from .redaction import redact_public
+from .storage import key_run
+
+
+BADGE = {"complete": "✅", "error": "⚠️", "running": "⏳"}
+
+
+def _clean_config(obj: object) -> object:
+    if isinstance(obj, dict):
+        out = {}
+        for k, v in obj.items():
+            lk = k.lower()
+            if any(x in lk for x in ("key", "secret", "token")):
+                out[k] = "•••"
+            elif isinstance(v, (dict, list)):
+                out[k] = _clean_config(v)
+            elif isinstance(v, str) and len(v) > 1000:
+                out[k] = f"<{len(v)} chars>"
+            else:
+                out[k] = v
+        return out
+    if isinstance(obj, list):
+        return [_clean_config(v) for v in obj]
+    return obj
+
+
+def _red(s: Optional[str]) -> str:
+    return redact_public(s or "")
+
+
+def _read_artifact(path: Path, max_bytes: int) -> Optional[str]:
+    try:
+        if not path.exists() or path.stat().st_size > max_bytes:
+            return None
+        text = path.read_text(encoding="utf-8")
+        return _red(text)
+    except Exception:
+        return None
 
 
 def build_notebook(
@@ -17,16 +53,16 @@ def build_notebook(
     meta: Mapping,
     lock: Mapping,
     rows: Sequence[Mapping],
-    artifacts: Sequence[Tuple[str, str]] | None = None,
+    artifacts: Sequence[tuple[str, str]] | None = None,
     *,
     include_small_artifacts: bool = True,
     max_embed_bytes: int = 200_000,
 ) -> bytes:
-    """Return UTF‑8 encoded ``.ipynb`` bytes."""
+    """Return UTF 8 encoded .ipynb bytes. Do not hit network. Redact secrets."""
 
     nb = new_notebook()
-    nb.metadata["kernelspec"] = {"name": "python3", "display_name": "Python 3"}
-    nb.metadata["language_info"] = {
+    nb["metadata"]["kernelspec"] = {"name": "python3", "display_name": "Python 3"}
+    nb["metadata"]["language_info"] = {
         "name": "python",
         "version": platform.python_version(),
     }
@@ -35,62 +71,97 @@ def build_notebook(
     completed = meta.get("completed_at")
     status = meta.get("status")
     mode = meta.get("mode")
-    title = f"# DR RD Run {run_id}\n\nStarted: {started}\n\nCompleted: {completed}\n\nStatus: {status}\n\nMode: {mode}"
+    details = []
+    if started is not None:
+        details.append(f"started {started}")
+    if completed is not None:
+        details.append(f"completed {completed}")
+    if status:
+        details.append(str(status))
+    if mode:
+        details.append(str(mode))
+    title = f"# DR RD Run {run_id}"
+    if details:
+        title += " (" + ", ".join(details) + ")"
     nb.cells.append(new_markdown_cell(title))
 
-    repro = ["## Reproduction info"]
-    provider = lock.get("provider") or lock.get("model")
+    repro_lines = []
+    provider = lock.get("provider") or lock.get("client")
+    model = lock.get("model")
     if provider:
-        repro.append(f"- Provider/model: {provider}")
+        repro_lines.append(f"- Provider: {provider}")
+    if model:
+        repro_lines.append(f"- Model: {model}")
     budgets = lock.get("budgets")
     if budgets:
-        repro.append(f"- Budgets: {json.dumps(budgets)}")
-    repro.append("- Warning: prompts and outputs are redacted for public sharing.")
-    nb.cells.append(new_markdown_cell("\n".join(repro)))
+        repro_lines.append(f"- Budgets: `{json.dumps(budgets)}`")
+    pins = lock.get("prompt_pins")
+    if pins:
+        repro_lines.append("- Prompt pins:")
+        for k, v in pins.items():
+            repro_lines.append(f"  - {k}: {v}")
+    repro_lines.append("\n_Warning: secrets have been redacted._")
+    nb.cells.append(new_markdown_cell("\n".join(repro_lines)))
 
-    cfg_json = json.dumps(lock, ensure_ascii=False, indent=2)
-    cfg_json = redact_public(cfg_json)
-    nb.cells.append(new_code_cell(cfg_json, metadata={"name": "config"}))
+    clean_lock = _clean_config(lock)
+    nb.cells.append(new_code_cell(json.dumps(clean_lock, ensure_ascii=False, indent=2)))
 
     for row in rows:
-        phase = row.get("phase")
-        name = row.get("name")
-        status = row.get("status")
+        phase = row.get("phase") or "unknown"
+        name = row.get("name") or ""
+        status = row.get("status") or ""
         dur = row.get("duration_ms")
-        header = f"## [{phase}] {name} ({status}, {dur} ms)"
+        badge = BADGE.get(status, status)
+        header = f"## [{phase}] {name} {badge}".rstrip()
+        if dur is not None:
+            header += f" ({dur} ms)"
         nb.cells.append(new_markdown_cell(header))
-
-        if row.get("prompt"):
-            nb.cells.append(
-                new_markdown_cell("### Prompt\n" + redact_public(str(row.get("prompt"))))
-            )
-        if row.get("summary"):
-            nb.cells.append(
-                new_markdown_cell("### Output\n" + redact_public(str(row.get("summary"))))
-            )
-        cites = row.get("citations") or []
-        if cites:
-            lines = ["### Citations"]
-            for c in cites:
+        prompt = row.get("prompt")
+        if prompt:
+            nb.cells.append(new_markdown_cell("**Prompt**\n\n" + _red(str(prompt))))
+        summary = row.get("summary")
+        if summary:
+            nb.cells.append(new_markdown_cell("**Output**\n\n" + _red(str(summary))))
+        citations = row.get("citations") or []
+        if citations:
+            lines = ["**Citations**"]
+            for c in citations:
                 if isinstance(c, Mapping):
-                    cid = c.get("id")
-                    snip = c.get("snippet") or c.get("text")
-                    lines.append(f"- {cid}: {redact_public(str(snip))}")
+                    doc = _red(str(c.get("doc") or c.get("id") or ""))
+                    snip = _red(str(c.get("snippet") or c.get("text") or ""))
+                    lines.append(f"- {doc}: {snip}")
+                else:
+                    lines.append(f"- {_red(str(c))}")
             nb.cells.append(new_markdown_cell("\n".join(lines)))
 
-    totals = {
-        "tokens": meta.get("tokens") or 0,
-        "cost_usd": meta.get("cost_usd") or 0.0,
-        "duration_s": meta.get("duration_ms", 0) / 1000,
-    }
-    lines = ["## Totals"]
-    lines.append(f"- Tokens: {totals['tokens']}")
-    lines.append(f"- Cost USD: {totals['cost_usd']}")
-    lines.append(f"- Duration s: {totals['duration_s']}")
-    nb.cells.append(new_markdown_cell("\n".join(lines)))
+    if artifacts:
+        nb.cells.append(new_markdown_cell("## Artifacts"))
+        for name, key in artifacts:
+            path = Path(key)
+            data = _read_artifact(path, max_embed_bytes) if include_small_artifacts else None
+            if data is not None:
+                ext = path.suffix.lstrip(".")
+                nb.cells.append(new_markdown_cell(f"### {name}"))
+                nb.cells.append(new_markdown_cell(f"```{ext}\n{data}\n```"))
+            else:
+                if path.suffix:
+                    display = key_run(run_id, path.stem, path.suffix.lstrip("."))
+                else:
+                    display = key
+                nb.cells.append(
+                    new_markdown_cell(
+                        f"### {name}\nStored as `{display}`. Fetch via the app."
+                    )
+                )
+
+    tokens = sum(int(row.get("tokens") or 0) for row in rows)
+    cost = sum(float(row.get("cost") or 0.0) for row in rows)
+    duration = sum(int(row.get("duration_ms") or 0) for row in rows)
+    nb.cells.append(
+        new_markdown_cell(
+            f"**Totals**\n\n- Tokens: {tokens}\n- Cost: ${cost:.4f}\n- Duration: {duration} ms"
+        )
+    )
 
     return nbformat.writes(nb).encode("utf-8")
-
-
-__all__ = ["build_notebook"]
 


### PR DESCRIPTION
## Summary
- export runs as self-contained Jupyter notebooks with config, prompts, summaries and artifacts
- record prompt previews during orchestration for inclusion in exports
- document notebook download option in UI spec

## Testing
- `pytest tests/test_notebook_export.py tests/test_trace_export_rows.py tests/test_diff_runs.py`

------
https://chatgpt.com/codex/tasks/task_e_68b35b3823d4832ca262859a428e9c2f