### PR TITLE
Handle non-string fields in trace filtering and reports, and missing durations in graph

### DIFF
--- a/app/ui/trace_viewer.py
+++ b/app/ui/trace_viewer.py
@@ -130,8 +130,8 @@ def render_trace(
     for s in steps:
         haystack = " ".join(
             [
-                s.get("name") or "",
-                s.get("summary") or "",
+                str(s.get("name") or ""),
+                str(s.get("summary") or ""),
                 (
                     json.dumps(s.get("raw"), ensure_ascii=False)
                     if isinstance(s.get("raw"), dict)

--- a/utils/graph/trace_graph.py
+++ b/utils/graph/trace_graph.py
@@ -43,13 +43,14 @@ def build_graph(rows: list[dict[str, Any]]) -> tuple[list[Node], list[Edge]]:
     for r in rows:
         sid = str(r.get("id") or f"s{r['i']}")
         status = str(r.get("status") or "unknown")
+        dur_ms = int(r.get("duration_ms") or 0)
         nodes.append(
             Node(
                 id=sid,
-                label=f"{r.get('name','step')}\\n{int(r.get('duration_ms',0))/1000:.1f}s",
+                label=f"{r.get('name','step')}\\n{dur_ms/1000:.1f}s",
                 phase=str(r.get("phase", "")),
                 status=status,
-                dur_ms=int(r.get("duration_ms", 0)),
+                dur_ms=dur_ms,
             )
         )
     # Index by phase for sequential edges

--- a/utils/report_html.py
+++ b/utils/report_html.py
@@ -1,10 +1,10 @@
-from __future__ import annotations
-
 """HTML report builder for DR RD runs."""
 
-from datetime import datetime
+from __future__ import annotations
+
 import html
-from typing import Callable, Mapping, Sequence, Tuple
+from datetime import datetime
+from typing import Callable, Mapping, Sequence
 
 from .report_builder import summarize_steps
 
@@ -25,13 +25,13 @@ def _iso(ts: object | None) -> str:
     return ""
 
 
-def _short(text: str | None, limit: int = 80) -> str:
-    text = text or ""
+def _short(text: object | None, limit: int = 80) -> str:
+    text = "" if text is None else str(text)
     return text[:limit]
 
 
 CSS = (
-    "body{font-family:-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,\"Helvetica Neue\",Arial,sans-serif;"
+    'body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;'
     "font-size:16px;line-height:1.5;color:#0A0A0A;background:#FFFFFF;padding:1rem;}"
     "h1,h2,h3{color:#0A0A0A;}"
     "table{width:100%;border-collapse:collapse;margin-top:1rem;}"
@@ -55,16 +55,16 @@ def build_html_report(
     rows: Sequence[Mapping],
     summary_text: str | None,
     totals: Mapping | None,
-    artifacts: Sequence[Tuple[str, str]] | None = None,
+    artifacts: Sequence[tuple[str, str]] | None = None,
     sanitizer: Callable[[str], str] | None = None,
 ) -> str:
     """Return a complete UTF-8 HTML report string."""
 
     lines: list[str] = []
     lines.append("<!DOCTYPE html>")
-    lines.append("<html lang=\"en\">")
+    lines.append('<html lang="en">')
     lines.append("<head>")
-    lines.append("<meta charset=\"utf-8\">")
+    lines.append('<meta charset="utf-8">')
     lines.append(f"<title>DR RD Report — {_esc(run_id)}</title>")
     lines.append("<style>" + CSS + "</style>")
     lines.append("</head>")
@@ -114,20 +114,20 @@ def build_html_report(
 
     # Metrics
     lines.append("<h2>Metrics</h2>")
-    lines.append("<div class=\"metrics\">")
+    lines.append('<div class="metrics">')
     lines.append(
-        f"<div class=\"metric\"><span class=\"label\">Steps</span><span class=\"value\">{len(rows)}</span></div>"
+        f'<div class="metric"><span class="label">Steps</span><span class="value">{len(rows)}</span></div>'
     )
     if totals:
         tokens = totals.get("tokens") if isinstance(totals, Mapping) else None
         cost = totals.get("cost") if isinstance(totals, Mapping) else None
         if tokens is not None:
             lines.append(
-                f"<div class=\"metric\"><span class=\"label\">Tokens</span><span class=\"value\">{_esc(tokens)}</span></div>"
+                f'<div class="metric"><span class="label">Tokens</span><span class="value">{_esc(tokens)}</span></div>'
             )
         if cost is not None:
             lines.append(
-                f"<div class=\"metric\"><span class=\"label\">Cost</span><span class=\"value\">${float(cost):.4f}</span></div>"
+                f'<div class="metric"><span class="label">Cost</span><span class="value">${float(cost):.4f}</span></div>'
             )
     lines.append("</div>")
 
@@ -138,7 +138,7 @@ def build_html_report(
     )
     for r in rows:
         status = r.get("status")
-        chip = f"<span class=\"chip {status}\">{_esc(status)}</span>" if status else ""
+        chip = f'<span class="chip {status}">{_esc(status)}</span>' if status else ""
         lines.append(
             "<tr>"
             f"<td>{_esc(r.get('i'))}</td>"
@@ -159,9 +159,7 @@ def build_html_report(
         lines.append("<h2>Errors</h2>")
         lines.append("<ul>")
         for e in errors:
-            lines.append(
-                f"<li>{_esc(e.get('name'))} — {_esc(e.get('summary'))}</li>"
-            )
+            lines.append(f"<li>{_esc(e.get('name'))} — {_esc(e.get('summary'))}</li>")
         lines.append("</ul>")
 
     # Artifacts
@@ -170,7 +168,7 @@ def build_html_report(
         lines.append("<ul>")
         for name, rel in artifacts:
             href = _esc(rel)
-            lines.append(f"<li><a href=\"{href}\">{_esc(name)}</a></li>")
+            lines.append(f'<li><a href="{href}">{_esc(name)}</a></li>')
         lines.append("</ul>")
 
     lines.append("</body></html>")


### PR DESCRIPTION
## Summary
- Avoid TypeError when trace step fields are non-strings by converting values to strings before filtering
- Prevent KeyError in HTML report generation by stringifying summary text before truncation
- Default missing step durations to zero when building trace graphs to avoid conversion errors

## Testing
- `pre-commit run --files app/ui/trace_viewer.py utils/report_html.py utils/graph/trace_graph.py`
- `pytest tests/test_report_html.py tests/test_agent_trace_ui_smoke.py tests/test_trace_graph.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5bcad18c8832c85ab7fae9e47d735