### PR TITLE
Handle invalid knowledge source defaults and empty trace graphs

### DIFF
--- a/app/ui/sidebar.py
+++ b/app/ui/sidebar.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import Any, Dict
+from typing import Any
 
 import streamlit as st
 
 from app.ui_presets import UI_PRESETS
+from utils import knowledge_store
 from utils.run_config import RunConfig, defaults
 from utils.session_store import init_stores
 from utils.telemetry import log_event
-from utils import knowledge_store
 
 
 def render_sidebar() -> RunConfig:
@@ -61,7 +61,13 @@ def render_sidebar() -> RunConfig:
         _track_change("idea", idea)
         modes = list(UI_PRESETS.keys())
         current_mode = run_store.get("mode", modes[0])
-        mode = st.selectbox("Mode", modes, index=modes.index(current_mode) if current_mode in modes else 0, key="mode", help="Choose run mode")
+        mode = st.selectbox(
+            "Mode",
+            modes,
+            index=modes.index(current_mode) if current_mode in modes else 0,
+            key="mode",
+            help="Choose run mode",
+        )
         run_store.set("mode", mode)
         _track_change("mode", mode)
 
@@ -71,10 +77,11 @@ def render_sidebar() -> RunConfig:
             choices = builtins + knowledge_store.as_choice_list()
             options = [c[1] for c in choices]
             labels = {c[1]: c[0] for c in choices}
+            default_sources = [s for s in run_store.get("knowledge_sources", []) if s in options]
             sources = st.multiselect(
                 "Sources",
                 options,
-                default=run_store.get("knowledge_sources", []),
+                default=default_sources,
                 key="knowledge_sources",
                 format_func=lambda x: labels.get(x, x),
                 help="Select knowledge sources",
@@ -153,7 +160,7 @@ def render_sidebar() -> RunConfig:
         st.button("Reset to defaults", on_click=_reset, help="Restore default settings")
 
     data = run_store.as_dict()
-    adv: Dict[str, Any] = {
+    adv: dict[str, Any] = {
         "temperature": st.session_state.get("temperature", 0.0),
         "retries": st.session_state.get("retries", 0),
         "timeout": st.session_state.get("timeout", 0),

--- a/tests/test_trace_graph.py
+++ b/tests/test_trace_graph.py
@@ -5,9 +5,23 @@ def test_build_and_critical_path():
     trace = [
         {"i": 1, "phase": "plan", "name": "a", "status": "success", "duration_ms": 10},
         {"i": 2, "phase": "plan", "name": "b", "status": "success", "duration_ms": 20},
-        {"i": 3, "phase": "exec", "name": "c", "status": "warn", "duration_ms": 30, "parents": ["s2"]},
+        {
+            "i": 3,
+            "phase": "exec",
+            "name": "c",
+            "status": "warn",
+            "duration_ms": 30,
+            "parents": ["s2"],
+        },
         {"i": 4, "phase": "exec", "name": "d", "status": "error", "duration_ms": 40},
-        {"i": 5, "phase": "synth", "name": "e", "status": "success", "duration_ms": 50, "parents": ["s4"]},
+        {
+            "i": 5,
+            "phase": "synth",
+            "name": "e",
+            "status": "success",
+            "duration_ms": 50,
+            "parents": ["s4"],
+        },
     ]
     nodes, edges = build_graph(trace)
     assert len(nodes) == 5
@@ -17,5 +31,9 @@ def test_build_and_critical_path():
     assert path == ["s1", "s2", "s3", "s4", "s5"]
 
     dot = to_dot(nodes, edges, highlight=path)
-    assert "label=\"plan\"" in dot
-    assert "\"s3\"" in dot
+    assert 'label="plan"' in dot
+    assert '"s3"' in dot
+
+
+def test_critical_path_empty_graph_returns_empty_list():
+    assert critical_path([], []) == []

--- a/utils/graph/trace_graph.py
+++ b/utils/graph/trace_graph.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
-from typing import List, Dict, Any, Tuple, Iterable, Optional
+
 from dataclasses import dataclass
+from typing import Any, Iterable
+
 
 @dataclass(frozen=True)
 class Node:
@@ -10,47 +12,52 @@ class Node:
     status: str
     dur_ms: int
 
+
 @dataclass(frozen=True)
 class Edge:
     src: str
     dst: str
     kind: str  # "seq" | "data"
 
+
 STATUS_COLOR = {
     "success": "#16a34a",
-    "warn":    "#d97706",
-    "error":   "#dc2626",
-    "cancelled":"#6b7280",
+    "warn": "#d97706",
+    "error": "#dc2626",
+    "cancelled": "#6b7280",
     "timeout": "#9333ea",
     "running": "#0ea5e9",
     "unknown": "#64748b",
 }
 
-def build_graph(rows: List[Dict[str, Any]]) -> Tuple[List[Node], List[Edge]]:
+
+def build_graph(rows: list[dict[str, Any]]) -> tuple[list[Node], list[Edge]]:
     """
     rows: flatten_trace_rows(trace) items with keys:
       i, id?, phase, name, status, duration_ms, parents? (list[str])
     If 'id' missing, synthesize 's{i}'. If 'parents' missing, add sequential edges within each phase.
     """
-    nodes: List[Node] = []
-    edges: List[Edge] = []
+    nodes: list[Node] = []
+    edges: list[Edge] = []
     # Build nodes
     for r in rows:
         sid = str(r.get("id") or f"s{r['i']}")
         status = str(r.get("status") or "unknown")
-        nodes.append(Node(
-            id=sid,
-            label=f"{r.get('name','step')}\\n{int(r.get('duration_ms',0))/1000:.1f}s",
-            phase=str(r.get("phase","")),
-            status=status,
-            dur_ms=int(r.get("duration_ms",0)),
-        ))
+        nodes.append(
+            Node(
+                id=sid,
+                label=f"{r.get('name','step')}\\n{int(r.get('duration_ms',0))/1000:.1f}s",
+                phase=str(r.get("phase", "")),
+                status=status,
+                dur_ms=int(r.get("duration_ms", 0)),
+            )
+        )
     # Index by phase for sequential edges
-    by_phase: Dict[str, List[Node]] = {}
+    by_phase: dict[str, list[Node]] = {}
     for n in nodes:
         by_phase.setdefault(n.phase, []).append(n)
-    for ph, L in by_phase.items():
-        L.sort(key=lambda n: int(n.id.replace("s","")) if n.id.startswith("s") else 0)
+    for _ph, L in by_phase.items():
+        L.sort(key=lambda n: int(n.id.replace("s", "")) if n.id.startswith("s") else 0)
         for a, b in zip(L, L[1:]):
             edges.append(Edge(src=a.id, dst=b.id, kind="seq"))
     # Explicit parents if present
@@ -62,52 +69,64 @@ def build_graph(rows: List[Dict[str, Any]]) -> Tuple[List[Node], List[Edge]]:
                 edges.append(Edge(src=p, dst=sid, kind="data"))
     return nodes, edges
 
-def critical_path(nodes: List[Node], edges: List[Edge]) -> List[str]:
+
+def critical_path(nodes: list[Node], edges: list[Edge]) -> list[str]:
     """
     Longest-duration path (ms) in DAG. If cycles exist, ignore offending edges.
     Returns list of node ids on the critical path in order.
     """
     # Topo sort
-    adj: Dict[str, List[str]] = {}
-    indeg: Dict[str, int] = {n.id: 0 for n in nodes}
+    adj: dict[str, list[str]] = {}
+    indeg: dict[str, int] = {n.id: 0 for n in nodes}
     for e in edges:
         adj.setdefault(e.src, []).append(e.dst)
-        if e.dst in indeg: indeg[e.dst] += 1
+        if e.dst in indeg:
+            indeg[e.dst] += 1
     q = [nid for nid, d in indeg.items() if d == 0]
-    order: List[str] = []
+    order: list[str] = []
     while q:
         u = q.pop(0)
         order.append(u)
         for v in adj.get(u, []):
             indeg[v] -= 1
-            if indeg[v] == 0: q.append(v)
+            if indeg[v] == 0:
+                q.append(v)
     # DP longest path by dur_ms
     dur = {n.id: n.dur_ms for n in nodes}
-    best = {nid: (dur.get(nid,0), None) for nid in order}  # (cost, prev)
+    best: dict[str, tuple[int, str | None]] = {nid: (dur.get(nid, 0), None) for nid in order}
     for u in order:
         for v in adj.get(u, []):
-            cand = best[u][0] + dur.get(v,0)
-            if cand > best.get(v,(0,None))[0]:
+            cand = best[u][0] + dur.get(v, 0)
+            if cand > best.get(v, (0, None))[0]:
                 best[v] = (cand, u)
     # Pick end with max cost
-    end = max(best.items(), key=lambda kv: kv[0] in order and kv[1][0] or 0)[0]
+    if not best:
+        return []
+    end = max(best.items(), key=lambda kv: kv[1][0])[0]
     # Reconstruct
     path = []
     cur = end
     seen = set()
     while cur and cur not in seen:
-        path.append(cur); seen.add(cur)
-        cur = best.get(cur,(0,None))[1]
+        path.append(cur)
+        seen.add(cur)
+        cur = best.get(cur, (0, None))[1]
     path.reverse()
     return path
 
-def to_dot(nodes: List[Node], edges: List[Edge], *, highlight: Iterable[str] = ()) -> str:
+
+def to_dot(nodes: list[Node], edges: list[Edge], *, highlight: Iterable[str] = ()) -> str:
     hi = set(highlight or [])
-    lines = ["digraph G {", 'rankdir=LR;', 'node [shape=box, style="rounded,filled", fontname="Inter,Arial"];']
+    lines = [
+        "digraph G {",
+        "rankdir=LR;",
+        'node [shape=box, style="rounded,filled", fontname="Inter,Arial"];',
+    ]
     # clusters by phase
-    by_phase: Dict[str, List[Node]] = {}
-    for n in nodes: by_phase.setdefault(n.phase or "phase", []).append(n)
-    for i,(ph,L) in enumerate(by_phase.items()):
+    by_phase: dict[str, list[Node]] = {}
+    for n in nodes:
+        by_phase.setdefault(n.phase or "phase", []).append(n)
+    for i, (ph, L) in enumerate(by_phase.items()):
         lines.append(f'subgraph cluster_{i} {{ label="{ph}"; color="#e5e7eb";')
         for n in L:
             col = STATUS_COLOR.get(n.status, STATUS_COLOR["unknown"])


### PR DESCRIPTION
## Summary
- filter sidebar knowledge source defaults to only include valid choices
- avoid ValueError in critical_path when the graph is empty and update type hints
- test that critical_path handles empty graphs

## Testing
- `pre-commit run --files app/ui/sidebar.py tests/test_trace_graph.py utils/graph/trace_graph.py`
- `pytest tests/test_trace_graph.py`

------
https://chatgpt.com/codex/tasks/task_e_68b3ae7dfc60832cbae03879e61d447c