### PR TITLE
Add development cycle scheduler with optional obfuscation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,38 @@ pip install -r requirements.txt
 cp .env.example .env  # edit with your keys
 streamlit run app.py
 ```
+
+## Generating a development report
+
+The script `scripts/generate_dev_report.py` demonstrates a simple
+planning/execution loop and exports a PDF summarizing the steps along
+with recent commits.  Run it after making changes to produce a report
+at `reports/build/development_report.pdf`:
+
+```bash
+python scripts/generate_dev_report.py
+```
+
+## Running the development cycle
+
+For a structured planning → execution → reporting loop, use
+`scripts/run_dev_cycle.py`. It can run the cycle once or on a schedule
+and optionally obfuscate the source code by compiling it to bytecode.
+
+Run a single cycle:
+
+```bash
+python scripts/run_dev_cycle.py
+```
+
+Run the cycle every hour:
+
+```bash
+python scripts/run_dev_cycle.py --interval 3600
+```
+
+Include an obfuscation step:
+
+```bash
+python scripts/run_dev_cycle.py --obfuscate
+```

--- a/scripts/generate_dev_report.py
+++ b/scripts/generate_dev_report.py
@@ -1,0 +1,47 @@
+"""Generate a PDF report summarizing recent development steps.
+
+This script demonstrates a simple planning/execution loop and
+produces a PDF report containing the steps and recent commit history.
+It uses the :func:`core.reporting.pdf.to_pdf` utility which falls back to
+a minimal PDF implementation if ReportLab is unavailable.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from core.reporting import pdf
+
+
+def main() -> None:
+    """Run a planning loop and export the results to a PDF report."""
+    tasks = [
+        {"stage": "Planning", "detail": "Gather requirements and outline tasks."},
+        {"stage": "Execution", "detail": "Implement features and fix bugs."},
+        {"stage": "Testing", "detail": "Run unit tests and lint checks."},
+        {"stage": "Reporting", "detail": "Generate development summary PDF."},
+    ]
+
+    lines = []
+    for step in tasks:  # planning/execution loop
+        lines.append(f"{step['stage']}: {step['detail']}")
+
+    try:
+        commits = subprocess.check_output(
+            ["git", "log", "--oneline", "-n", "5"], text=True
+        )
+        lines.append("\nRecent commits:\n" + commits.strip())
+    except Exception:  # pragma: no cover - git may be unavailable
+        lines.append("\nRecent commits: (unavailable)")
+
+    report_text = "\n".join(lines)
+
+    out_dir = Path("reports/build")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_file = out_dir / "development_report.pdf"
+    info = pdf.to_pdf(report_text, str(out_file))
+    print(f"Wrote {info['bytes']} bytes to {info['path']}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/scripts/run_dev_cycle.py
+++ b/scripts/run_dev_cycle.py
@@ -1,0 +1,70 @@
+"""Schedule the planning → execution → reporting cycle."""
+from __future__ import annotations
+
+import argparse
+import py_compile
+import sched
+import sys
+import time
+from pathlib import Path
+
+if __package__ is None or __package__ == "":  # allow running as script
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+from scripts.generate_dev_report import main as generate_report
+
+
+def obfuscate_source(src: Path, out: Path) -> None:
+    """Compile Python sources to bytecode in *out*.
+
+    This provides a lightweight form of obfuscation by distributing
+    `.pyc` files instead of raw `.py` sources.
+    """
+    for py in src.rglob("*.py"):
+        rel = py.relative_to(src)
+        target = out / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        py_compile.compile(str(py), cfile=str(target.with_suffix(".pyc")), optimize=2)
+
+
+def run_cycle(obfuscate: bool) -> None:
+    """Run one full planning → execution → reporting cycle."""
+    generate_report()
+    if obfuscate:
+        out_dir = Path("build/obfuscated")
+        obfuscate_source(Path("src"), out_dir)
+        print(f"Obfuscated bytecode written to {out_dir}")
+
+
+def schedule(interval: int, obfuscate: bool) -> None:
+    """Repeatedly run the cycle at *interval* seconds."""
+    scheduler = sched.scheduler(time.time, time.sleep)
+
+    def task() -> None:
+        run_cycle(obfuscate)
+        scheduler.enter(interval, 1, task)
+
+    scheduler.enter(0, 1, task)
+    scheduler.run()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--interval", type=int, default=0,
+        help="Seconds between cycles; 0 runs once and exits.")
+    parser.add_argument(
+        "--obfuscate", action="store_true",
+        help="Compile sources to bytecode after reporting.")
+    return parser.parse_args()
+
+
+def main() -> None:  # pragma: no cover - manual execution
+    args = parse_args()
+    if args.interval > 0:
+        schedule(args.interval, args.obfuscate)
+    else:
+        run_cycle(args.obfuscate)
+
+
+if __name__ == "__main__":  # pragma: no cover - script entrypoint
+    main()


### PR DESCRIPTION
## Summary
- document a new scheduled development cycle runner in README
- add `run_dev_cycle.py` that schedules planning→execution→reporting cycles and can obfuscate source into bytecode

## Testing
- `pytest tests/test_pdf_fallback.py tests/test_pdf_generator.py -q`
- `python scripts/run_dev_cycle.py`


------
https://chatgpt.com/codex/tasks/task_e_68b531a13288832cb91977b34c4a0fae