### PR TITLE
Fix Streamlit session state mutation in trace viewer

### DIFF
--- a/app/ui/trace_viewer.py
+++ b/app/ui/trace_viewer.py
@@ -232,7 +232,6 @@ def render_trace(
     prev_show_all = show_all
     show_all_new = st.checkbox("Show all", key=show_all_key, value=show_all)
     if show_all_new != prev_show_all:
-        st.session_state[show_all_key] = show_all_new
         log_event(
             {
                 "event": "trace_page_changed",


### PR DESCRIPTION
## Summary
- avoid modifying `st.session_state` after widget instantiation in trace viewer
- keep telemetry logging when 'Show all' toggled

## Testing
- `pre-commit run --files app/ui/trace_viewer.py tests/test_agent_trace_ui_smoke.py`
- `pytest tests/test_agent_trace_ui_smoke.py`


------
https://chatgpt.com/codex/tasks/task_e_68b60e51a954832cb094caa1372a47d0