### PR TITLE
Initialize cloud logging and remove safety preflight checks

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,8 +1,6 @@
 """Run page for the DR-RD Streamlit application."""
 
-from dr_rd.config import env as _env  # noqa: F401
 from app import main
-
 
 if __name__ == "__main__":
     main()

--- a/app/logging_setup.py
+++ b/app/logging_setup.py
@@ -27,7 +27,9 @@ def init_gcp_logging() -> bool:
         return True
 
     logger = logging.getLogger()
-    if any(getattr(h, "__class__", None).__name__.lower().startswith("gcl") for h in logger.handlers):
+    if any(
+        getattr(h, "__class__", None).__name__.lower().startswith("gcl") for h in logger.handlers
+    ):
         _GCP_LOGGED = True
         return True
 
@@ -55,4 +57,3 @@ def init_gcp_logging() -> bool:
 
 
 __all__ = ["init_gcp_logging"]
-


### PR DESCRIPTION
## Summary
- initialize GCP logging when the app boots
- drop safety preflight checks before runs
- look for Google Cloud credentials in Streamlit secrets via `get_env`

## Testing
- `pre-commit run --files app.py app/__init__.py app/logging_setup.py`
- `pytest tests/test_safety_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4d599c620832cb025d4d51b234d1b