### PR TITLE
Handle colon-separated role tasks in planner output

### DIFF
--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -101,6 +101,23 @@ def _normalize_plan_payload(data: dict) -> dict:
             if "summary" in t and "title" not in t:
                 t["title"] = t.get("summary")
 
+            # Some legacy planners stuffed the task details into the ``role``
+            # field using a ``Role: task`` format. Split that into the new
+            # separate role/title/summary fields so validation succeeds.
+            if (
+                "role" in t
+                and "title" not in t
+                and "summary" not in t
+                and isinstance(t["role"], str)
+                and ":" in t["role"]
+            ):
+                role, task = t["role"].split(":", 1)
+                t["role"] = role.strip()
+                task = task.strip()
+                t.setdefault("title", task)
+                t.setdefault("summary", task)
+                t.setdefault("description", task)
+
         if missing:
             logger.info("Planner normalizer injected %d task IDs", missing)
     return data

--- a/tests/test_planner_schema.py
+++ b/tests/test_planner_schema.py
@@ -24,3 +24,13 @@ def test_legacy_task_field_backfilled():
     t = validated.tasks[0]
     assert t.title == "Build prototype"
     assert t.summary == "Build prototype"
+
+
+def test_role_field_with_colon_split():
+    data = {"tasks": [{"role": "Product Manager: Draft updates"}]}
+    norm = _normalize_plan_payload(data)
+    validated = Plan.model_validate(norm)
+    t = validated.tasks[0]
+    assert t.role == "Product Manager"
+    assert t.title == "Draft updates"
+    assert t.summary == "Draft updates"


### PR DESCRIPTION
## Summary
- split legacy `Role: task` strings into role, title, and summary in `_normalize_plan_payload`
- test colon-separated role string normalization

## Testing
- `pytest tests/test_planner_schema.py tests/test_planner_normalize.py`

------
https://chatgpt.com/codex/tasks/task_e_68b5fb4a6fc0832c9ea35b44ebec4ec2