### PR TITLE
feat: always generate build spec

### DIFF
--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -690,38 +690,36 @@ def execute_plan(
             st.session_state["poc_report"] = report
         except Exception:
             pass
-    enable_build = os.environ.get("DRRD_ENABLE_BUILD_SPEC", "false").lower() == "true"
-    if enable_build:
-        from orchestrators.spec_builder import assemble_from_agent_payloads
-        from utils.reportgen import render, write_csv
+    from orchestrators.spec_builder import assemble_from_agent_payloads
+    from utils.reportgen import render, write_csv
 
-        sdd, impl = assemble_from_agent_payloads(project_name, idea, answers)
-        out_dir = f"audits/{project_id}/build"
-        os.makedirs(out_dir, exist_ok=True)
-        sdd_md = render("build/SDD.md.j2", {"sdd": sdd})
-        impl_md = render("build/ImplementationPlan.md.j2", {"impl": impl})
-        open(f"{out_dir}/SDD.md", "w", encoding="utf-8").write(sdd_md)
-        open(f"{out_dir}/ImplementationPlan.md", "w", encoding="utf-8").write(impl_md)
-        write_csv(
-            f"{out_dir}/bom.csv",
-            [b.model_dump() for b in impl.bom],
-            headers=["part_no", "desc", "qty", "unit_cost", "vendor"],
+    sdd, impl = assemble_from_agent_payloads(project_name, idea, answers)
+    out_dir = f"audits/{project_id}/build"
+    os.makedirs(out_dir, exist_ok=True)
+    sdd_md = render("build/SDD.md.j2", {"sdd": sdd})
+    impl_md = render("build/ImplementationPlan.md.j2", {"impl": impl})
+    open(f"{out_dir}/SDD.md", "w", encoding="utf-8").write(sdd_md)
+    open(f"{out_dir}/ImplementationPlan.md", "w", encoding="utf-8").write(impl_md)
+    write_csv(
+        f"{out_dir}/bom.csv",
+        [b.model_dump() for b in impl.bom],
+        headers=["part_no", "desc", "qty", "unit_cost", "vendor"],
+    )
+    write_csv(
+        f"{out_dir}/budget.csv",
+        [b.model_dump() for b in impl.budget],
+        headers=["phase", "cost_usd"],
+    )
+    os.makedirs(f"{out_dir}/interface_contracts", exist_ok=True)
+    for i in sdd.interfaces:
+        open(
+            f"{out_dir}/interface_contracts/{i.name}.md",
+            "w",
+            encoding="utf-8",
+        ).write(
+            f"# {i.name}\n\nProducer: {i.producer}\n"
+            f"Consumer: {i.consumer}\n\nContract:\n{i.contract}\n",
         )
-        write_csv(
-            f"{out_dir}/budget.csv",
-            [b.model_dump() for b in impl.budget],
-            headers=["phase", "cost_usd"],
-        )
-        os.makedirs(f"{out_dir}/interface_contracts", exist_ok=True)
-        for i in sdd.interfaces:
-            open(
-                f"{out_dir}/interface_contracts/{i.name}.md",
-                "w",
-                encoding="utf-8",
-            ).write(
-                f"# {i.name}\n\nProducer: {i.producer}\n"
-                f"Consumer: {i.consumer}\n\nContract:\n{i.contract}\n"
-            )
 
     try:
         st.session_state["_last_prompt"] = "\n\n".join(prompt_previews)[:4000]

--- a/docs/build_spec.md
+++ b/docs/build_spec.md
@@ -1,6 +1,6 @@
 # Build Spec & Work Plan
 
-When enabled, DR-RD emits a build specification package alongside the final proposal. The package contains:
+DR-RD emits a build specification package alongside the final proposal. The package contains:
 
 - `SDD.md` – System Design Doc with requirements, interfaces and risks.
 - `ImplementationPlan.md` – work items, milestones and rollback notes.
@@ -10,6 +10,4 @@ When enabled, DR-RD emits a build specification package alongside the final prop
 
 All files are written under `audits/<project_slug>/build/`.
 
-## Enabling
-
-Set environment variable `DRRD_ENABLE_BUILD_SPEC=true` or check **Generate Build Spec & Work Plan** in the *Build Spec* expander of the UI before running domain experts. After execution, download links for these files appear in the app.
+The build spec and work plan are generated automatically. After a run completes, download links for these files appear in the app.


### PR DESCRIPTION
## Summary
- remove `DRRD_ENABLE_BUILD_SPEC` flag and always build SDD/implementation plan artifacts
- update docs to note build spec & work plan generation is automatic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pptx')*
- `pytest tests/test_spec_builder.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b67ef3b248832cbc750e26b039de70