### PR TITLE
Planner → Plan compatibility: alias mapping, normalization, and recovery

### DIFF
--- a/core/schemas.py
+++ b/core/schemas.py
@@ -1,40 +1,45 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import AliasChoices, BaseModel, Field
+from pydantic.config import ConfigDict
 
 
 class ScopeNote(BaseModel):
     """Metadata captured from the intake UI about the project scope."""
 
     idea: str
-    constraints: List[str]
-    time_budget_hours: Optional[float] = None
-    cost_budget_usd: Optional[float] = None
+    constraints: list[str]
+    time_budget_hours: float | None = None
+    cost_budget_usd: float | None = None
     risk_posture: Literal["low", "medium", "high"]
-    redaction_rules: Optional[List[str]] = None
+    redaction_rules: list[str] | None = None
 
 
 class Task(BaseModel):
     """Single task item produced by the planner."""
 
     id: str
-    role: str
-    title: str
-    summary: str
-    description: Optional[str] = None
-    inputs: Optional[Dict[str, Any]] = None
-    dependencies: List[str] = Field(default_factory=list)
-    stop_rules: List[str] = Field(default_factory=list)
-    tags: List[str] = Field(default_factory=list)
-    tool_request: Optional[Dict[str, Any]] = None
+    title: str = Field(validation_alias=AliasChoices("title", "role", "name"))
+    summary: str = Field(
+        validation_alias=AliasChoices("summary", "objective", "description", "goal")
+    )
+    inputs: dict[str, Any] | None = None
+    dependencies: list[str] = Field(default_factory=list)
+    stop_rules: list[str] = Field(default_factory=list)
+    tags: list[str] = Field(default_factory=list)
+    tool_request: dict[str, Any] | None = None
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
 
 
 class Plan(BaseModel):
     """Planner response schema."""
 
-    tasks: List[Task] = Field(min_length=1)
+    tasks: list[Task] = Field(min_length=1)
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
 
 
 class ConceptBrief(BaseModel):
@@ -56,8 +61,8 @@ class RoleCard(BaseModel):
 class TaskSpec(BaseModel):
     role: str
     task: str
-    inputs: Optional[dict[str, Any]] = None
-    stop_rules: Optional[list[str]] = None
+    inputs: dict[str, Any] | None = None
+    stop_rules: list[str] | None = None
 
 
 __all__ = [

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-09-01T21:39:04.074274Z from commit 8ec9e26_
+_Last generated at 2025-09-02T01:35:17.472738Z from commit bfe43af_

--- a/dr_rd/schemas/planner_v1.json
+++ b/dr_rd/schemas/planner_v1.json
@@ -9,11 +9,11 @@
       "items": {
         "type": "object",
         "properties": {
+          "id": {"type": "string"},
           "title": {"type": "string"},
-          "desc": {"type": "string"},
-          "role_hint": {"type": "string"}
+          "summary": {"type": "string"}
         },
-        "required": ["title", "desc"],
+        "required": ["id", "title", "summary"],
         "additionalProperties": false
       }
     },

--- a/prompts/prompts.py
+++ b/prompts/prompts.py
@@ -1,13 +1,13 @@
 """Central repository of prompt templates used across agents."""
 
 PLANNER_SYSTEM_PROMPT = (
-    # Schema: dr_rd/schemas/planner_agent.json
+    # Schema: dr_rd/schemas/planner_v1.json
     "You are a Project Planner AI. Decompose the idea into role-specific tasks. "
     "Prefer assigning tasks to these roles where appropriate: CTO, Research Scientist, Regulatory, Finance, Marketing Analyst, IP Analyst, HRM, Materials Engineer, Reflection, Synthesizer. "
     "If a task clearly needs repository reading/patch planning, numerical simulation/Monte Carlo, or image/video analysis, you may include an optional tool_request object with the tool name (read_repo | plan_patch | simulate | analyze_image | analyze_video) and minimal params. "
     'When background research is required, you may also add "retrieval_request": true and/or "queries": ["..."] to hint the orchestrator. '
     'For patent or regulatory needs, tasks may include optional ip_request {"query":str,...} and/or compliance_request {"profile_ids":[...],"min_coverage":float}. '
-    'Output ONLY JSON matching this schema: {"tasks":[{"id":"T01","role":"Role","title":"Task title","summary":"Short","tool_request":{"tool":"simulate","params":{"inputs":{"a":1.0},"monte_carlo":10,"seed":42}}}]}.'
+    'Output ONLY JSON matching this schema: {"tasks":[{"id":"T01","title":"CTO","summary":"Assess feasibility"}]}.'
 )
 
 PLANNER_USER_PROMPT_TEMPLATE = (

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-09-01T21:39:04.074274Z'
-git_sha: 8ec9e265b07214a5e112df94be976ab39719f1ad
+generated_at: '2025-09-02T01:35:17.472738Z'
+git_sha: bfe43af8333b8c4f83a75ede9bee13268fabe171
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -184,6 +184,27 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
+- path: orchestrators/spec_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/plan_utils.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/qa_router.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
 - path: orchestrators/__init__.py
   role: Orchestrator
   responsibilities: []
@@ -198,28 +219,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/spec_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/qa_router.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/plan_utils.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: core/summarization/__init__.py
+- path: core/summarization/integrator.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -233,14 +233,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
+- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/schemas.py
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_orchestrator_recovery.py
+++ b/tests/test_orchestrator_recovery.py
@@ -1,0 +1,15 @@
+import pytest
+from pydantic import ValidationError
+
+from core.orchestrator import _normalize_plan_payload
+from core.schemas import Plan
+
+
+def test_orchestrator_recovery_normalizes_and_validates():
+    data = {"tasks": [{"role": "CTO", "objective": "Assess"}]}
+    with pytest.raises(ValidationError):
+        Plan.model_validate(data)
+    norm = _normalize_plan_payload(data)
+    plan = Plan.model_validate(norm)
+    assert plan.tasks[0].title == "CTO"
+    assert plan.tasks[0].summary == "Assess"

--- a/tests/test_planner_schema_strict.py
+++ b/tests/test_planner_schema_strict.py
@@ -1,0 +1,14 @@
+import pytest
+from pydantic import ValidationError
+
+from core.orchestrator import _normalize_plan_payload
+from core.schemas import Plan
+
+
+def test_planner_schema_strict_rejects_bad_keys():
+    data = {"tasks": [{"foo": "bar"}]}
+    with pytest.raises(ValidationError):
+        Plan.model_validate(data)
+    norm = _normalize_plan_payload(data)
+    with pytest.raises(ValidationError):
+        Plan.model_validate(norm)

--- a/tests/test_schemas_minimal.py
+++ b/tests/test_schemas_minimal.py
@@ -41,5 +41,5 @@ def test_task_spec_instantiation():
 
 
 def test_plan_requires_id_and_summary():
-    plan = Plan(tasks=[Task(id="T1", role="R", title="T", summary="S")])
+    plan = Plan(tasks=[Task(id="T1", title="R", summary="S")])
     assert plan.tasks[0].id == "T1"

--- a/tests/test_task_alias_mapping.py
+++ b/tests/test_task_alias_mapping.py
@@ -1,0 +1,15 @@
+from core.schemas import Task
+
+
+def test_task_alias_mapping_role_objective():
+    t = Task.model_validate({"id": "1", "role": "CTO", "objective": "Assess architecture"})
+    assert t.title == "CTO"
+    assert t.summary == "Assess architecture"
+
+
+def test_task_alias_mapping_name_description():
+    t = Task.model_validate(
+        {"id": "2", "name": "Research Scientist", "description": "Study feasibility"}
+    )
+    assert t.title == "Research Scientist"
+    assert t.summary == "Study feasibility"


### PR DESCRIPTION
## Summary
- expand Task model to accept common planner aliases and ignore extras
- normalize planner output before validation and retry with logged dump on failure
- tighten planner schema/prompt to require `id`, `title`, and `summary` only

## Testing
- `pytest tests/test_task_alias_mapping.py tests/test_orchestrator_recovery.py tests/test_planner_schema_strict.py tests/test_schemas_minimal.py`
- `pre-commit run --files core/orchestrator.py core/plan_utils.py core/schemas.py docs/REPO_MAP.md dr_rd/schemas/planner_v1.json prompts/prompts.py repo_map.yaml tests/test_schemas_minimal.py tests/test_orchestrator_recovery.py tests/test_planner_schema_strict.py tests/test_task_alias_mapping.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6474a1cf4832c8534dc47031fda2d