### PR TITLE
Fix missing idea capture in sidebar prevents run start

### DIFF
--- a/app/ui/sidebar.py
+++ b/app/ui/sidebar.py
@@ -59,6 +59,8 @@ def render_sidebar() -> RunConfig:
             key="idea",
             help="What should the agents work on?",
         )
+        run_store.set("idea", idea)
+        _track_change("idea", idea)
         legacy_mode = run_store.get("mode")
         if legacy_mode not in ("", "standard"):
             st.warning(f"Mode '{legacy_mode}' is deprecated; using 'standard'.", icon="⚠️")


### PR DESCRIPTION
## Summary
- ensure the sidebar stores and tracks the Project idea so runs can start when filled

## Testing
- `pytest tests/test_app_ui.py::test_empty_idea_shows_info tests/test_ui_modes_and_knowledge.py` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'query_params')*
- `pytest tests/test_ui_modes_and_knowledge.py tests/test_ui_bridge.py`


------
https://chatgpt.com/codex/tasks/task_e_68b74fcd200c832cb1c1e8eab0bd1c89