### PR TITLE
Show reports downloads outside viewer mode

### DIFF
--- a/pages/20_Reports.py
+++ b/pages/20_Reports.py
@@ -220,7 +220,7 @@ else:
         with ZipFile(io.BytesIO(bundle_bytes)) as zf:
             bundle_count = len(zf.namelist())
 
-        if "artifacts" in scopes:
+        if not viewer_mode or "artifacts" in scopes:
             col_md, col_html, col_ipynb, col_zip = st.columns(4)
             if col_md.download_button(
                 t("download_report"),
@@ -282,5 +282,5 @@ else:
                         key=path.name,
                         help=t("bundle_download_help"),
                     )
-        else:
+        elif viewer_mode:
             st.info("Downloads disabled for this link.")


### PR DESCRIPTION
## Summary
- Fix reports page to always show download controls unless viewer mode lacks `artifacts` scope

## Testing
- `pytest -q --maxfail=1 --disable-warnings` *(fails: ImportError: cannot import name 'redact' from 'utils.errors')*


------
https://chatgpt.com/codex/tasks/task_e_68b75d962868832c90600e33a2e9a5e4