### PR TITLE
CI: stabilize Streamlit E2E (Xvfb, health-check, app logs)

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2,9 +2,17 @@ name: e2e
 on:
   pull_request: {}
   workflow_dispatch: {}
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   e2e:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      APP_EXTERNAL: "1"
+      APP_BASE_URL: "http://localhost:8501"
+      APP_START_TIMEOUT_SEC: "180"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -16,10 +24,30 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           pip install -r requirements-dev.txt
           python -m playwright install --with-deps chromium
-      - name: Start app and run E2E
-        env:
-          APP_EXTERNAL: "0"
-          APP_BASE_URL: "http://localhost:8501"
-          APP_START_CMD: "streamlit run app.py --server.port 8501 --server.headless true"
+      - name: Start app
         run: |
-          pytest -q e2e
+          nohup streamlit run app.py --server.port 8501 --server.headless true > app.log 2>&1 &
+          for i in $(seq 1 120); do
+            curl -f http://localhost:8501 && break
+            sleep 1
+            if [ $i -eq 120 ]; then echo "app failed to start"; exit 1; fi
+          done
+      - name: Run E2E tests
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: pytest -q e2e
+      - name: Upload app log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-log
+          path: app.log
+      - name: Upload test reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: |
+            playwright-report
+            test-results
+          if-no-files-found: ignore

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-30T20:18:44.821716Z from commit f4624ec_
+_Last generated at 2025-08-31T03:04:29.326235Z from commit 2a16b8c_

--- a/docs/ci_e2e.md
+++ b/docs/ci_e2e.md
@@ -1,0 +1,19 @@
+# Streamlit E2E CI
+
+The end-to-end tests exercise the Streamlit app through Playwright. In CI the workflow:
+
+1. installs dependencies and browsers.
+2. starts `streamlit run app.py --server.port 8501 --server.headless true` with output redirected to `app.log`.
+3. polls `http://localhost:8501` until ready.
+4. runs `pytest -q e2e` under Xvfb.
+5. uploads `app.log` as an artifact if tests fail.
+
+To reproduce locally:
+
+```bash
+# in one shell
+streamlit run app.py --server.port 8501 --server.headless true
+
+# in another shell
+APP_EXTERNAL=1 pytest -q e2e
+```

--- a/e2e/config.py
+++ b/e2e/config.py
@@ -5,4 +5,5 @@ APP_START_CMD = os.getenv(
     "APP_START_CMD",
     "streamlit run app.py --server.port 8501 --server.headless true",
 )
-APP_START_TIMEOUT_SEC = int(os.getenv("APP_START_TIMEOUT_SEC", "90"))
+APP_START_TIMEOUT_SEC = int(os.getenv("APP_START_TIMEOUT_SEC", "180"))
+APP_LOG_FILE = os.getenv("APP_LOG_FILE", "app.log")

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -5,7 +5,7 @@ import time
 import pytest
 import requests
 
-from e2e.config import APP_BASE_URL, APP_START_CMD, APP_START_TIMEOUT_SEC
+from e2e.config import APP_BASE_URL, APP_START_CMD, APP_START_TIMEOUT_SEC, APP_LOG_FILE
 
 
 def _wait_ready(url: str, timeout: int) -> None:
@@ -27,7 +27,13 @@ def app_server():
     if ext:
         yield
         return
-    proc = subprocess.Popen(APP_START_CMD, shell=True)
+    log = open(APP_LOG_FILE, "a")
+    proc = subprocess.Popen(
+        APP_START_CMD,
+        shell=True,
+        stdout=log,
+        stderr=log,
+    )
     try:
         _wait_ready(APP_BASE_URL, APP_START_TIMEOUT_SEC)
         yield
@@ -37,6 +43,7 @@ def app_server():
             proc.wait(timeout=10)
         except Exception:
             proc.kill()
+        log.close()
 
 
 @pytest.fixture(scope="session")

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-30T20:18:44.821716Z'
-git_sha: f4624ec6693fec58c4bf56827c99ca8928817234
+generated_at: '2025-08-31T03:04:29.326235Z'
+git_sha: 2a16b8c5c460b4427c19448317bc929e6f81ef18
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -184,21 +184,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
+- path: orchestrators/__init__.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
 - path: orchestrators/qa_router.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/app_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -212,21 +205,21 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/__init__.py
+- path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
-  role: Summarization
+- path: orchestrators/app_builder.py
+  role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/schemas.py
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -240,7 +233,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/__init__.py
+- path: core/summarization/integrator.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []


### PR DESCRIPTION
## Summary
- start Streamlit in the e2e workflow with health checks and Xvfb
- capture app logs and test reports when runs fail
- document how the e2e workflow runs and how to reproduce locally

## Testing
- `python scripts/generate_repo_map.py`
- `python -m pip install -U pip`
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `python -m playwright install --with-deps chromium` *(failed: Domain forbidden)*
- `APP_START_TIMEOUT_SEC=180 pytest -q e2e` *(failed: Locator.select_option: Error: Element is not a <select> element)*

------
https://chatgpt.com/codex/tasks/task_e_68b3bb658898832c97761240919bf65c