### PR TITLE
Gracefully handle missing API credentials with Cloud Logging

### DIFF
--- a/dr_rd/connectors/web_search.py
+++ b/dr_rd/connectors/web_search.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 from typing import List
 
+import logging
+
 from dr_rd.config.env import get_env
 from config import feature_flags as ff
 from dr_rd.rag.types import Doc
 from .commons import use_fixtures, load_fixture
+from utils.clients import get_cloud_logging_client
 
 
 def search_web(query: str, k: int, freshness_days: int | None = None, site_filters=None) -> List[Doc]:
@@ -30,5 +33,13 @@ def search_web(query: str, k: int, freshness_days: int | None = None, site_filte
     if not getattr(ff, "ENABLE_LIVE_SEARCH", False):
         raise RuntimeError("live search disabled")
     if not (get_env("BING_API_KEY") or get_env("SERPAPI_KEY")):
-        raise RuntimeError("no web search API key")
+        message = "no web search API key"
+        logging.error(message)
+        try:
+            client = get_cloud_logging_client()
+            if client:
+                client.logger("drrd").log_text(message, severity="ERROR")
+        except Exception:
+            pass
+        return []
     raise RuntimeError("web search not implemented in tests")


### PR DESCRIPTION
## Summary
- Log missing environment variables to Google Cloud Logging instead of raising exceptions
- Allow web search and SerpAPI helpers to proceed with empty results when API keys are absent
- Ensure LLM client logs failures to Cloud Logging rather than crashing when credentials are missing

## Testing
- `pytest -q` *(fails: No module named 'pptx'; No module named 'fastapi'; ImportError: cannot import name 'redact')*


------
https://chatgpt.com/codex/tasks/task_e_68b4e848c52c832c8a59dfa0c0cad4bf