### PR TITLE
fix: handle gcp secrets dict and cleanup theme config

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -2,7 +2,6 @@
 fileWatcherType = "none"
 
 [theme]
-base="light"
 primaryColor="#0B5FFF"
 backgroundColor="#FFFFFF"
 secondaryBackgroundColor="#F5F7FB"

--- a/utils/health_check.py
+++ b/utils/health_check.py
@@ -226,6 +226,24 @@ def _check_secrets() -> tuple[str, str, str, str, str]:
             "gcp_service_account missing",
             "Set gcp_service_account in env or secrets",
         )
+    if isinstance(secret, dict):
+        try:
+            json.dumps(secret)
+            return (
+                "secrets",
+                "GCP service account",
+                "pass",
+                "gcp_service_account present",
+                "",
+            )
+        except Exception as e:
+            return (
+                "secrets",
+                "GCP service account",
+                "fail",
+                f"Invalid JSON: {e}",
+                "Provide valid JSON",
+            )
     try:
         json.loads(secret)
         return (


### PR DESCRIPTION
## Summary
- handle dict-style `gcp_service_account` in health check so Streamlit secrets.toml works
- remove unsupported `base` key from Streamlit theme config

## Testing
- `pytest tests/test_health_check.py`
- `pre-commit run --files utils/health_check.py .streamlit/config.toml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b0066150832cb04cb6355d33fe82