### PR TITLE
feat: add field-level aliasing and segmentation

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -10,6 +10,7 @@ init_gcp_logging()
 import io
 import json
 import logging
+import os
 import time
 
 import fitz
@@ -368,6 +369,9 @@ def main() -> None:
         cfg = replace(cfg, mode="demo")
 
     kwargs = to_orchestrator_kwargs(cfg)
+    os.environ["DRRD_PSEUDONYMIZE_TO_MODEL"] = (
+        "1" if kwargs.get("pseudonymize_to_model", True) else "0"
+    )
     resume_from = st.query_params.pop("resume_from", None)
     if resume_from:
         kwargs["resume_from"] = resume_from

--- a/app/ui/sidebar.py
+++ b/app/ui/sidebar.py
@@ -108,6 +108,14 @@ def render_sidebar() -> RunConfig:
             )
             run_store.set("verbose_planner", verbose_planner)
             _track_change("verbose_planner", verbose_planner)
+            aliasing = st.checkbox(
+                "Alias sensitive entities",
+                value=run_store.get("pseudonymize_to_model", True),
+                key="pseudonymize_to_model",
+                help="Show placeholder labels like [PERSON_1] in outputs",
+            )
+            run_store.set("pseudonymize_to_model", aliasing)
+            _track_change("pseudonymize_to_model", aliasing)
 
         with st.expander("Exports"):
             auto_export_trace = st.checkbox(

--- a/core/plan_utils.py
+++ b/core/plan_utils.py
@@ -88,5 +88,9 @@ def normalize_tasks(tasks: list[dict[str, Any]]) -> list[dict[str, Any]]:
         }
         if t.get("tool_request"):
             task["tool_request"] = t.get("tool_request")
+        if t.get("field"):
+            task["field"] = t.get("field")
+        if t.get("context"):
+            task["context"] = t.get("context")
         deduped.append(task)
     return deduped

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -20,6 +20,11 @@ per-artifact TTLs, PII detection patterns and erasure parameters. Tenants may
 override values via `config/tenants/{org}/{workspace}/retention.yaml`.
 Set the `PRIVACY_SALT` environment variable to derive stable subject hashes.
 
+`DRRD_PSEUDONYMIZE_TO_MODEL` controls per-field aliasing before any model call.
+When set (default), sensitive entities are replaced with placeholders like
+`[PERSON_1]`. The Streamlit sidebar exposes an "Alias sensitive entities" toggle
+which writes this flag for the current run.
+
 Diagnostics for trace diffing read thresholds from `config/diagnostics.yaml`:
 
 - `latency.warn_ms` / `latency.fail_ms`

--- a/docs/PRIVACY_SEGMENTATION.md
+++ b/docs/PRIVACY_SEGMENTATION.md
@@ -1,0 +1,30 @@
+# Privacy Segmentation
+
+The execution pipeline isolates context for each field. The Planner emits tasks with a
+canonical `field` key (e.g. `finance`, `regulatory`) and a minimal `context`
+string describing only what that field needs to know. During execution the
+orchestrator:
+
+1. selects the agent for the task,
+2. aliases detected entities per field,
+3. pseudonymizes the context via `pseudonymize_for_model`, and
+4. dispatches the sanitized payload to the agent.
+
+Aliases are reversible only during final synthesis. Intermediate requests and
+logs contain placeholder tokens like `[PERSON_1]`. The combined alias map is
+applied after the Synthesizer runs so that the final report restores the
+original entities.
+
+## Example
+
+A two-field plan might produce tasks:
+
+```json
+[
+  {"role": "Regulatory", "field": "regulatory", "context": "Review [ORG_1] filing"},
+  {"role": "Finance", "field": "finance", "context": "Model [PERSON_1] budget"}
+]
+```
+
+Each agent sees only its `context` with aliased entities. The final proposal is
+de-aliased before presentation.

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-09-02T01:35:17.472738Z from commit bfe43af_
+_Last generated at 2025-09-02T06:07:13.364285Z from commit d44303e_

--- a/orchestrators/plan_utils.py
+++ b/orchestrators/plan_utils.py
@@ -93,5 +93,8 @@ def _post(tasks: List[Dict[str, str]], backfill: bool, dedupe: bool) -> List[Dic
                     "description": f"Draft first actionable tasks for {miss} to advance the project.",
                 }
             )
+    for t in tasks:
+        t.setdefault("field", t["role"].lower().replace(" ", "_"))
+        t.setdefault("context", t.get("description", ""))
     return tasks
 

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-09-02T01:35:17.472738Z'
-git_sha: bfe43af8333b8c4f83a75ede9bee13268fabe171
+generated_at: '2025-09-02T06:07:13.364285Z'
+git_sha: d44303e0691fe7f2b024cde477f1706481d49ec6
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -184,7 +184,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/spec_builder.py
+- path: orchestrators/app_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -192,6 +192,13 @@ modules:
   invoked_by: []
   invokes: []
 - path: orchestrators/plan_utils.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -206,13 +213,6 @@ modules:
   invoked_by: []
   invokes: []
 - path: orchestrators/__init__.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/app_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []

--- a/tests/test_privacy_segmentation.py
+++ b/tests/test_privacy_segmentation.py
@@ -1,0 +1,91 @@
+import streamlit as st
+
+from core import orchestrator
+
+
+def test_no_raw_entities_in_agent_call():
+    st.session_state.clear()
+    recorded = {}
+
+    class FakeAgent:
+        def run(self, context, task, model=None):
+            recorded["context"] = context
+            recorded["task"] = task
+            return "{}"
+
+    task = {"title": "Greet", "description": "Meet Alice at Bob Corp", "context": "Meet Alice at Bob Corp"}
+    orchestrator._invoke_agent(FakeAgent(), "irrelevant", task)
+    assert "Alice" not in recorded["context"]
+    assert "Bob Corp" not in recorded["task"]["description"]
+    assert task["alias_map"]
+
+
+def test_alias_map_per_field():
+    st.session_state.clear()
+
+    class FakeAgent:
+        def run(self, context, task, model=None):
+            return "{}"
+
+    t1 = {"title": "T1", "description": "Talk to Alice", "context": "Talk to Alice"}
+    t2 = {"title": "T2", "description": "Email Bob", "context": "Email Bob"}
+    orchestrator._invoke_agent(FakeAgent(), "i1", t1)
+    orchestrator._invoke_agent(FakeAgent(), "i2", t2)
+    assert t1["alias_map"] != t2["alias_map"]
+
+
+def test_synthesis_de_aliases(monkeypatch):
+    st.session_state.clear()
+    st.session_state["alias_maps"] = {"r": {"Alice": "[PERSON_1]"}}
+
+    captured = {}
+
+    def fake_complete(system, prompt):
+        captured["prompt"] = prompt
+        return type("R", (), {"content": "Report about [PERSON_1]"})()
+
+    monkeypatch.setattr(orchestrator, "complete", fake_complete)
+    out = orchestrator.compose_final_proposal("Idea about Alice", {"r": "[PERSON_1] did work"})
+    assert "[PERSON_1]" in captured["prompt"]
+    assert "Alice" in out
+
+
+def test_multi_field_plan(monkeypatch):
+    st.session_state.clear()
+    calls = []
+
+    class FakeAgent:
+        def run(self, context, task, model=None):
+            calls.append({"context": context, "task": task})
+            return "{}"
+
+    agents = {"Regulatory": FakeAgent(), "Finance": FakeAgent()}
+    tasks = [
+        {
+            "role": "Regulatory",
+            "title": "Check",
+            "description": "Review Alice filing",
+            "context": "Review Alice filing",
+        },
+        {
+            "role": "Finance",
+            "title": "Budget",
+            "description": "Assess Bob Corp budget",
+            "context": "Assess Bob Corp budget",
+        },
+    ]
+    orchestrator.execute_plan(
+        "Project about Alice and Bob Corp",
+        tasks,
+        agents=agents,
+        save_decision_log=False,
+        save_evidence=False,
+    )
+    roles = [c["task"]["role"] for c in calls]
+    assert "Regulatory" in roles and "Finance" in roles
+    reg_call = next(c for c in calls if c["task"]["role"] == "Regulatory")
+    fin_call = next(c for c in calls if c["task"]["role"] == "Finance")
+    assert "Bob" not in reg_call["context"]
+    assert "Alice" not in fin_call["task"]["description"]
+    alias_maps = st.session_state.get("alias_maps", {})
+    assert set(alias_maps.keys()) == {"Regulatory", "Finance"}

--- a/utils/run_config.py
+++ b/utils/run_config.py
@@ -23,6 +23,7 @@ class RunConfig:
     verbose_planner: bool = False
     auto_export_trace: bool = False
     auto_export_report: bool = False
+    pseudonymize_to_model: bool = True
     advanced: Dict[str, Any] = field(default_factory=dict)
 
 
@@ -67,6 +68,7 @@ def to_orchestrator_kwargs(cfg: RunConfig) -> Dict[str, Any]:
         "budget_limit_usd": cfg.budget_limit_usd,
         "max_tokens": cfg.max_tokens,
         "knowledge_sources": list(cfg.knowledge_sources),
+        "pseudonymize_to_model": cfg.pseudonymize_to_model,
     }
     kwargs.update(cfg.advanced)
     return kwargs


### PR DESCRIPTION
## Summary
- segment planner tasks with canonical `field` keys and minimal `context`
- pseudonymize agent dispatch and aggregate per-role alias maps for final synthesis
- expose "Alias sensitive entities" toggle in sidebar and document privacy flow

## Testing
- `pytest tests/test_privacy_segmentation.py -q`
- `pytest -q` *(fails: No module named 'pptx'; No module named 'fastapi'; ImportError in tests/test_errors.py)*
- `python - <<'PY' ... generate_repo_map.main() ... PY`

------
https://chatgpt.com/codex/tasks/task_e_68b687c7e694832ca0c0bd4800906ffd