### PR TITLE
Fix indentation in app run completion block

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -659,7 +659,7 @@ def _send_note(event: str, status: str, extra: dict | None = None) -> None:
         st.session_state["active_run"]["status"] = "success"
         complete_run_meta(run_id, status="success")
         log_event({"event": "run_completed", "run_id": run_id, "status": "success"})
-    _send_note("run_completed", "success")
+        _send_note("run_completed", "success")
         if origin_run_id:
             log_event(
                 {


### PR DESCRIPTION
## Summary
- fix indentation around run completion so `try` block ends correctly

## Testing
- `python -m py_compile app/__init__.py`
- `pytest tests/test_app_ui.py -q` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'cache_resource')*


------
https://chatgpt.com/codex/tasks/task_e_68b363632bf4832c9d81e6013ead3c36