### PR TITLE
Handle date range input and update Streamlit rerun API

### DIFF
--- a/pages/14_Prompts.py
+++ b/pages/14_Prompts.py
@@ -70,4 +70,4 @@ if sel:
             prompt_saved(sel, new_version)
             prompt_edited(sel, new_version)
             st.success("Saved")
-            st.experimental_rerun()
+            st.rerun()

--- a/pages/16_Profiles.py
+++ b/pages/16_Profiles.py
@@ -41,14 +41,14 @@ for pr in profs:
             profiles.delete(pr.name)
             profile_saved(new_nm)
             profile_deleted(pr.name)
-            st.experimental_rerun()
+            st.rerun()
         raw = c3.text_area("Edit JSON", json.dumps(pr.data, indent=2), key=f"ed_{pr.name}")
         if c3.button("Update", key=f"ed_btn_{pr.name}"):
             try:
                 obj = json.loads(raw)
                 profiles.save(pr.name, obj.get("defaults", {}), obj.get("description", ""))
                 profile_saved(pr.name)
-                st.experimental_rerun()
+                st.rerun()
             except Exception:
                 c3.error("Invalid JSON")
         if st.session_state.get(f"del_{pr.name}"):
@@ -56,7 +56,7 @@ for pr in profs:
                 profiles.delete(pr.name)
                 profile_deleted(pr.name)
                 st.session_state.pop(f"del_{pr.name}")
-                st.experimental_rerun()
+                st.rerun()
         elif c4.button("Delete", key=f"del_{pr.name}"):
             st.session_state[f"del_{pr.name}"] = True
         if c5.button("Set as default", key=f"def_{pr.name}"):

--- a/pages/30_Metrics.py
+++ b/pages/30_Metrics.py
@@ -63,9 +63,18 @@ st.title(t("metrics_title"))
 st.caption(t("metrics_caption"))
 
 start_default = date.today() - timedelta(days=7)
-start, end = st.date_input(
+date_range = st.date_input(
     t("date_range_label"), value=(start_default, date.today()), help=t("metrics_date_help")
 )
+if isinstance(date_range, (list, tuple)):
+    if len(date_range) == 2:
+        start, end = date_range
+    elif len(date_range) == 1:
+        start = end = date_range[0]
+    else:
+        start = end = start_default
+else:
+    start = end = date_range
 start_ts = datetime.combine(start, datetime.min.time()).timestamp()
 end_ts = datetime.combine(end, datetime.max.time()).timestamp()
 


### PR DESCRIPTION
## Summary
- fix metrics date range input to handle single-date selections
- replace deprecated `st.experimental_rerun` with `st.rerun`

## Testing
- `pytest -q --maxfail=1 --disable-warnings` *(fails: cannot import name 'redact' from 'utils.errors')*


------
https://chatgpt.com/codex/tasks/task_e_68b3acf5a8d0832cacac273d0a35e39b