### PR TITLE
Standard-only mode, knowledge source controls and executor artifacts

### DIFF
--- a/config/modes.yaml
+++ b/config/modes.yaml
@@ -17,6 +17,4 @@ standard: &standard
   enable_images: false
   graph_enabled: false
 
-test: *standard  # DEPRECATED: alias to 'standard'; will be removed next release
-deep: *standard  # DEPRECATED: alias to 'standard'; will be removed next release
-# redaction time
+# Only the standard profile is supported.

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -43,6 +43,7 @@ from utils.telemetry import (
     stream_started,
 )
 from utils.timeouts import Deadline, with_deadline
+from orchestrators.executor import execute as exec_artifacts
 
 evidence: EvidenceSet | None = None
 
@@ -746,6 +747,10 @@ def execute_plan(
         st.session_state["alias_maps"] = alias_maps
     except Exception:
         pass
+    try:
+        exec_artifacts(tasks, {"run_id": run_id or "", "idea": idea})
+    except Exception:
+        logger.warning("executor artifacts failed", exc_info=True)
     return answers
 
 

--- a/core/retrieval/__init__.py
+++ b/core/retrieval/__init__.py
@@ -1,5 +1,6 @@
 """Retrieval utilities."""
 
 from .run import run_retrieval
+from .simple import retrieve
 
-__all__ = ["run_retrieval"]
+__all__ = ["run_retrieval", "retrieve"]

--- a/core/retrieval/simple.py
+++ b/core/retrieval/simple.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, List, Dict
+
+try:
+    import faiss  # type: ignore
+except Exception:  # pragma: no cover - faiss optional
+    faiss = None  # type: ignore
+
+
+def _gather_texts(sources: Iterable[Path]) -> List[tuple[str, str]]:
+    items: List[tuple[str, str]] = []
+    for path in sources:
+        if path.is_file():
+            try:
+                items.append((path.read_text(encoding="utf-8"), path.as_posix()))
+            except Exception:
+                continue
+    return items
+
+
+def retrieve(query: str, sources_selected: List[str], top_k: int = 5) -> List[Dict[str, str]]:
+    """Return matching docs with citation metadata.
+
+    This is a minimal fallback implementation that avoids heavy dependencies
+    when FAISS is unavailable. It performs a naive substring search over
+    collected texts from ``samples/`` and ``.dr_rd/uploads/``.
+    """
+    roots: List[Path] = []
+    if "samples" in sources_selected:
+        roots.append(Path("samples"))
+    if "uploads" in sources_selected:
+        roots.append(Path(".dr_rd/uploads"))
+    texts: List[tuple[str, str]] = []
+    for r in roots:
+        texts.extend(_gather_texts(r.rglob("*.txt")))
+        texts.extend(_gather_texts(r.rglob("*.md")))
+    matches: List[Dict[str, str]] = []
+    for text, path in texts:
+        if query.lower() in text.lower():
+            matches.append({"text": text[:1000], "citation": path})
+    return matches[:top_k]

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -2,6 +2,8 @@
 
 Quick links to core documentation:
 
+The runtime operates solely in *standard* mode. Each run can draw from Samples, Connectors, and Uploads knowledge sources and produces `build_spec.md` and `work_plan.md` artifacts.
+
 - [Playbook](ARCHITECTURE.md)
 - [Configuration](CONFIG.md)
 - [RAG Pipeline](RAG_PIPELINE.md)

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -12,7 +12,7 @@ User idea → Planner → Router/Registry → Executor → Summarization → Syn
 
 ### Runtime Modes
 - **standard**: target cost USD 2.5
-Deprecated aliases: test, deep
+
 
 ## Agent Roster
 | Role | Module | Contract |
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-09-02T06:07:13.364285Z from commit d44303e_
+_Last generated at 2025-09-02T19:57:40.702578Z from commit 2bc8e93_

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -36,18 +36,16 @@ flowchart LR
 ## Configuration
 Most run-time options live in the sidebar:
 - **Project idea** – free‑form text describing the goal.
-- **Mode** – selects presets that control target cost, retrieval, and search behavior.
-- **Knowledge sources** – choose built-in or uploaded sources for RAG.
+- **Knowledge sources** – toggle Samples, Connectors, and Uploads for retrieval.
 - **Diagnostics** – toggle agent trace and verbose planner output.
 - **Exports** – auto-export trace or report after a run.
 - **Advanced options** – temperature, retries, and overall timeout.
-
-Modes are defined in `config/modes.yaml` and include switches for vector search and live web search.
+Runs always execute in the standard profile defined in `config/modes.yaml`.
 
 ## Using the App
 1. Enter an idea in the sidebar and adjust settings.
 2. Click **Run** (from the main page) to generate a plan, execute tasks, and view results.
-3. Review the synthesized proposal in the main panel.
+3. Review the synthesized proposal and associated artifacts (`build_spec.md` and `work_plan.md`) in the main panel.
 
 ## Agent Trace
 When **Show agent trace** is enabled, a Trace page becomes available:
@@ -60,7 +58,10 @@ When **Show agent trace** is enabled, a Trace page becomes available:
 The system first queries a FAISS vector index when retrieval is enabled. If no context is found and live search is on, a web search backend such as OpenAI or SerpAPI provides additional snippets. Both pathways respect retrieval budgets to avoid excessive calls.
 
 ## Budgets and Cost Meter
-Each mode targets a total cost (e.g., $2.50 for *standard*). The cost meter estimates remaining budget before a run and shows actual vs. projected spend afterward.
+The standard profile targets a total cost (e.g., $2.50). The cost meter estimates remaining budget before a run and shows actual vs. projected spend afterward.
+
+## Metrics
+Every model call returns token usage and cost data from the provider. Per-step totals are aggregated into the trace and displayed on the Reports page.
 
 ## Export and Downloads
 - Automatic export options produce trace files or markdown reports on completion.

--- a/dr_rd/schemas/synthesizer_agent.json
+++ b/dr_rd/schemas/synthesizer_agent.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Synthesizer Agent",
+  "type": "object",
+  "properties": {
+    "summary": {"type": "string"},
+    "key_points": {"type": "array", "items": {"type": "string"}},
+    "contradictions": {"type": "array", "items": {"type": "string"}},
+    "confidence": {"type": "number"},
+    "sources": {"type": "array", "items": {"type": "string"}},
+    "citations_json": {"type": "string"}
+  },
+  "required": ["summary", "key_points", "citations_json"],
+  "additionalProperties": false
+}

--- a/orchestrators/executor.py
+++ b/orchestrators/executor.py
@@ -1,0 +1,36 @@
+"""Executor orchestrator that emits build artifacts."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Dict, Any
+
+from utils.paths import write_text
+
+
+def _render(template: str, context: Dict[str, Any]) -> str:
+    try:
+        from jinja2 import Template
+
+        return Template(template).render(**context)
+    except Exception:
+        return template.format(**context)
+
+
+DEFAULT_BUILD_SPEC = "# Build Spec\n\nGenerated for: {idea}\n"
+DEFAULT_WORK_PLAN = "# Work Plan\n\nTasks:\n{tasks}\n"
+
+
+def execute(plan: List[Dict[str, Any]], ctx: Dict[str, Any]) -> Dict[str, Path]:
+    """Write ``build_spec.md`` and ``work_plan.md`` artifacts for a run."""
+    run_id = ctx.get("run_id", "latest")
+    idea = ctx.get("idea", "")
+    tasks_md = "\n".join(f"- {t.get('title','')}" for t in plan)
+    context = {"idea": idea, "tasks": tasks_md}
+
+    build_spec = _render(DEFAULT_BUILD_SPEC, context)
+    work_plan = _render(DEFAULT_WORK_PLAN, context)
+
+    path_spec = write_text(run_id, "build_spec", "md", build_spec)
+    path_plan = write_text(run_id, "work_plan", "md", work_plan)
+
+    return {"build_spec": path_spec, "work_plan": path_plan}

--- a/pages/90_Settings.py
+++ b/pages/90_Settings.py
@@ -2,6 +2,7 @@
 
 import copy
 import json
+import os
 
 import streamlit as st
 
@@ -90,12 +91,8 @@ def _flatten(d: dict, prefix: str = "", out: dict | None = None) -> dict:
 
 # Defaults for new runs
 st.subheader("Defaults for new runs")
-mode = st.selectbox(
-    t("mode_label"),
-    ["standard", "test", "deep"],
-    index=["standard", "test", "deep"].index(prefs["defaults"].get("mode", "standard")),
-    help=t("mode_help"),
-)
+st.caption("Mode: standard")
+mode = "standard"
 max_tokens = st.number_input(
     t("max_tokens_label"),
     min_value=0,
@@ -110,12 +107,32 @@ budget_limit = st.number_input(
     value=prefs["defaults"].get("budget_limit_usd") or 0.0,
     help=t("budget_limit_help"),
 )
-knowledge_sources = st.multiselect(
-    t("knowledge_sources_label"),
-    ["samples", "uploads", "connectors"],
-    default=prefs["defaults"].get("knowledge_sources", []),
-    help=t("knowledge_sources_help"),
+ks_defaults = set(prefs["defaults"].get("knowledge_sources", []))
+ks_samples = st.checkbox(
+    "Samples",
+    value="samples" in ks_defaults,
+    key="pref_samples",
 )
+connectors_enabled = bool(os.getenv("CONNECTORS_CONFIGURED"))
+ks_connectors = st.checkbox(
+    "Connectors",
+    value="connectors" in ks_defaults and connectors_enabled,
+    disabled=not connectors_enabled,
+    key="pref_connectors",
+    help="Configure connectors in Settings → Connectors",
+)
+ks_uploads = st.checkbox(
+    "Uploads",
+    value="uploads" in ks_defaults,
+    key="pref_uploads",
+)
+knowledge_sources = []
+if ks_samples:
+    knowledge_sources.append("samples")
+if ks_connectors:
+    knowledge_sources.append("connectors")
+if ks_uploads:
+    knowledge_sources.append("uploads")
 
 # UI behavior
 st.subheader("UI behavior")

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-09-02T06:07:13.364285Z'
-git_sha: d44303e0691fe7f2b024cde477f1706481d49ec6
+generated_at: '2025-09-02T19:57:40.702578Z'
+git_sha: 2bc8e93525a37d6cbbbf348658f862e3b31ca576
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -33,9 +33,6 @@ runtime_modes:
     faiss_index_uri: ''
     enable_images: false
     graph_enabled: false
-mode_aliases:
-- test
-- deep
 env_flags:
 - DRRD_MODE (deprecated shim)
 - RAG_ENABLED
@@ -184,7 +181,21 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
+- path: orchestrators/spec_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
 - path: orchestrators/app_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/executor.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -198,7 +209,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/spec_builder.py
+- path: orchestrators/__init__.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -212,20 +223,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/__init__.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: core/summarization/integrator.py
-  role: Summarization
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
@@ -234,6 +231,13 @@ modules:
   invoked_by: []
   invokes: []
 - path: core/summarization/schemas.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/integrator.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/scripts/generate_repo_map.py
+++ b/scripts/generate_repo_map.py
@@ -37,7 +37,11 @@ def _get_agent_registry() -> dict[str, str]:
     import types
 
     if "streamlit" not in sys.modules:
-        sys.modules["streamlit"] = types.SimpleNamespace()
+        def _cr(func=None, *a, **k):
+            if func:
+                return func
+            return lambda f: f
+        sys.modules["streamlit"] = types.SimpleNamespace(cache_resource=_cr)
     if "openai" not in sys.modules:
 
         class _Resp:
@@ -145,7 +149,6 @@ def build_repo_map() -> dict:
         ],
         "architecture": "Planner → Router/Registry → Executor → Summarization → Synthesizer",
         "runtime_modes": modes,
-        "mode_aliases": aliases,
         "env_flags": [
             "DRRD_MODE (deprecated shim)",
             "RAG_ENABLED",
@@ -169,6 +172,8 @@ def build_repo_map() -> dict:
         ),
         "rules_ref": "docs/REPO_RULES.md",
     }
+    if aliases:
+        data["mode_aliases"] = aliases
     return data
 
 

--- a/tests/test_e2e_unified_smoke.py
+++ b/tests/test_e2e_unified_smoke.py
@@ -43,7 +43,7 @@ def _run_once(monkeypatch, caplog, fetch_resp):
 
 
 def test_e2e_unified_smoke(monkeypatch, caplog):
-    monkeypatch.setenv("DRRD_MODE", "deep")
+    monkeypatch.setenv("DRRD_MODE", "legacy")
     m1 = pick_model_for_stage("exec")
     monkeypatch.setenv("DRRD_MODE", "bogus")
     m2 = pick_model_for_stage("exec")

--- a/tests/test_mode_env.py
+++ b/tests/test_mode_env.py
@@ -4,8 +4,8 @@ from app.config_loader import load_profile
 
 
 def test_env_mode_deprecated(monkeypatch, caplog):
-    monkeypatch.setenv("DRRD_MODE", "deep")
+    monkeypatch.setenv("DRRD_MODE", "legacy")
     with caplog.at_level(logging.WARNING):
         cfg, _ = load_profile()
-    assert "DRRD_MODE 'deep' is deprecated" in caplog.text
+    assert "DRRD_MODE 'legacy' is deprecated" in caplog.text
     assert cfg.get("target_cost_usd") == 2.50

--- a/tests/test_model_router_mode_deprecation.py
+++ b/tests/test_model_router_mode_deprecation.py
@@ -5,10 +5,9 @@ import config.model_routing as mr
 
 def test_mode_argument_deprecated(caplog):
     with caplog.at_level(logging.WARNING):
-        model_test = mr.pick_model(stage="plan", role=None, mode="test")
-        model_deep = mr.pick_model(stage="plan", role=None, mode="deep")
+        model_custom = mr.pick_model(stage="plan", role=None, mode="custom")
         model_stage = mr.pick_model_for_stage("plan")
 
-    assert model_test == model_deep == model_stage
+    assert model_custom == model_stage
     warnings = [r for r in caplog.records if "mode' argument is deprecated" in r.message]
-    assert len(warnings) == 2
+    assert len(warnings) == 1

--- a/tests/test_pipeline_executor_artifacts.py
+++ b/tests/test_pipeline_executor_artifacts.py
@@ -1,0 +1,15 @@
+from orchestrators.executor import execute
+from utils.paths import artifact_path
+
+
+def test_executor_creates_artifacts(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    plan = [{"title": "Do thing"}]
+    ctx = {"run_id": "r1", "idea": "Idea"}
+    paths = execute(plan, ctx)
+    spec = artifact_path("r1", "build_spec", "md")
+    plan_p = artifact_path("r1", "work_plan", "md")
+    assert spec.exists()
+    assert plan_p.exists()
+    assert paths["build_spec"] == spec
+    assert paths["work_plan"] == plan_p

--- a/tests/test_prefs.py
+++ b/tests/test_prefs.py
@@ -25,10 +25,10 @@ def test_save_and_load_roundtrip(tmp_path, monkeypatch):
     _patch_config(tmp_path, monkeypatch)
     data = prefs.DEFAULT_PREFS.copy()
     data["defaults"] = data["defaults"].copy()
-    data["defaults"]["mode"] = "deep"
+    data["defaults"]["mode"] = "standard"
     prefs.save_prefs(data)
     loaded = prefs.load_prefs()
-    assert loaded["defaults"]["mode"] == "deep"
+    assert loaded["defaults"]["mode"] == "standard"
     assert loaded["version"] == prefs.DEFAULT_PREFS["version"]
 
 
@@ -55,11 +55,11 @@ def test_merge_defaults(tmp_path, monkeypatch):
     _patch_config(tmp_path, monkeypatch)
     data = prefs.DEFAULT_PREFS.copy()
     data["defaults"] = data["defaults"].copy()
-    data["defaults"]["mode"] = "test"
+    data["defaults"]["mode"] = "standard"
     prefs.save_prefs(data)
     base = {"mode": "standard", "max_tokens": 8000, "budget_limit_usd": None, "knowledge_sources": []}
     merged = prefs.merge_defaults(base)
-    assert merged["mode"] == "test"
+    assert merged["mode"] == "standard"
     assert merged["max_tokens"] is None
     assert "budget_limit_usd" in merged
 

--- a/tests/test_query_params.py
+++ b/tests/test_query_params.py
@@ -18,7 +18,7 @@ def test_round_trip_simple_fields():
     }
     cfg = {
         "idea": "hello",
-        "mode": "deep",
+        "mode": "standard",
         "budget_limit_usd": 2.5,
         "max_tokens": 8000,
         "knowledge_sources": ["local", "samples"],
@@ -27,7 +27,7 @@ def test_round_trip_simple_fields():
     dec = decode_config(enc)
     merged = merge_into_defaults(defaults, dec)
     assert merged["idea"] == "hello"
-    assert merged["mode"] == "deep"
+    assert merged["mode"] == "standard"
     assert isinstance(merged["budget_limit_usd"], float)
     assert isinstance(merged["max_tokens"], int)
     assert merged["knowledge_sources"] == ["local", "samples"]

--- a/tests/test_ui_modes_and_knowledge.py
+++ b/tests/test_ui_modes_and_knowledge.py
@@ -1,0 +1,11 @@
+import streamlit as st
+from utils.run_config import RunConfig, to_session, from_session
+
+
+def test_ui_modes_and_knowledge():
+    st.session_state.clear()
+    cfg = RunConfig(mode="standard", knowledge_sources=["samples", "uploads"])
+    to_session(cfg)
+    rc = from_session()
+    assert rc.mode == "standard"
+    assert set(rc.knowledge_sources) == {"samples", "uploads"}


### PR DESCRIPTION
## Summary
- Fix sidebar and settings to run only in `standard` mode and expose Samples, Connectors and Uploads knowledge sources
- Add executor step that writes `build_spec.md` and `work_plan.md` artifacts for each run
- Introduce minimal retrieval helper and update docs for standard profile

## Testing
- `pytest tests/test_ui_modes_and_knowledge.py tests/test_pipeline_executor_artifacts.py tests/test_model_router_mode_deprecation.py tests/test_query_params.py tests/test_prefs.py tests/test_mode_env.py tests/test_e2e_unified_smoke.py`


------
https://chatgpt.com/codex/tasks/task_e_68b74a20fc64832ca171ac547bce9ea9