### PR TITLE
Enable .env-based config and improve local Streamlit setup

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,5 +1,8 @@
 [server]
-fileWatcherType = "none"
+headless = true
+fileWatcherType = "poll"  # helps on Windows/WSL
+# address = "0.0.0.0"
+# port = 8501
 
 [theme]
 primaryColor="#0B5FFF"

--- a/README.md
+++ b/README.md
@@ -23,10 +23,14 @@ The planner now uses OpenAI's JSON mode for reliable parsing.
 ## Quick start (local)
 
 ```bash
-git clone https://github.com/YOUR_USERNAME/rnd_tool.git
-cd rnd_tool
-python -m venv .venv && source .venv/bin/activate   # PowerShell: .venv\Scripts\activate
+git clone https://github.com/clcriswell/DR-RD.git
+cd DR-RD
+python -m venv .venv
+# macOS/Linux
+source .venv/bin/activate
+# Windows PowerShell
+.venv\Scripts\Activate.ps1
 pip install -r requirements.txt
-export OPENAI_API_KEY="sk-..."
+cp .env.example .env  # edit with your keys
 streamlit run app.py
 ```

--- a/app.py
+++ b/app.py
@@ -1,14 +1,8 @@
 """Run page for the DR-RD Streamlit application."""
 
+from dr_rd.config import env as _env  # noqa: F401
 from app import main
-from utils.telemetry import log_event
-
-
-def run() -> None:
-    """Launch the DR-RD Streamlit application."""
-    log_event({"event": "nav_page_view", "page": "run"})
-    main()
 
 
 if __name__ == "__main__":
-    run()
+    main()

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,6 +2,8 @@
 
 # ruff: noqa: E402
 
+from dr_rd.config import env as _env  # noqa: F401
+
 import io
 import json
 import logging

--- a/app/logging_setup.py
+++ b/app/logging_setup.py
@@ -1,13 +1,15 @@
 """Logging configuration for the Streamlit app.
 
 This module exposes :func:`init_gcp_logging` which attempts to initialize
-Google Cloud Logging based on credentials provided via ``st.secrets``. If the
+Google Cloud Logging based on credentials provided via configuration. If the
 credentials are missing or invalid, the application will continue to run with
 standard Python logging instead of crashing.
 """
 
+import json
 import logging
-import streamlit as st
+
+from dr_rd.config.env import get_env
 
 _GCP_LOGGED = False
 
@@ -33,14 +35,14 @@ def init_gcp_logging() -> bool:
         from google.cloud import logging as gcp_logging
         from google.oauth2 import service_account
 
-        # Extract service account credentials from Streamlit secrets.
-        creds_info = dict(st.secrets["gcp_service_account"])
+        creds_raw = get_env("GCP_SERVICE_ACCOUNT")
+        if not creds_raw:
+            raise KeyError("missing gcp_service_account secret")
+        creds_info = json.loads(creds_raw)
         if not creds_info.get("private_key"):
             raise KeyError("missing private_key in gcp_service_account secret")
 
-        credentials = service_account.Credentials.from_service_account_info(
-            creds_info
-        )
+        credentials = service_account.Credentials.from_service_account_info(creds_info)
         client = gcp_logging.Client(credentials=credentials)
         client.setup_logging()
         logging.info("✅ Google Cloud Logging initialized")

--- a/config/feature_flags.py
+++ b/config/feature_flags.py
@@ -7,9 +7,11 @@ from pathlib import Path
 
 import yaml
 
+from dr_rd.config.env import get_env
+
 
 def _flag(name: str) -> bool:
-    return os.getenv(name, "false").lower() == "true"
+    return get_env(name, "false").lower() == "true"
 
 
 EVALUATORS_ENABLED = _flag("EVALUATORS_ENABLED")
@@ -25,7 +27,7 @@ ENABLE_LIVE_SEARCH = _flag("ENABLE_LIVE_SEARCH")
 LIVE_SEARCH_BACKEND: str = os.getenv("LIVE_SEARCH_BACKEND", "openai")
 LIVE_SEARCH_MAX_CALLS: int = 3
 LIVE_SEARCH_SUMMARY_TOKENS: int = 256
-SERPAPI_KEY: str = os.getenv("SERPAPI_KEY", "")
+SERPAPI_KEY: str = get_env("SERPAPI_KEY", "") or ""
 ENABLE_IMAGES = _flag("ENABLE_IMAGES")
 CODE_IO_ENABLED = _flag("CODE_IO_ENABLED")
 SIM_ENABLED = _flag("SIM_ENABLED")

--- a/core/audit_log.py
+++ b/core/audit_log.py
@@ -6,6 +6,8 @@ import json
 import os
 import time
 from dataclasses import dataclass, asdict
+
+from dr_rd.config.env import get_env
 from pathlib import Path
 from typing import Any, Dict, Iterable, Optional
 
@@ -39,7 +41,7 @@ _DEF_KEY = "dummy_audit_key"
 
 
 def _get_key() -> str:
-    return os.getenv("AUDIT_HMAC_KEY", _DEF_KEY)
+    return get_env("AUDIT_HMAC_KEY", _DEF_KEY)
 
 
 def _hmac(data: str) -> str:

--- a/core/cache.py
+++ b/core/cache.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import streamlit as st
+import json
 
+from dr_rd.config.env import get_env
 from utils.lazy_import import lazy
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -24,9 +25,13 @@ def _get_client() -> firestore.Client | None:
     global _client
     if _client is None:
         try:
-            info = st.secrets["gcp_service_account"]
-            credentials = _service_account.Credentials.from_service_account_info(info)
-            _client = _firestore.Client(credentials=credentials)
+            info_raw = get_env("GCP_SERVICE_ACCOUNT")
+            if info_raw:
+                info = json.loads(info_raw)
+                credentials = _service_account.Credentials.from_service_account_info(info)
+                _client = _firestore.Client(credentials=credentials)
+            else:
+                _client = _firestore.Client()
         except Exception:
             try:
                 _client = _firestore.Client()

--- a/core/llm_client.py
+++ b/core/llm_client.py
@@ -39,7 +39,9 @@ def _client() -> Any:
     """Return a cached OpenAI client instance."""
     global _client_instance
     if _client_instance is None:
-        _client_instance = _openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY", "test"))
+        from dr_rd.config.env import get_env
+
+        _client_instance = _openai.OpenAI(api_key=get_env("OPENAI_API_KEY", "test"))
     return _client_instance
 
 

--- a/core/retrieval/websearch.py
+++ b/core/retrieval/websearch.py
@@ -2,6 +2,8 @@ from typing import Any, Dict, List, Tuple
 import os
 import logging
 
+from dr_rd.config.env import get_env
+
 from core.llm_client import call_openai
 
 log = logging.getLogger("drrd")
@@ -54,7 +56,7 @@ def openai_web_search(query: str, *, max_results: int = 5) -> Dict[str, Any]:
 def serpapi_web_search(query: str, *, max_results: int = 5) -> Dict[str, Any]:
     import requests
 
-    key = os.getenv("SERPAPI_API_KEY")
+    key = get_env("SERPAPI_API_KEY")
     if not key:
         raise WebSearchError("SERPAPI_API_KEY not configured")
     try:
@@ -88,7 +90,7 @@ def run_live_search(
             return openai_web_search(query, max_results=max_results), "openai_ok"
         except WebSearchError as e:
             reasons.append(f"openai_fail:{e}")
-            if os.getenv("SERPAPI_API_KEY"):
+            if get_env("SERPAPI_API_KEY"):
                 try:
                     return serpapi_web_search(query, max_results=max_results), "serpapi_fallback_ok"
                 except WebSearchError as e2:

--- a/core/router.py
+++ b/core/router.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 from pathlib import Path
 from typing import Any, Dict, Tuple, Type
+
+from dr_rd.config.env import get_env
 
 import yaml
 
@@ -188,7 +189,7 @@ def route_task(
                 "retrieval_level": retrieval_level,
                 "top_k_applied": topk_map.get(retrieval_level, 0),
                 "per_doc_cap_tokens": RAG_CFG.get("per_doc_cap_tokens", 400),
-                "dense_enabled": bool(os.getenv("OPENAI_API_KEY")),
+                "dense_enabled": bool(get_env("OPENAI_API_KEY")),
                 "caps": {
                     "max_tool_calls": exec_cfg.get("max_tool_calls"),
                     "max_parallel_tools": route_cfg.get("max_parallel_tools"),

--- a/core/security/auth.py
+++ b/core/security/auth.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Iterable, Optional
 
 from dr_rd.tenancy.models import Principal
+from dr_rd.config.env import get_env
 
 BASE_DIR = Path.home() / ".dr_rd" / "tenants"
 BASE_DIR.mkdir(parents=True, exist_ok=True)
@@ -31,7 +32,7 @@ class ApiKey:
 
 
 def _hash_secret(secret: str) -> str:
-    salt = os.getenv("APIKEY_HASH_SALT", "drrd_salt")
+    salt = get_env("APIKEY_HASH_SALT", "drrd_salt") or "drrd_salt"
     return hmac.new(salt.encode(), secret.encode(), hashlib.sha256).hexdigest()
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       dockerfile: docker/Dockerfile.app
     environment:
       - RAG_ENABLED=${RAG_ENABLED:-false}
+      - OPENAI_API_KEY
     ports:
       - "8501:8501"
     volumes:
@@ -18,6 +19,7 @@ services:
       dockerfile: docker/Dockerfile.worker
     environment:
       - RAG_ENABLED=${RAG_ENABLED:-false}
+      - OPENAI_API_KEY
     ports:
       - "8000:8000"
     volumes:

--- a/docs/LOCAL_DEV.md
+++ b/docs/LOCAL_DEV.md
@@ -1,0 +1,40 @@
+# Local Development
+
+This project can be run locally on macOS, Linux, or Windows. The steps below assume Python 3.9+.
+
+## macOS/Linux
+
+```bash
+git clone https://github.com/clcriswell/DR-RD.git
+cd DR-RD
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env  # add your keys
+streamlit run app.py
+```
+
+## Windows (PowerShell)
+
+```powershell
+git clone https://github.com/clcriswell/DR-RD.git
+cd DR-RD
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+pip install -r requirements.txt
+Copy-Item .env.example .env  # add your keys
+streamlit run app.py
+```
+
+## Docker
+
+A simple development container is provided. Ensure `OPENAI_API_KEY` is set in your environment.
+
+```bash
+docker-compose up --build
+```
+
+## Troubleshooting
+
+- **C++ build tools missing**: Some packages require a C++ compiler. On Windows install the [Microsoft C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/).
+- **Port already in use**: Pass `--server.port` to `streamlit run app.py` to override the default port.

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-31T03:04:29.326235Z from commit 2a16b8c_
+_Last generated at 2025-08-31T03:37:01.894758Z from commit 43189ff_

--- a/dr_rd/config/env.py
+++ b/dr_rd/config/env.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Optional
+
+from dotenv import load_dotenv
+import streamlit as st
+
+load_dotenv()
+
+def _from_secrets(key: str) -> Optional[str]:
+    try:
+        for k, v in st.secrets.items():
+            if k.lower() == key.lower():
+                return v if isinstance(v, str) else json.dumps(v)
+    except Exception:
+        return None
+    return None
+
+def get_env(key: str, default: str | None = None) -> str | None:
+    value = os.getenv(key)
+    if value is not None:
+        return value
+    secret_val = _from_secrets(key)
+    if secret_val is not None:
+        return secret_val
+    return default
+
+def require_env(key: str) -> str:
+    value = get_env(key)
+    if value is None or value == "":
+        message = f"Missing required environment variable: {key}"
+        try:
+            from streamlit.runtime.scriptrunner import get_script_run_ctx
+
+            if get_script_run_ctx() is not None:
+                st.error(message)
+                st.stop()
+        except Exception:
+            pass
+        raise RuntimeError(message)
+    return value
+
+__all__ = ["get_env", "require_env"]

--- a/dr_rd/connectors/commons.py
+++ b/dr_rd/connectors/commons.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Optional
 
 import requests
 
+from dr_rd.config.env import get_env
 from dr_rd.cache.file_cache import cached
 
 _RATE_LIMITS: dict[str, list[float]] = defaultdict(list)
@@ -67,7 +68,7 @@ def http_json(
 
 def signed_headers(key_env: str, headers: dict[str, str] | None = None) -> dict[str, str]:
     headers = dict(headers or {})
-    key = os.getenv(key_env)
+    key = get_env(key_env)
     if key:
         headers["Authorization"] = f"Bearer {key}"
     return headers

--- a/dr_rd/connectors/credentials.py
+++ b/dr_rd/connectors/credentials.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import os
 from pathlib import Path
 from typing import Optional
 
+from dr_rd.config.env import get_env
 from dr_rd.tenancy.models import TenantContext
 
 
@@ -25,7 +25,7 @@ def get_credential(ctx: TenantContext, name: str) -> Optional[str]:
         f"DRRD_CRED_{name}".upper(),
     ]
     for key in env_keys:
-        val = os.getenv(key)
+        val = get_env(key)
         if val:
             return val
 

--- a/dr_rd/connectors/epo_ops.py
+++ b/dr_rd/connectors/epo_ops.py
@@ -1,22 +1,20 @@
 from __future__ import annotations
 
-import os
 from typing import Any, Dict
 
+from dr_rd.config.env import require_env
 from .commons import cached
 
 
 @cached(ttl_s=86400)
 def search_patents(query: str) -> Dict[str, Any]:
-    if not os.getenv("EPO_OPS_KEY"):
-        raise RuntimeError("EPO_OPS_KEY not set")
+    require_env("EPO_OPS_KEY")
     return {"items": []}
 
 
 @cached(ttl_s=86400)
 def fetch_patent(pub_number: str) -> Dict[str, Any]:
-    if not os.getenv("EPO_OPS_KEY"):
-        raise RuntimeError("EPO_OPS_KEY not set")
+    require_env("EPO_OPS_KEY")
     return {"record": {}}
 
 

--- a/dr_rd/connectors/web_search.py
+++ b/dr_rd/connectors/web_search.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from typing import List
-import os
 
+from dr_rd.config.env import get_env
 from config import feature_flags as ff
 from dr_rd.rag.types import Doc
 from .commons import use_fixtures, load_fixture
@@ -29,6 +29,6 @@ def search_web(query: str, k: int, freshness_days: int | None = None, site_filte
         return docs
     if not getattr(ff, "ENABLE_LIVE_SEARCH", False):
         raise RuntimeError("live search disabled")
-    if not (os.getenv("BING_API_KEY") or os.getenv("SERPAPI_KEY")):
+    if not (get_env("BING_API_KEY") or get_env("SERPAPI_KEY")):
         raise RuntimeError("no web search API key")
     raise RuntimeError("web search not implemented in tests")

--- a/dr_rd/integrations/patents/adapters.py
+++ b/dr_rd/integrations/patents/adapters.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from typing import Any, Dict, List
-import os
+
 import requests
 
+from dr_rd.config.env import get_env
 from . import normalizer
 
 
@@ -27,7 +28,7 @@ def _search_epo_ops(query: Dict[str, Any], caps: Dict[str, Any]) -> List[Dict[st
     params = query.copy()
     timeout = int(caps.get("timeouts_s", 10))
     headers = {}
-    key = os.getenv("EPO_OPS_KEY")
+    key = get_env("EPO_OPS_KEY")
     if key:
         headers["Authorization"] = f"Bearer {key}"
     resp = requests.get(url, params=params, headers=headers, timeout=timeout)

--- a/dr_rd/privacy/subject.py
+++ b/dr_rd/privacy/subject.py
@@ -7,6 +7,8 @@ from typing import Any, Dict, Iterable, Optional
 
 import yaml
 
+from dr_rd.config.env import get_env
+
 from .pii import get_pii_patterns
 
 _CFG_PATH = os.path.join("config", "retention.yaml")
@@ -71,7 +73,7 @@ def derive_subject_key(record_or_text: Any, fields: Iterable[str], salt_env: str
             parts.append(f"{f}:{val}")
     if not parts:
         return None
-    salt = os.getenv(salt_env, "")
+    salt = get_env(salt_env, "") or ""
     if not salt:
         return None
     base = "|".join(sorted(parts))

--- a/dr_rd/rag/embeddings.py
+++ b/dr_rd/rag/embeddings.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 from pathlib import Path
 from typing import Dict
+
+from dr_rd.config.env import get_env
 
 try:
     from openai import OpenAI
@@ -24,7 +25,7 @@ def _hash(text: str) -> str:
 
 
 def embed(text: str) -> Dict[str, float] | None:
-    if not OpenAI or not os.getenv("OPENAI_API_KEY"):
+    if not OpenAI or not get_env("OPENAI_API_KEY"):
         return None
     key = _hash(text)
     cached = cache.get(key)

--- a/dr_rd/retrieval/context.py
+++ b/dr_rd/retrieval/context.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import json
 import logging
 from typing import Any, Dict, List
-import os
+
+from dr_rd.config.env import get_env
 
 from core.llm_client import BUDGET
 from core.retrieval import budget as rbudget
@@ -119,7 +120,7 @@ def fetch_context(
                 )
                 web_used = False
                 reason = "live_search_error"
-                serp_key = os.getenv("SERPAPI_KEY")
+                serp_key = get_env("SERPAPI_KEY")
                 if str(cfg.get("live_search_backend")) == "serpapi" and serp_key:
                     backend = "serpapi"
                     raw = search_google(agent_name, "", query, k=rag_top_k)

--- a/dr_rd/retrieval/live_search.py
+++ b/dr_rd/retrieval/live_search.py
@@ -10,13 +10,14 @@ dataclasses and ``search_and_summarize`` tuples.
 
 from dataclasses import dataclass
 from typing import Any, Dict, List, Tuple, Optional, Protocol
-import os
 import json
 import logging
 import httpx
 
 from core.llm_client import call_openai
 from utils.search_tools import search_google, summarize_search
+
+from dr_rd.config.env import get_env
 
 log = logging.getLogger("drrd")
 
@@ -134,7 +135,7 @@ class SerpAPIWebSearchClient:
 
     def __init__(self, llm_model: str, api_key: Optional[str] = None):
         self.llm_model = llm_model
-        self.api_key = api_key or os.getenv("SERPAPI_API_KEY")
+        self.api_key = api_key or get_env("SERPAPI_API_KEY")
         if not self.api_key:
             raise RuntimeError("SERPAPI_API_KEY missing; cannot use SerpAPI fallback.")
 

--- a/memory/memory_manager.py
+++ b/memory/memory_manager.py
@@ -8,6 +8,7 @@ import uuid
 import re
 from difflib import SequenceMatcher
 
+from dr_rd.config.env import get_env
 from utils.config import load_config
 from filelock import FileLock
 
@@ -109,13 +110,13 @@ class MemoryManager:
         }
         try:  # pragma: no cover - optional Firestore
             if name:
-                import streamlit as st
                 from google.cloud import firestore
                 from google.oauth2 import service_account
 
-                if "gcp_service_account" in st.secrets:
+                creds_raw = get_env("GCP_SERVICE_ACCOUNT")
+                if creds_raw:
                     creds = service_account.Credentials.from_service_account_info(
-                        st.secrets["gcp_service_account"]
+                        json.loads(creds_raw)
                     )
                     db = firestore.Client(credentials=creds, project=creds.project_id)
                     doc_id = _slugify(name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,9 @@ authors = [
 ]
 license = { text = "MIT" }
 dynamic = ["version"]
-dependencies = []
+dependencies = [
+    "python-dotenv>=1.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/openai/dr-rd"

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-31T03:04:29.326235Z'
-git_sha: 2a16b8c5c460b4427c19448317bc929e6f81ef18
+generated_at: '2025-08-31T03:37:01.894758Z'
+git_sha: 43189ff0ec66cfe3ff2da6fddc1c951711d4e906
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -191,13 +191,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/qa_router.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/plan_utils.py
   role: Orchestrator
   responsibilities: []
@@ -219,7 +212,21 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
+- path: orchestrators/qa_router.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
 - path: core/summarization/__init__.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -234,13 +241,6 @@ modules:
   invoked_by: []
   invokes: []
 - path: core/summarization/integrator.py
-  role: Summarization
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 streamlit>=1.35.0
+python-dotenv>=1.0
 openai>=1.51.0
 requests>=2.31.0
 google-cloud-logging

--- a/utils/firestore_workspace.py
+++ b/utils/firestore_workspace.py
@@ -5,8 +5,9 @@ import re
 import time
 from typing import TYPE_CHECKING, Any
 
-import streamlit as st
+import json
 
+from dr_rd.config.env import get_env
 from utils.lazy_import import lazy
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -20,11 +21,14 @@ _COLLECTION = "rd_projects"  # single namespace!
 
 def _client() -> firestore.Client:
     try:
-        info = dict(st.secrets["gcp_service_account"])
-        creds = _service_account.Credentials.from_service_account_info(info)
-        return _firestore.Client(credentials=creds, project=info["project_id"])
+        info_raw = get_env("GCP_SERVICE_ACCOUNT")
+        if info_raw:
+            info = json.loads(info_raw)
+            creds = _service_account.Credentials.from_service_account_info(info)
+            return _firestore.Client(credentials=creds, project=info["project_id"])
     except Exception:
-        return _firestore.Client()  # fallback to ADC
+        pass
+    return _firestore.Client()  # fallback to ADC
 
 
 def _slugify(name: str) -> str:

--- a/utils/llm_client.py
+++ b/utils/llm_client.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import time
 from typing import Any, Iterator, Mapping, Optional
 
@@ -19,7 +18,9 @@ def _call_provider(prov: str, model: str, payload: Mapping[str, Any], *, stream:
             from openai import OpenAI
         except Exception as exc:  # pragma: no cover - environment guard
             raise RuntimeError('openai sdk missing') from exc
-        client = OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
+        from dr_rd.config.env import require_env
+
+        client = OpenAI(api_key=require_env('OPENAI_API_KEY'))
         messages = payload.get('messages') or []
         if stream:
             return client.chat.completions.create(model=model, messages=messages, stream=True)

--- a/utils/search_tools.py
+++ b/utils/search_tools.py
@@ -6,6 +6,8 @@ from typing import Dict, List
 import requests
 from utils.logging import logger
 
+from dr_rd.config.env import get_env
+
 from core.llm_client import call_openai
 
 
@@ -49,7 +51,7 @@ def obfuscate_query(role: str, idea: str, q: str) -> str:
 def search_google(role: str, idea: str, q: str, k: int = 5) -> List[Dict]:
     """Query SerpAPI for Google results using a redacted query."""
 
-    key = os.getenv("SERPAPI_KEY")
+    key = get_env("SERPAPI_KEY")
     if not key:
         return []
 

--- a/utils/secrets.py
+++ b/utils/secrets.py
@@ -1,32 +1,17 @@
-import json
-import os
 from typing import Callable, Optional, TypeVar
+
+from dr_rd.config.env import get_env, require_env
 
 T = TypeVar("T")
 
-
 def get(
-    name: str, cast: Callable[[str], T] | None = None, *, default: Optional[T] = None
+    name: str,
+    cast: Callable[[str], T] | None = None,
+    *,
+    default: Optional[T] = None,
 ) -> Optional[T]:
-    """Resolve secret by precedence: env var → st.secrets → default.
-
-    Parameters
-    ----------
-    name: Secret name.
-    cast: Optional callable applied to the secret value. If it raises, the
-        default is returned instead.
-    default: Value returned when the secret is missing or cast fails.
-    """
-    v: Optional[str] | None = os.getenv(name)
-    if v is None:
-        try:  # lazy import to avoid heavy Streamlit dependency
-            import streamlit as st  # type: ignore
-
-            sv = st.secrets.get(name)
-            if sv is not None:
-                v = sv if isinstance(sv, str) else json.dumps(sv)
-        except Exception:
-            v = None
+    """Resolve secret by precedence: env var → st.secrets → default."""
+    v = get_env(name)
     if v is None:
         return default
     if cast:
@@ -36,9 +21,6 @@ def get(
             return default
     return v  # type: ignore[return-value]
 
-
 def require(name: str) -> str:
-    v = get(name)
-    if not v:
-        raise RuntimeError(f"missing secret: {name}")
-    return v
+    """Return secret or raise RuntimeError if missing."""
+    return require_env(name)


### PR DESCRIPTION
## Summary
- add `dr_rd.config.env` helper to load `.env` and resolve secrets from env vars or `st.secrets`
- simplify app entrypoint and replace direct secret access with `get_env`/`require_env`
- document macOS/Windows setup and default Streamlit/Docker configs

## Testing
- `pre-commit run --files .streamlit/config.toml README.md app.py app/__init__.py app/logging_setup.py config/feature_flags.py core/audit_log.py core/cache.py core/llm_client.py core/retrieval/websearch.py core/router.py core/security/auth.py docker-compose.yml docs/REPO_MAP.md dr_rd/connectors/commons.py dr_rd/connectors/credentials.py dr_rd/connectors/epo_ops.py dr_rd/connectors/web_search.py dr_rd/integrations/patents/adapters.py dr_rd/privacy/subject.py dr_rd/rag/embeddings.py dr_rd/retrieval/context.py dr_rd/retrieval/live_search.py memory/memory_manager.py pyproject.toml repo_map.yaml requirements.txt utils/firestore_workspace.py utils/llm_client.py utils/search_tools.py utils/secrets.py utils/survey_store.py docs/LOCAL_DEV.md dr_rd/config/env.py` *(command not found: pre-commit)*
- `pytest` *(errors: tests/gtm/test_generate_deck.py, tests/integrations/test_jira_bridge.py, tests/integrations/test_slack_bridge.py, tests/integrations/test_teams_bridge.py, tests/test_errors.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c181f664832c883c335e4b49ad53