### PR TITLE
Handle non-string summaries in trace markdown export

### DIFF
--- a/utils/trace_export.py
+++ b/utils/trace_export.py
@@ -147,7 +147,10 @@ def to_markdown(
             if meta:
                 header += f" ({', '.join(meta)})"
             lines.append(header)
-            summary = step.get("summary") or ""
+            raw_summary = step.get("summary")
+            if not raw_summary:
+                raw_summary = step.get("output") or step.get("result") or step.get("text") or ""
+            summary = _safe_summary(raw_summary, max_len=10_000)
             if sanitizer:
                 summary = sanitizer(summary)
             if len(summary) <= 200:


### PR DESCRIPTION
## Summary
- avoid AttributeError when exporting traces with non-string summaries by normalizing summary data before markdown generation
- fallback to alternate output fields when summary is missing

## Testing
- `pre-commit run --files utils/trace_export.py`
- `pytest tests/test_trace_export.py tests/test_trace_export_rows.py tests/test_trace_export_rows_newschema.py`

------
https://chatgpt.com/codex/tasks/task_e_68b5d9e397a8832cb50670b5f12def76