### PR TITLE
Fix trace export and safety badge robustness

### DIFF
--- a/app/ui/safety.py
+++ b/app/ui/safety.py
@@ -4,7 +4,16 @@ import streamlit as st
 def badge(result, *, where: str):
     if not result.findings:
         return
-    sev = max((f.severity for f in result.findings), default="low")
+    # ``result.findings`` may contain lightweight dicts when coming from
+    # JSON sources instead of rich objects.  Access ``severity`` via
+    # ``getattr``/``dict.get`` to support both shapes.
+    severities = []
+    for f in result.findings:
+        sev = getattr(f, "severity", None)
+        if sev is None and isinstance(f, dict):
+            sev = f.get("severity")
+        severities.append(sev or "low")
+    sev = max(severities, default="low")
     label = f"Safety: {sev.upper()} ({len(result.findings)})"
     st.caption(label)
 


### PR DESCRIPTION
## Summary
- avoid KeyError when trace step summary is not a string
- support dict-based findings in safety badge rendering
- handle missing phase values when aligning trace steps for run comparisons

## Testing
- `pre-commit run --files utils/trace_export.py app/ui/safety.py utils/compare.py`
- `pytest tests/test_trace_export.py tests/test_trace_export_rows.py tests/test_trace_export_rows_newschema.py tests/test_diff_runs.py tests/test_compare.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5cbf973ac832cb5ee0d01cab5255e