### PR TITLE
fix: allow executor prompt without task

### DIFF
--- a/prompts/executor.yaml
+++ b/prompts/executor.yaml
@@ -4,7 +4,8 @@ title: "Executor system prompt"
 description: "Runs tasks assigned by the planner."
 vars:
   - name: task
-    required: true
+    required: false
+    default: ""
 template: |
   You are the Executor. Complete the task: {task}
 changelog:

--- a/tests/test_prompts_runtime.py
+++ b/tests/test_prompts_runtime.py
@@ -1,4 +1,3 @@
-import pytest
 from utils.prompts import runtime
 
 
@@ -10,6 +9,12 @@ def test_defaults_and_pin():
     assert len(pin["hash"]) == 64
 
 
-def test_missing_var():
-    with pytest.raises(KeyError):
-        runtime.render("executor", {})
+def test_executor_placeholder_task():
+    text, pin = runtime.render("executor", {})
+    assert "Complete the task:" in text
+    assert pin["id"] == "executor"
+
+
+def test_executor_with_task():
+    text, _ = runtime.render("executor", {"task": "do something"})
+    assert "do something" in text


### PR DESCRIPTION
## Summary
- allow executor prompt to render even when task is absent
- test executor prompt default and explicit task rendering

## Testing
- `pre-commit run --files prompts/executor.yaml tests/test_prompts_runtime.py`
- `pytest tests/test_prompts_runtime.py`


------
https://chatgpt.com/codex/tasks/task_e_68b36677ab34832cbee9391002514607