### PR TITLE
refactor: replace deprecated use_container_width

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -105,7 +105,7 @@ if _c is None:
 if st.button(
     "⌘K Command palette",
     key="cmd_btn",
-    use_container_width=False,
+    width="content",
     help="Open global search",
 ):
     log_event({"event": "palette_opened"})
@@ -508,7 +508,7 @@ def _run(run_id: str, kwargs: dict, prefs: dict, origin_run_id: str | None) -> N
         "Stop run",
         key=f"stop_{run_id}",
         type="secondary",
-        use_container_width=True,
+        width="stretch",
     )
     if stop:
         token.cancel()
@@ -683,11 +683,11 @@ def _run(run_id: str, kwargs: dict, prefs: dict, origin_run_id: str | None) -> N
         components.error_banner(err)
         r1, r2, r3 = st.columns([1, 1, 1])
         with r1:
-            retry = st.button("Retry run", type="primary", use_container_width=True)
+            retry = st.button("Retry run", type="primary", width="stretch")
         with r2:
-            open_trace = st.button("Open trace", use_container_width=True)
+            open_trace = st.button("Open trace", width="stretch")
         with r3:
-            resume = st.button("Resume run", use_container_width=True)
+            resume = st.button("Resume run", width="stretch")
         if retry:
             st.query_params["retry_of"] = err.context.get("run_id") or ""
             st.rerun()
@@ -729,11 +729,11 @@ def _run(run_id: str, kwargs: dict, prefs: dict, origin_run_id: str | None) -> N
         components.error_banner(err)
         r1, r2, r3 = st.columns([1, 1, 1])
         with r1:
-            retry = st.button("Retry run", type="primary", use_container_width=True)
+            retry = st.button("Retry run", type="primary", width="stretch")
         with r2:
-            open_trace = st.button("Open trace", use_container_width=True)
+            open_trace = st.button("Open trace", width="stretch")
         with r3:
-            resume = st.button("Resume run", use_container_width=True)
+            resume = st.button("Resume run", width="stretch")
         if retry:
             st.query_params["retry_of"] = err.context.get("run_id") or ""
             st.rerun()
@@ -774,9 +774,9 @@ def _run(run_id: str, kwargs: dict, prefs: dict, origin_run_id: str | None) -> N
         components.error_banner(err)
         r1, r2 = st.columns([1, 1])
         with r1:
-            retry = st.button("Retry run", type="primary", use_container_width=True)
+            retry = st.button("Retry run", type="primary", width="stretch")
         with r2:
-            open_trace = st.button("Open trace", use_container_width=True)
+            open_trace = st.button("Open trace", width="stretch")
         if retry:
             st.query_params["retry_of"] = err.context.get("run_id") or ""
             st.rerun()

--- a/app/ui/command_palette.py
+++ b/app/ui/command_palette.py
@@ -1,8 +1,8 @@
 import streamlit as st
 
-from utils.global_search import search, resolve_action
-from utils.telemetry import log_event
+from utils.global_search import resolve_action, search
 from utils.session_store import SessionStore
+from utils.telemetry import log_event
 
 
 def open_palette():
@@ -23,9 +23,10 @@ def open_palette():
             with col1:
                 st.write(f"**{r['label']}**  \n{r.get('hint','')}")
             with col2:
-                if st.button("Select", key=f"sel_{i}", use_container_width=True):
+                if st.button("Select", key=f"sel_{i}", width="stretch"):
                     act = resolve_action(r)
                     st.session_state["_cmd_action"] = act
                     st.rerun()
+
     _dlg()
     view_store.set("palette_open", False)

--- a/app/ui/components.py
+++ b/app/ui/components.py
@@ -66,6 +66,6 @@ def error_banner(err: SafeError):
             data=as_json(err),
             file_name=f"error_{err.support_id}.json",
             mime="application/json",
-            use_container_width=True,
+            width="stretch",
         )
     return True

--- a/app/ui/empty_states.py
+++ b/app/ui/empty_states.py
@@ -1,5 +1,7 @@
 import streamlit as st
+
 from utils.i18n import tr as t
+
 
 def empty_card(title_key: str, body_key: str, *, actions: list[tuple[str, str]] | None = None):
     st.info(f"**{t(title_key)}**\n\n{t(body_key)}")
@@ -8,15 +10,18 @@ def empty_card(title_key: str, body_key: str, *, actions: list[tuple[str, str]] 
         cols = st.columns(len(actions))
         for (label, key), col in zip(actions, cols):
             with col:
-                if st.button(label, key=f"empty_{key}", use_container_width=True):
+                if st.button(label, key=f"empty_{key}", width="stretch"):
                     clicked = key
     return clicked
+
 
 def trace_empty():
     return empty_card("trace_empty_title", "trace_empty_body")
 
+
 def reports_empty():
     return empty_card("reports_empty_title", "reports_empty_body")
+
 
 def metrics_empty():
     return empty_card("metrics_empty_title", "metrics_empty_body")

--- a/app/ui/graph.py
+++ b/app/ui/graph.py
@@ -1,8 +1,9 @@
 import streamlit as st
 
+
 def render_dot(dot: str, *, height: int = 520):
     """Render a Graphviz DOT string in Streamlit."""
     try:
-        st.graphviz_chart(dot, use_container_width=True, height=height)
+        st.graphviz_chart(dot, width="stretch", height=height)
     except Exception:
         st.code(dot, language="dot")

--- a/app/ui/trace_viewer.py
+++ b/app/ui/trace_viewer.py
@@ -215,11 +215,10 @@ def render_trace(
                 if step.get("citations"):
                     with st.expander("Sources"):
                         for c in step.get("citations", []):
-                            st.markdown(
-                                f"- Doc {c.get('doc_id')} — {c.get('snippet','')}")
+                            st.markdown(f"- Doc {c.get('doc_id')} — {c.get('snippet','')}")
 
     if not show_all and shown < len(filtered_steps):
-        if st.button("Load more", key=f"more_{run_id}", use_container_width=True):
+        if st.button("Load more", key=f"more_{run_id}", width="stretch"):
             st.session_state[page_key] = page + 1
             log_event(
                 {

--- a/pages/05_Health.py
+++ b/pages/05_Health.py
@@ -18,7 +18,7 @@ aria_live_region()
 if st.button(
     "⌘K Command palette",
     key="cmd_btn",
-    use_container_width=False,
+    width="content",
     help="Open global search",
 ):
     log_event({"event": "palette_opened"})
@@ -61,7 +61,7 @@ if st.button("Run diagnostics", help="Run system diagnostics"):
     cols[2].metric("fail", report.summary.get("fail", 0))
     pd = local_import("pandas")
     df = pd.DataFrame([{"id": c.id, "name": c.name, "status": c.status} for c in report.checks])
-    st.dataframe(df, use_container_width=True)
+    st.dataframe(df, width="stretch")
     for c in report.checks:
         with st.expander(c.name):
             st.write(c.details)

--- a/pages/10_Trace.py
+++ b/pages/10_Trace.py
@@ -8,10 +8,6 @@ from urllib.parse import urlencode
 
 import streamlit as st
 
-from utils.share_links import viewer_from_query
-from utils.redaction import redact_public
-from utils.telemetry import log_event
-
 from app.ui import empty_states
 from app.ui.a11y import aria_live_region, inject, main_start
 from app.ui.command_palette import open_palette
@@ -21,9 +17,12 @@ from utils.flags import is_enabled
 from utils.i18n import tr as t
 from utils.paths import artifact_path
 from utils.query_params import encode_config
+from utils.redaction import redact_public
 from utils.run_config import RunConfig, to_orchestrator_kwargs
 from utils.runs import last_run_id, list_runs
 from utils.session_store import init_stores
+from utils.share_links import viewer_from_query
+from utils.telemetry import log_event
 
 inject()
 main_start()
@@ -31,7 +30,13 @@ aria_live_region()
 
 viewer_mode, vinfo = viewer_from_query(dict(st.query_params))
 if viewer_mode:
-    log_event({"event": "share_link_accessed", "run_id": vinfo.get("rid"), "scopes": vinfo.get("scopes", [])})
+    log_event(
+        {
+            "event": "share_link_accessed",
+            "run_id": vinfo.get("rid"),
+            "scopes": vinfo.get("scopes", []),
+        }
+    )
     st.info("View only link. Some controls are disabled.")
 elif "error" in vinfo:
     if vinfo["error"] == "exp":
@@ -44,7 +49,7 @@ elif "error" in vinfo:
 if st.button(
     "⌘K Command palette",
     key="cmd_btn",
-    use_container_width=False,
+    width="content",
     help="Open global search",
 ):
     log_event({"event": "palette_opened"})
@@ -129,7 +134,7 @@ if runs:
     else:
         if meta.get("status") == "resumable" and not viewer_mode:
             st.info("This run can be resumed.")
-            if st.button("Resume run", use_container_width=True):
+            if st.button("Resume run", width="stretch"):
                 st.query_params.update({"resume_from": run_id, "view": "run"})
                 st.switch_page("app.py")
         if not viewer_mode:
@@ -155,7 +160,7 @@ if runs:
                         "included_adv": bool(include_adv),
                     }
                 )
-            if st.button("Reproduce run", use_container_width=True):
+            if st.button("Reproduce run", width="stretch"):
                 try:
                     locked = run_reproduce.load_run_inputs(run_id)
                     kwargs = run_reproduce.to_orchestrator_kwargs(locked)

--- a/pages/11_Compare_Runs.py
+++ b/pages/11_Compare_Runs.py
@@ -79,6 +79,6 @@ if run_a and run_b:
         "Download diff (.md)",
         data=md.encode("utf-8"),
         file_name=f"compare_{run_a}_{run_b}.md",
-        use_container_width=True,
+        width="stretch",
     ):
         compare_export_clicked(run_a, run_b, "md")

--- a/pages/12_History.py
+++ b/pages/12_History.py
@@ -25,7 +25,7 @@ aria_live_region()
 if st.button(
     "⌘K Command palette",
     key="cmd_btn",
-    use_container_width=False,
+    width="content",
     help="Open global search",
 ):
     log_event({"event": "palette_opened"})
@@ -154,7 +154,7 @@ if rows:
     )
     st.dataframe(
         df,
-        use_container_width=True,
+        width="stretch",
         hide_index=True,
         column_config={
             "Trace": st.column_config.LinkColumn("Trace"),

--- a/pages/25_Compare.py
+++ b/pages/25_Compare.py
@@ -33,7 +33,7 @@ aria_live_region()
 if st.button(
     "⌘K Command palette",
     key="cmd_btn",
-    use_container_width=False,
+    width="content",
     help="Open global search",
 ):
     log_event({"event": "palette_opened"})
@@ -203,7 +203,7 @@ def _load(run_id: str) -> tuple[dict, list[dict], dict, str]:
 
     col1, col2 = st.columns(2)
     if col1.download_button(
-        "Download diff CSV", to_csv(rows), file_name="run_diff.csv", use_container_width=True
+        "Download diff CSV", to_csv(rows), file_name="run_diff.csv", width="stretch"
     ):
         log_event(
             {
@@ -217,7 +217,7 @@ def _load(run_id: str) -> tuple[dict, list[dict], dict, str]:
         "Download summary Markdown",
         to_markdown(summary, rows),
         file_name="run_diff.md",
-        use_container_width=True,
+        width="stretch",
     ):
         log_event(
             {

--- a/pages/30_Metrics.py
+++ b/pages/30_Metrics.py
@@ -21,7 +21,7 @@ metrics_region = aria_live_region("metrics")
 if st.button(
     "⌘K Command palette",
     key="cmd_btn",
-    use_container_width=False,
+    width="content",
     help="Open global search",
 ):
     log_event({"event": "palette_opened"})

--- a/pages/90_Settings.py
+++ b/pages/90_Settings.py
@@ -20,7 +20,7 @@ aria_live_region()
 if st.button(
     "⌘K Command palette",
     key="cmd_btn",
-    use_container_width=False,
+    width="content",
     help="Open global search",
 ):
     log_event({"event": "palette_opened"})

--- a/pages/96_Privacy.py
+++ b/pages/96_Privacy.py
@@ -18,7 +18,7 @@ aria_live_region()
 if st.button(
     "⌘K Command palette",
     key="cmd_btn",
-    use_container_width=False,
+    width="content",
     help="Open global search",
 ):
     log_event({"event": "palette_opened"})


### PR DESCRIPTION
## Summary
- replace deprecated `use_container_width` with new `width` argument across UI components and pages

## Testing
- `pre-commit run --files app/__init__.py app/ui/command_palette.py app/ui/components.py app/ui/empty_states.py app/ui/graph.py app/ui/trace_viewer.py pages/05_Health.py pages/10_Trace.py pages/11_Compare_Runs.py pages/12_History.py pages/15_Knowledge.py pages/20_Reports.py pages/25_Compare.py pages/30_Metrics.py pages/90_Settings.py pages/96_Privacy.py`
- `pytest` *(fails: tests/gtm/test_generate_deck.py, tests/integrations/test_jira_bridge.py, tests/integrations/test_slack_bridge.py, tests/integrations/test_teams_bridge.py, tests/test_errors.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b5191e053c832cbdddbc5b9b3be9af