### PR TITLE
Preserve planner tasks; backfill missing fields; route on summary/ID prefixes; fail-fast; knowledge store fix

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -539,10 +539,11 @@ def _run(run_id: str, kwargs: dict, prefs: dict, origin_run_id: str | None) -> N
                 )
             except ValueError as e:
                 box.update(label="Planning failed", state="error")
+                reason = str(e)
                 msg = {
                     "planner.normalization_zero": f"Planner produced tasks but normalization removed them (run {run_id}).",
-                    "planner.no_tasks": "Planner returned no tasks.",
-                }.get(str(e), str(e))
+                    "planner.no_tasks": f"Planner returned no tasks (run {run_id}).",
+                }.get(reason, f"{reason} (run {run_id})")
                 st.error(msg)
                 return
             box.update(label="Planning complete", state="complete")
@@ -588,9 +589,11 @@ def _run(run_id: str, kwargs: dict, prefs: dict, origin_run_id: str | None) -> N
                 )
             except ValueError as e:
                 box.update(label="Execution failed", state="error")
+                reason = str(e)
                 msg = {
-                    "no_executable_tasks": "No executable tasks after routing.",
-                }.get(str(e), str(e))
+                    "no_executable_tasks": f"No executable tasks after routing (run {run_id}).",
+                    "No executable tasks after planning/routing": f"No executable tasks after routing (run {run_id}).",
+                }.get(reason, f"{reason} (run {run_id})")
                 st.error(msg)
                 return
             box.update(label="Execution complete", state="complete")

--- a/core/engine/executor.py
+++ b/core/engine/executor.py
@@ -52,11 +52,12 @@ def run_tasks(
     """Execute ``tasks`` concurrently when possible.
 
     Returns a dict with ``executed`` and ``pending`` lists.  If ``tasks`` is
-    empty, an empty dict is returned.
+    empty, both lists are empty.
     """
 
     if not tasks:
-        return {}
+        tasks_executable(0)
+        return {"executed": [], "pending": []}
 
     ready: list[Task] = []
     pending: list[Task] = []

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-09-03T01:41:10.396105Z from commit c2294fd_
+_Last generated at 2025-09-03T02:05:58.772434Z from commit 2f23a16_

--- a/pages/20_Reports.py
+++ b/pages/20_Reports.py
@@ -145,6 +145,21 @@ else:
         "tokens": sum(_step_tokens(step) for step in trace),
         "cost": sum(_step_cost(step) for step in trace),
     }
+    phase_meta = {}
+    meta_path = run_root(run_id) / "phase_meta.json"
+    if meta_path.exists():
+        try:
+            phase_meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        except Exception:
+            phase_meta = {}
+    totals.update(
+        {
+            "planned_tasks": phase_meta.get("planner", {}).get("planned_tasks"),
+            "normalized_tasks": phase_meta.get("planner", {}).get("normalized_tasks"),
+            "routed_tasks": phase_meta.get("router", {}).get("routed_tasks"),
+            "exec_tasks": phase_meta.get("executor", {}).get("exec_tasks"),
+        }
+    )
     results = []
     for step in trace:
         if isinstance(step.get("safety"), dict):

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-09-03T01:41:10.396105Z'
-git_sha: c2294fdf43699a000e196f479c3b2edb699ff627
+generated_at: '2025-09-03T02:05:58.772434Z'
+git_sha: 2f23a16728c98a61fe25e4ceb3e4c86fab2a4ad5
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -181,28 +181,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/executor.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/qa_router.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/__init__.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -216,6 +195,13 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
+- path: orchestrators/spec_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
 - path: orchestrators/plan_utils.py
   role: Orchestrator
   responsibilities: []
@@ -223,7 +209,21 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/__init__.py
+- path: orchestrators/__init__.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/executor.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/integrator.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -244,7 +244,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_executor_empty_list.py
+++ b/tests/test_executor_empty_list.py
@@ -11,5 +11,5 @@ def test_executor_handles_empty_task_list():
             return None, 0.0
 
     result = run_tasks([], state=State())
-    assert result == {}
+    assert result == {"executed": [], "pending": []}
 

--- a/tests/test_executor_guard.py
+++ b/tests/test_executor_guard.py
@@ -27,7 +27,7 @@ def test_run_tasks_empty(monkeypatch):
 
     monkeypatch.setattr(ex, "ThreadPoolExecutor", fake_pool)
     out = ex.run_tasks([], DummyState())
-    assert out == {}
+    assert out == {"executed": [], "pending": []}
     assert called is False
 
 

--- a/tests/test_planner_failfast.py
+++ b/tests/test_planner_failfast.py
@@ -17,6 +17,12 @@ def test_summary_backfilled(monkeypatch):
     assert tasks[0]["description"] == "Build"
 
 
+def test_description_backfilled():
+    data = {"tasks": [{"id": "T01", "title": "CTO", "description": "Build"}]}
+    out = orch._normalize_plan_payload(data)
+    assert out["tasks"][0]["summary"] == "Build"
+
+
 class _NoIdResp:
     content = json.dumps({"tasks": [{"title": "CTO", "summary": "Build"}]})
 
@@ -26,6 +32,17 @@ def test_missing_id_backfilled(monkeypatch):
     monkeypatch.setattr(orch, "select_model", lambda *a, **k: "test")
     tasks = orch.generate_plan("idea")
     assert tasks[0]["id"].startswith("T")
+
+
+class _PrefixedIdResp:
+    content = json.dumps({"tasks": [{"id": "DEV_1", "title": "CTO", "summary": "Build"}]})
+
+
+def test_prefixed_id_survives(monkeypatch):
+    monkeypatch.setattr(orch, "complete", lambda *a, **k: _PrefixedIdResp())
+    monkeypatch.setattr(orch, "select_model", lambda *a, **k: "test")
+    tasks = orch.generate_plan("idea")
+    assert tasks[0]["id"] == "DEV_1"
 
 
 class _BadResp:

--- a/tests/test_router_prefix.py
+++ b/tests/test_router_prefix.py
@@ -1,0 +1,22 @@
+import core.router as router
+
+def _choose(task_id, title="Task", summary="Do work"):
+    t = {"id": task_id, "title": title, "summary": summary}
+    role, _cls, _model = router.choose_agent_for_task(None, title, summary, task=t)
+    return role
+
+
+def test_dev_prefix_routes_to_cto():
+    assert _choose("DEV_1") == "CTO"
+
+
+def test_qa_prefix_routes_to_qa():
+    assert _choose("QA_1") == "QA"
+
+
+def test_mkt_prefix_routes_to_marketing():
+    assert _choose("MKT_1") == "Marketing Analyst"
+
+
+def test_unknown_prefix_falls_back():
+    assert _choose("XYZ_1") == "Dynamic Specialist"

--- a/utils/knowledge_store.py
+++ b/utils/knowledge_store.py
@@ -34,7 +34,7 @@ def _read_meta() -> dict[str, dict]:
 
 def _write_meta(data: Mapping[str, dict]) -> None:
     META.parent.mkdir(parents=True, exist_ok=True)
-    tmp = META.with_suffix(".tmp")
+    tmp = META.parent / (META.stem + ".tmp")
     try:
         tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
         tmp.replace(META)

--- a/utils/report_builder.py
+++ b/utils/report_builder.py
@@ -103,6 +103,20 @@ def build_markdown_report(
         lines.append(f"- Cost: ${cost:.4f}")
     lines.append("")
 
+    if any(k in totals for k in ["planned_tasks", "normalized_tasks", "routed_tasks", "exec_tasks"]):
+        lines.append("## Task counts")
+        lines.append("| planned | normalized | routed | executed |")
+        lines.append("|---|---|---|---|")
+        lines.append(
+            "| {p} | {n} | {r} | {e} |".format(
+                p=totals.get("planned_tasks", ""),
+                n=totals.get("normalized_tasks", ""),
+                r=totals.get("routed_tasks", ""),
+                e=totals.get("exec_tasks", ""),
+            )
+        )
+        lines.append("")
+
     rows = flatten_trace_rows(trace)
     lines.append("## Trace summary table")
     lines.append(trace_table(rows))


### PR DESCRIPTION
## Summary
- Normalize planner tasks without dropping descriptions, synthesize missing IDs, backfill summary/description, persist plans, and fail fast when normalization yields no tasks
- Route tasks using ID prefixes with expanded role aliases, record routing decisions and counts for telemetry/reporting, and guard executor against empty task lists
- Fix knowledge store initialization, surface planner/executor errors to UI, and report task counts in generated reports

## Testing
- `pytest tests/test_planner_failfast.py tests/test_router_prefix.py tests/test_executor_guard.py tests/test_executor_empty_list.py`
- `python scripts/generate_repo_map.py`

------
https://chatgpt.com/codex/tasks/task_e_68b7a01b8968832cbd2bc90c6f70aac3