### PR TITLE
Restore plan when resuming pipeline

### DIFF
--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -947,6 +947,12 @@ def orchestrate(*args, resume_from: str | None = None, **kwargs):
     if start["planner"] == 0:
         tasks = generate_plan(idea)
         checkpoints.mark_step_done(run_id, "planner", "plan")
+    elif resume_from:
+        # When resuming after planning, recover the plan from the prior trace
+        for step in trace_writer.read_trace(resume_from):
+            if step.get("phase") == "planner" and isinstance(step.get("summary"), list):
+                tasks = step["summary"]
+                break
     agents = kwargs.get("agents") or {}
     results: Dict[str, str] = {}
     if start["executor"] == 0:

--- a/utils/trace_writer.py
+++ b/utils/trace_writer.py
@@ -19,6 +19,13 @@ def _read_trace(p: Path) -> list[Any]:
     return []
 
 
+def read_trace(run_id: str) -> list[Any]:
+    """Return the saved trace list for ``run_id`` or an empty list."""
+
+    p = trace_path(run_id)
+    return _read_trace(p) if p.exists() else []
+
+
 def _atomic_write(p: Path, data: list[Any]) -> None:
     tmp = p.with_suffix(p.suffix + ".tmp")
     tmp.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
@@ -52,4 +59,4 @@ def flush_phase_meta(run_id: str, phase: str, meta: Mapping[str, Any]) -> None:
     _atomic_write(p, existing)
 
 
-__all__ = ["trace_path", "append_step", "flush_phase_meta"]
+__all__ = ["trace_path", "append_step", "flush_phase_meta", "read_trace"]


### PR DESCRIPTION
## Summary
- recover planner output from previous run's trace when resuming the pipeline
- expose `read_trace` helper for reading stored run traces
- test resuming flow with stored tasks

## Testing
- `pytest tests/test_trace_writer.py tests/test_resume_flow.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b68e2c2abc832cadb54b2e10fb0cb9