### PR TITLE
fix planner payload normalization

### DIFF
--- a/tests/test_planner_schema.py
+++ b/tests/test_planner_schema.py
@@ -15,3 +15,12 @@ def test_missing_ids_injected():
     norm = _normalize_plan_payload(data)
     validated = Plan.model_validate(norm)
     assert validated.tasks[0].id == "T01"
+
+
+def test_legacy_task_field_backfilled():
+    data = {"tasks": [{"role": "Engineer", "task": "Build prototype"}]}
+    norm = _normalize_plan_payload(data)
+    validated = Plan.model_validate(norm)
+    t = validated.tasks[0]
+    assert t.title == "Build prototype"
+    assert t.summary == "Build prototype"


### PR DESCRIPTION
## Summary
- normalize legacy planner tasks to populate required title/summary fields
- add regression test covering legacy `task` field normalization

## Testing
- `pytest tests/test_planner_schema.py tests/test_plan_min_items.py`
- `pytest` *(fails: ERROR tests/gtm/test_generate_deck.py, tests/integrations/test_jira_bridge.py, tests/integrations/test_slack_bridge.py, tests/integrations/test_teams_bridge.py, tests/test_errors.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b5048209b8832c8db08653855022b1