### PR TITLE
docs: add user-facing guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ prototype or development plan.
 See the docs index in [docs/INDEX.md](docs/INDEX.md) for more information.
 New contributors should start with the [Migration Guide](docs/MIGRATION_GUIDE_v1_to_v2.md).
 
+## Get Started
+For a short setup guide, see [docs/QUICKSTART.md](docs/QUICKSTART.md). The full
+user guide is available at [docs/USER_GUIDE.md](docs/USER_GUIDE.md).
+
 _Current repo state_
 **Step 1:** Minimal Streamlit front-end + “Creation Planner” prompt.
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -303,3 +303,27 @@ Runtime dependencies live in `requirements.in` and development tooling in `dev-r
 License reports are produced by `scripts/check_licenses.py` and written to `reports/licenses.json`.
 
 CI enforces license and vulnerability gates. `pip-licenses` and `pip-audit` write reports to `reports/licenses.json` and `reports/pip-audit.json`. Builds fail on HIGH/CRITICAL vulnerabilities unless `AUDIT_ALLOW_HIGH=1` (default `0`).
+
+## Streamlit App Controls
+The sidebar fields map to run-time configuration values:
+
+| UI Control | Config Field | Description |
+|------------|--------------|-------------|
+| Project idea | `RunConfig.idea` | Core prompt sent to the planner |
+| Mode | `RunConfig.mode` | Selects preset cost and search behaviour |
+| Knowledge sources | `RunConfig.knowledge_sources` | List of vector stores used for retrieval |
+| Show agent trace | `RunConfig.show_agent_trace` | Display detailed step logs |
+| Auto export trace | `RunConfig.auto_export_trace` | Save trace files when a run completes |
+| Auto export report | `RunConfig.auto_export_report` | Save markdown report after completion |
+| Temperature | `advanced.temperature` | Sampling temperature passed to models |
+| Retries | `advanced.retries` | Maximum retry attempts for API calls |
+| Timeout (s) | `advanced.timeout` | Overall run timeout in seconds |
+
+## Key Environment Variables
+| Variable | Purpose |
+|----------|---------|
+| `OPENAI_API_KEY` | Access to OpenAI models and embeddings |
+| `SERPAPI_KEY` | Enables SerpAPI live search backend |
+| `RAG_ENABLED` | Toggles vector index retrieval |
+| `ENABLE_LIVE_SEARCH` | Allows web search fallback |
+| `BUDGET_PROFILE` | Chooses cost profile such as `low`, `standard`, or `high` |

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,0 +1,27 @@
+# Quickstart
+
+## Streamlit Community Cloud
+1. Fork the repository.
+2. In the Streamlit workspace, click **New app** and select the fork.
+3. Under *Advanced settings*, add required secrets (`OPENAI_API_KEY`, optional `SERPAPI_KEY`).
+4. Click **Deploy** and wait for the build to finish.
+
+## Local Development
+1. Install Python 3.10+ and Git.
+2. Clone and set up a virtual environment:
+   ```bash
+   git clone https://github.com/clcriswell/DR-RD.git
+   cd DR-RD
+   python -m venv .venv
+   source .venv/bin/activate  # Windows: .venv\Scripts\Activate.ps1
+   pip install -r requirements.txt
+   ```
+3. Set API keys:
+   ```bash
+   export OPENAI_API_KEY=your_key
+   export SERPAPI_KEY=optional_key
+   ```
+4. Run the app:
+   ```bash
+   streamlit run app.py
+   ```

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-08-31T03:37:01.894758Z from commit 43189ff_
+_Last generated at 2025-09-01T21:39:04.074274Z from commit 8ec9e26_

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,16 @@
+# Troubleshooting
+
+## Missing API Keys
+The app requires `OPENAI_API_KEY` for language models. Web search backends need `SERPAPI_KEY` or other provider keys. Ensure these are set in Streamlit secrets or environment variables.
+
+## API Quotas or Rate Limits
+If runs stop early or return errors, you may have hit a provider quota. Wait before retrying or reduce the number of runs.
+
+## Empty or Incomplete Results
+Check that the selected mode enables retrieval and live search. Lack of knowledge sources or disabled RAG may yield empty answers.
+
+## PDF Generation Errors
+The PDF exporter supports up to 50 pages. Larger documents or malformed Markdown may fail to render.
+
+## Unicode or Encoding Issues
+If output shows garbled characters, ensure your terminal and browser use UTF‑8 encoding.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,0 +1,95 @@
+# DR-RD Streamlit App User Guide
+
+## Overview and Capabilities
+DR-RD is an AI research and development workbench that takes a project idea, plans tasks, routes them to specialized agents, executes the plan, and synthesizes a proposal. The Streamlit interface exposes a thin UI while the orchestration logic lives in backend modules.
+
+```mermaid
+flowchart LR
+    A[Planner] --> B[Router/Registry]
+    B --> C[Executor]
+    C --> D[Synthesizer]
+    D --> E[UI]
+```
+
+## Quick Start
+### Streamlit Community Cloud
+1. Fork the repository and deploy from the Streamlit workspace. Streamlit Cloud builds most apps in minutes and only needs a GitHub link.
+2. In the app's *Advanced settings*, paste required secrets such as `OPENAI_API_KEY` and `SERPAPI_KEY`.
+3. Click **Deploy** and open the resulting URL to start using the app.
+
+### Local Development
+1. Install Python 3.10+ and Git.
+2. Clone the repo and install dependencies:
+   ```bash
+   git clone https://github.com/clcriswell/DR-RD.git
+   cd DR-RD
+   python -m venv .venv
+   source .venv/bin/activate  # Windows: .venv\Scripts\Activate.ps1
+   pip install -r requirements.txt
+   ```
+3. Provide API keys via environment variables or a `.env` file.
+4. Launch the app:
+   ```bash
+   streamlit run app.py
+   ```
+
+## Configuration
+Most run-time options live in the sidebar:
+- **Project idea** – free‑form text describing the goal.
+- **Mode** – selects presets that control target cost, retrieval, and search behavior.
+- **Knowledge sources** – choose built-in or uploaded sources for RAG.
+- **Diagnostics** – toggle agent trace and verbose planner output.
+- **Exports** – auto-export trace or report after a run.
+- **Advanced options** – temperature, retries, and overall timeout.
+
+Modes are defined in `config/modes.yaml` and include switches for vector search and live web search.
+
+## Using the App
+1. Enter an idea in the sidebar and adjust settings.
+2. Click **Run** (from the main page) to generate a plan, execute tasks, and view results.
+3. Review the synthesized proposal in the main panel.
+
+## Agent Trace
+When **Show agent trace** is enabled, a Trace page becomes available:
+- **Live Status** shows per-task progress, token counts, and cost.
+- **Role tabs** display each agent's output with optional raw views.
+- **Run Diff** compares two runs and can export incident bundles.
+- **Trace Viewer** lets you filter steps and download JSON, CSV, or Markdown reports.
+
+## Retrieval and Web Search
+The system first queries a FAISS vector index when retrieval is enabled. If no context is found and live search is on, a web search backend such as OpenAI or SerpAPI provides additional snippets. Both pathways respect retrieval budgets to avoid excessive calls.
+
+## Budgets and Cost Meter
+Each mode targets a total cost (e.g., $2.50 for *standard*). The cost meter estimates remaining budget before a run and shows actual vs. projected spend afterward.
+
+## Export and Downloads
+- Automatic export options produce trace files or markdown reports on completion.
+- The Trace viewer provides buttons to download the full trace (JSON), a summary (CSV), or a readable report (Markdown).
+- Generated reports can be saved as PDF via the **Download PDF** button.
+
+## Troubleshooting
+- **Missing API key** – ensure `OPENAI_API_KEY` and optional search keys are set.
+- **Quota or network errors** – retry later; costs are shown in the trace.
+- **Empty results** – check that RAG and live search are enabled for the chosen mode.
+- **PDF issues** – ensure documents have fewer than 50 pages.
+
+## Security and Privacy
+Secrets are stored in Streamlit's encrypted settings or local `.env` files. Only the provided API keys are sent to external services. Trace exports redact sensitive fields based on repository policies.
+
+## FAQ
+**What does Mode control?** Preset budgets, model choices, and retrieval defaults.
+
+**Can I rerun a session?** Use the **Retry run** button shown on error banners or rerun with the same idea.
+
+**Where are files saved?** Downloads are temporary; the container's filesystem is ephemeral.
+
+## Observed vs Intended
+| Feature | Observed | Intended | Recommendation |
+|--------|----------|---------|----------------|
+| RAG toggle | Enabled via mode only | Explicit UI toggle | Consider exposing a direct RAG checkbox for clarity |
+| PDF export | Manual button | Auto-export on completion | Document automation or enable by default |
+
+## Glossary
+- **RAG** – Retrieval-Augmented Generation, using a vector index to supply context.
+- **SerpAPI** – Web search API used for live search when enabled.
+- **Trace** – Detailed log of planner, executor, and synthesizer steps.

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-08-31T03:37:01.894758Z'
-git_sha: 43189ff0ec66cfe3ff2da6fddc1c951711d4e906
+generated_at: '2025-09-01T21:39:04.074274Z'
+git_sha: 8ec9e265b07214a5e112df94be976ab39719f1ad
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -191,7 +191,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/plan_utils.py
+- path: orchestrators/app_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -205,13 +205,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/qa_router.py
   role: Orchestrator
   responsibilities: []
@@ -219,14 +212,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/__init__.py
-  role: Summarization
+- path: orchestrators/plan_utils.py
+  role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/schemas.py
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -241,6 +234,13 @@ modules:
   invoked_by: []
   invokes: []
 - path: core/summarization/integrator.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []


### PR DESCRIPTION
## Summary
- add comprehensive Streamlit app user guide
- provide quickstart and troubleshooting references
- document sidebar controls and env vars

## Testing
- `python scripts/generate_repo_map.py`
- `pytest -q` *(fails: Module errors in integrations and gtm tests)*


------
https://chatgpt.com/codex/tasks/task_e_68b610f8ddb8832c9b44ba3aa378f33c