### PR TITLE
Handle new trace token fields in reports

### DIFF
--- a/pages/20_Reports.py
+++ b/pages/20_Reports.py
@@ -131,9 +131,19 @@ else:
     summary_text = summary_path.read_text(encoding="utf-8") if summary_path.exists() else None
     if viewer_mode and summary_text:
         summary_text = redact_public(summary_text)
+    def _step_tokens(step: dict) -> int:
+        if step.get("tokens") is not None:
+            return int(step.get("tokens") or 0)
+        return int(step.get("tokens_in") or 0) + int(step.get("tokens_out") or 0)
+
+    def _step_cost(step: dict) -> float:
+        if step.get("cost") is not None:
+            return float(step.get("cost") or 0.0)
+        return float(step.get("cost_usd") or 0.0)
+
     totals = {
-        "tokens": sum((step.get("tokens") or 0) for step in trace),
-        "cost": sum((step.get("cost") or 0.0) for step in trace),
+        "tokens": sum(_step_tokens(step) for step in trace),
+        "cost": sum(_step_cost(step) for step in trace),
     }
     results = []
     for step in trace:

--- a/tests/test_trace_export_rows_newschema.py
+++ b/tests/test_trace_export_rows_newschema.py
@@ -1,0 +1,17 @@
+from utils.trace_export import flatten_trace_rows
+
+
+def test_flatten_trace_rows_new_schema():
+    trace = [
+        {
+            "phase": "exec",
+            "name": "a",
+            "status": "complete",
+            "tokens_in": 1,
+            "tokens_out": 2,
+            "cost_usd": 0.3,
+        }
+    ]
+    rows = flatten_trace_rows(trace)
+    assert rows[0]["tokens"] == 3
+    assert rows[0]["cost"] == 0.3

--- a/utils/trace_export.py
+++ b/utils/trace_export.py
@@ -35,6 +35,15 @@ def flatten_trace_rows(trace: Sequence[TraceStep]) -> list[dict]:
                 or ""
             )
         prompt = step.get("prompt") or step.get("prompt_preview")
+
+        tokens = step.get("tokens")
+        if tokens is None:
+            tokens = (step.get("tokens_in") or 0) + (step.get("tokens_out") or 0)
+
+        cost = step.get("cost")
+        if cost is None:
+            cost = step.get("cost_usd")
+
         rows.append(
             {
                 "i": idx,
@@ -44,8 +53,8 @@ def flatten_trace_rows(trace: Sequence[TraceStep]) -> list[dict]:
                 "name": step.get("name"),
                 "status": step.get("status"),
                 "duration_ms": step.get("duration_ms"),
-                "tokens": step.get("tokens"),
-                "cost": step.get("cost"),
+                "tokens": tokens,
+                "cost": cost,
                 "summary": summary,
                 "prompt": prompt,
                 "citations": step.get("citations"),


### PR DESCRIPTION
## Summary
- include tokens_in/tokens_out and cost_usd in trace exports
- aggregate token and cost totals from new trace fields on Reports page
- test flatten_trace_rows with new schema

## Testing
- `pytest tests/test_trace_export_rows.py tests/test_trace_export_rows_newschema.py tests/test_diff_runs.py tests/test_report_builder.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b538978284832ca8d48433d2bf1972