### PR TITLE
Harden planner prompt to emit complete, routable tasks

### DIFF
--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-09-03T02:05:58.772434Z from commit 2f23a16_
+_Last generated at 2025-09-03T02:21:48.555217Z from commit 7d62603_

--- a/prompts/prompts.py
+++ b/prompts/prompts.py
@@ -2,23 +2,24 @@
 
 PLANNER_SYSTEM_PROMPT = (
     # Schema: dr_rd/schemas/planner_v1.json
-    "You are a Project Planner AI. Decompose the idea into role-specific tasks. "
-    "Prefer assigning tasks to these roles where appropriate: CTO, Research Scientist, Regulatory, Finance, Marketing Analyst, IP Analyst, HRM, Materials Engineer, Reflection, Synthesizer. "
-    "If a task clearly needs repository reading/patch planning, numerical simulation/Monte Carlo, or image/video analysis, you may include an optional tool_request object with the tool name (read_repo | plan_patch | simulate | analyze_image | analyze_video) and minimal params. "
-    'When background research is required, you may also add "retrieval_request": true and/or "queries": ["..."] to hint the orchestrator. '
-    'For patent or regulatory needs, tasks may include optional ip_request {"query":str,...} and/or compliance_request {"profile_ids":[...],"min_coverage":float}. '
-    "All tasks MUST include non-empty string fields id, title, and summary and MAY NOT include any extra keys. "
-    "Never emit blank strings or placeholders; if any required field would be empty, return an error message instead. "
-    "If information is insufficient or you cannot craft at least four valid tasks, return an error message instead. "
-    'Output ONLY JSON matching this schema: {"tasks":[{"id":"T01","title":"CTO","summary":"Assess feasibility"}]}.'
+    "You are the Planner AI. Break the user's idea into discrete tasks spanning different domains such as architecture/design, materials, regulatory/IP, finance/budgeting, marketing, and QA/testing. "
+    "Output must be ONLY JSON matching {\"tasks\": [...]} with no extra commentary or Markdown. "
+    "Each task MUST provide non-empty string fields id, title, summary, description, and role. "
+    "Field meanings: id – short identifier (prefer T01, T02, ...), title – 5-7 word task name, summary – one-sentence overview, description – 1-3 sentence detail, role – one of CTO, Research Scientist, Regulatory, Finance, Marketing Analyst, IP Analyst, HRM, Materials Engineer, QA, Simulation, Dynamic Specialist. "
+    "Optional fields include inputs (object), dependencies (array of ids), stop_rules (array of strings), and tags (array of strings). "
+    "Produce at least six tasks covering design/architecture, materials, compliance/regulatory/IP, cost/finance, marketing, and QA/testing. Unknown domains must use the role Dynamic Specialist. "
+    "If any required field is missing or information is insufficient to craft all tasks, return {\"error\":\"MISSING_INFO\",\"needs\":[...missing_fields...]}. "
+    "No placeholders or blank strings."
+    "\nExample (illustrative only, actual content must differ):\n"
+    '{"tasks": [{"id": "T01", "title": "Draft system architecture", "summary": "Outline major components", "description": "Define high-level modules and interfaces for the product.", "role": "CTO"}, '
+    '{"id": "T02", "title": "Estimate materials cost", "summary": "Calculate key material expenses", "description": "Compile a bill of materials with cost estimates.", "role": "Finance", "dependencies": ["T01"]}, '
+    '{"id": "T03", "title": "Assess regulatory pathway", "summary": "Review standards and approvals", "description": "Identify applicable regulations and required certifications.", "role": "Regulatory"}]}\n'
 )
 
 PLANNER_USER_PROMPT_TEMPLATE = (
     # Schema: dr_rd/schemas/planner_agent.json
-    "Project idea: {idea}{constraints_section}{risk_section}\n"
-    "Break the project into role-specific tasks. Every task must include non-empty id, title, and summary fields. Do not use placeholders or empty strings. "
-    'Output ONLY JSON matching {{"tasks": [...]}} with at least 4 tasks. '
-    "If any required field would be blank or you cannot produce at least 4 valid tasks, return an error message instead of empty strings."
+    "Project idea: {idea}{constraints_section}{risk_section}\n\n"
+    "Using the schema and guidelines above, break this idea into at least six role-specific tasks and return only the JSON object. Do not include any extra text."
 )
 
 SYNTHESIZER_TEMPLATE = """\

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-09-03T02:05:58.772434Z'
-git_sha: 2f23a16728c98a61fe25e4ceb3e4c86fab2a4ad5
+generated_at: '2025-09-03T02:21:48.555217Z'
+git_sha: 7d62603ee35c8e8662b210f7298c3f30bb78a637
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -181,28 +181,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/qa_router.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/app_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/spec_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/plan_utils.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -223,14 +202,28 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
-  role: Summarization
+- path: orchestrators/plan_utils.py
+  role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
+- path: orchestrators/qa_router.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/spec_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -244,7 +237,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/__init__.py
+- path: core/summarization/integrator.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []


### PR DESCRIPTION
## Summary
- enforce strict JSON schema for planner tasks, requiring id, title, summary, description, and role with domain coverage and fallback to Dynamic Specialist
- update planner user prompt to reference schema and demand at least six tasks
- regenerate repo map documentation

## Testing
- `pytest` *(fails: ModuleNotFoundError / integration bridge errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_68b7a5c1cefc832c9a88f3ef7cf97409