### PR TITLE
Fix Streamlit app entrypoint import

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,15 @@
 """Run page for the DR-RD Streamlit application."""
 
-from app import main
+import importlib
+import sys
 
-if __name__ == "__main__":
+# When this file is executed via ``streamlit run app.py`` it is loaded as the
+# module ``app`` which shadows the real ``app`` package. Drop this module from
+# ``sys.modules`` so that importing ``app`` loads the package instead of this
+# file.
+sys.modules.pop("app", None)
+
+main = importlib.import_module("app").main
+
+if __name__ in ("__main__", "app"):
     main()


### PR DESCRIPTION
## Summary
- prevent Streamlit from shadowing the real `app` package
- load `app.main` via importlib and run when executed

## Testing
- `pre-commit run --files app.py`
- `pytest tests/test_app_builder_codegen.py tests/test_global_search.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5201d6f08832caf13840f7e6760fd