### PR TITLE
Load Streamlit secrets for env vars

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -10,13 +10,13 @@ init_gcp_logging()
 import io
 import json
 import logging
-import os
 import time
 
 import fitz
 import streamlit as st
 from markdown_pdf import MarkdownPdf, Section
 
+from dr_rd.config.env import get_env
 from utils.i18n import missing_keys, set_locale
 from utils.i18n import tr as t
 from utils.session_store import get_session_id, init_stores  # noqa: F401
@@ -474,10 +474,8 @@ def _send_note(event: str, status: str, extra: dict | None = None) -> None:
         "tokens": getattr(usage, "total_tokens", None),
         "cost_usd": getattr(usage, "cost_usd", None),
     }
-    base = os.getenv("APP_BASE_URL") or (
-        "https://dr-rnd.streamlit.app"
-        if os.getenv("STREAMLIT_RUNTIME")
-        else "http://localhost:8501"
+    base = get_env("APP_BASE_URL") or (
+        "https://dr-rnd.streamlit.app" if get_env("STREAMLIT_RUNTIME") else "http://localhost:8501"
     )
     url = f"{base}/?view=trace&run_id={run_id}"
     note = Note(

--- a/app/config_loader.py
+++ b/app/config_loader.py
@@ -6,13 +6,13 @@ release to avoid breaking imports.
 """
 
 import logging
-import os
 from pathlib import Path
 
 import yaml
 
 from config.feature_flags import apply_overrides
 from core.budget import CostTracker
+from dr_rd.config.env import get_env
 
 CONFIG_DIR = Path(__file__).resolve().parent.parent / "config"
 
@@ -24,14 +24,14 @@ def load_profile(mode: str | None = None) -> tuple[dict, CostTracker]:
     deprecation warning. Any unknown or missing mode also falls back to
     ``standard`` with a warning.
     """
-    env_mode = os.getenv("DRRD_MODE")
+    env_mode = get_env("DRRD_MODE")
     if env_mode and env_mode.lower() != "standard":
         logging.warning("DRRD_MODE '%s' is deprecated and maps to 'standard'.", env_mode)
     if mode is None:
         mode = env_mode
 
     modes_path = CONFIG_DIR / "modes.yaml"
-    prices_path = Path(os.getenv("PRICES_PATH", CONFIG_DIR / "prices.yaml"))
+    prices_path = Path(get_env("PRICES_PATH", str(CONFIG_DIR / "prices.yaml")))
 
     with open(modes_path) as fh:
         modes = yaml.safe_load(fh) or {}
@@ -58,13 +58,13 @@ def load_profile(mode: str | None = None) -> tuple[dict, CostTracker]:
     # FAISS defaults and env overrides
     mode_cfg.setdefault("faiss_index_local_dir", ".faiss_index")
     mode_cfg.setdefault("faiss_bootstrap_mode", "download")
-    env_uri = os.getenv("FAISS_INDEX_URI")
+    env_uri = get_env("FAISS_INDEX_URI")
     if env_uri:
         mode_cfg["faiss_index_uri"] = env_uri
-    env_dir = os.getenv("FAISS_INDEX_DIR")
+    env_dir = get_env("FAISS_INDEX_DIR")
     if env_dir:
         mode_cfg["faiss_index_local_dir"] = env_dir
-    env_boot = os.getenv("FAISS_BOOTSTRAP_MODE")
+    env_boot = get_env("FAISS_BOOTSTRAP_MODE")
     if env_boot:
         mode_cfg["faiss_bootstrap_mode"] = env_boot
 

--- a/app/price_loader.py
+++ b/app/price_loader.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
-from pathlib import Path
-import os
-import yaml
 from functools import lru_cache
+from pathlib import Path
+
+import yaml
+
+from dr_rd.config.env import get_env
 
 _CONFIG_DIR = Path(__file__).resolve().parent.parent / "config"
 
 
 @lru_cache(maxsize=1)
 def load_prices() -> dict:
-    path = Path(os.getenv("PRICES_PATH", _CONFIG_DIR / "prices.yaml"))
+    path = Path(get_env("PRICES_PATH", str(_CONFIG_DIR / "prices.yaml")))
     try:
         with open(path) as fh:
             data = yaml.safe_load(fh) or {}
@@ -22,6 +24,6 @@ def load_prices() -> dict:
 def cost_usd(model: str, prompt_toks: int, completion_toks: int) -> float:
     prices = load_prices()
     p = prices.get(model) or prices.get("default", {})
-    return (prompt_toks / 1000.0) * p.get("in_per_1k", 0.0) + (
-        completion_toks / 1000.0
-    ) * p.get("out_per_1k", 0.0)
+    return (prompt_toks / 1000.0) * p.get("in_per_1k", 0.0) + (completion_toks / 1000.0) * p.get(
+        "out_per_1k", 0.0
+    )

--- a/dr_rd/config/env.py
+++ b/dr_rd/config/env.py
@@ -9,6 +9,20 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+# Populate ``os.environ`` with Streamlit secrets so modules using ``os.getenv``
+# can transparently access credentials defined in ``st.secrets`` when running
+# on Streamlit Cloud.
+try:
+    for _k, _v in st.secrets.items():
+        if isinstance(_v, Mapping):
+            for _sk, _sv in _v.items():
+                os.environ.setdefault(_sk, str(_sv))
+        else:
+            os.environ.setdefault(_k, str(_v))
+except Exception:
+    # Accessing ``st.secrets`` can fail outside a Streamlit runtime; ignore.
+    pass
+
 
 def _from_secrets(key: str) -> str | None:
     try:

--- a/pages/05_Health.py
+++ b/pages/05_Health.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-import os
-
 import streamlit as st
 
 from app.ui.a11y import aria_live_region, inject, main_start
 from app.ui.command_palette import open_palette
+from dr_rd.config.env import get_env
 from utils import health_check
 from utils.i18n import tr as t
 from utils.lazy_import import local_import
@@ -81,7 +80,7 @@ if st.button("Run diagnostics", help="Run system diagnostics"):
         mime="text/markdown",
     )
     log_event({"event": "health_check_run", "summary": report.summary})
-    if os.getenv("NO_NET") == "1":
+    if get_env("NO_NET") == "1":
         st.caption("Network tests skipped")
 else:
     st.write("Click to run diagnostics")

--- a/pages/11_Share.py
+++ b/pages/11_Share.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import os
 import streamlit as st
 
+from dr_rd.config.env import get_env
 from utils.prefs import load_prefs
 from utils.share_links import make_link
 from utils.telemetry import share_link_created
@@ -29,7 +29,7 @@ else:
     ttl = int(st.number_input("TTL seconds", min_value=60, value=default_ttl))
 
 if st.button("Create link", disabled=not run_id or not scopes):
-    base = os.getenv("APP_BASE_URL", ".").rstrip("/")
+    base = get_env("APP_BASE_URL", ".").rstrip("/")
     link = make_link(base, run_id, scopes=scopes, ttl_sec=ttl)
     st.text_input("Share link", value=link, help="Copy this link to share", key="share_link_out")
     share_link_created(run_id, scopes, ttl)

--- a/utils/health_check.py
+++ b/utils/health_check.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from dr_rd.config.env import get_env
+
 try:  # Python 3.11+
     import tomllib as toml  # type: ignore
 except Exception:  # pragma: no cover
@@ -209,7 +211,7 @@ def _check_telemetry() -> tuple[str, str, str, str, str]:
 
 @_time_it
 def _check_secrets() -> tuple[str, str, str, str, str]:
-    secret = os.environ.get("gcp_service_account")
+    secret = get_env("gcp_service_account")
     if not secret:
         secrets_path = Path(".streamlit/secrets.toml")
         if secrets_path.exists() and toml is not None:
@@ -265,7 +267,7 @@ def _check_secrets() -> tuple[str, str, str, str, str]:
 
 @_time_it
 def _check_network() -> tuple[str, str, str, str, str]:
-    if os.getenv("NO_NET") == "1":
+    if get_env("NO_NET") == "1":
         return (
             "network",
             "Network reachability",


### PR DESCRIPTION
## Summary
- populate `os.environ` with `st.secrets` so modules using `os.getenv` find Streamlit Cloud credentials
- resolve configuration and runtime options with `get_env` across app modules
- ensure health checks and share page honor secrets-based configuration

## Testing
- `pre-commit run --files app/__init__.py app/config_loader.py app/price_loader.py dr_rd/config/env.py pages/05_Health.py pages/11_Share.py utils/health_check.py`
- `pytest tests/test_health_check.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4e568d5f4832c9d65aa32252b2f75