### PR TITLE
Handle missing summary in trace viewer search

### DIFF
--- a/app/ui/trace_viewer.py
+++ b/app/ui/trace_viewer.py
@@ -130,8 +130,8 @@ def render_trace(
     for s in steps:
         haystack = " ".join(
             [
-                s.get("name", ""),
-                s.get("summary", ""),
+                s.get("name") or "",
+                s.get("summary") or "",
                 (
                     json.dumps(s.get("raw"), ensure_ascii=False)
                     if isinstance(s.get("raw"), dict)


### PR DESCRIPTION
## Summary
- prevent `render_trace` from raising `TypeError` when a step summary is `None`

## Testing
- `pre-commit run --files app/ui/trace_viewer.py`
- `pytest tests/test_agent_trace_ui_smoke.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b54d75c44c832c9a8157a5756cbc44