### PR TITLE
Stop zeroing planner tasks; coerce+backfill in normalizer; robust routing; executor guard

### DIFF
--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -105,8 +105,8 @@ def _coerce_and_fill(data: dict | list) -> dict:
             continue
         tid = str(t.get("id") or f"T{i:02d}")
         title = (t.get("title") or "").strip()
-        summary = (t.get("summary") or "").strip()
-        description = (t.get("description") or summary).strip()
+        summary = (t.get("summary") or t.get("description") or "").strip()
+        description = (t.get("description") or t.get("summary") or "").strip()
         role = (t.get("role") or "Dynamic Specialist").strip()
         if title == "" or summary == "":
             continue

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-09-03T05:07:27.161499Z from commit 9a4e0e8_
+_Last generated at 2025-09-03T15:43:27.352313Z from commit d0e16f2_

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-09-03T05:07:27.161499Z'
-git_sha: 9a4e0e82dfc0e57213812a6ea29be114fd577c0c
+generated_at: '2025-09-03T15:43:27.352313Z'
+git_sha: d0e16f29e12315b6a1b7c4cda9f5428462da38aa
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -195,14 +195,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/plan_utils.py
+- path: orchestrators/app_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
+- path: orchestrators/plan_utils.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -230,14 +230,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
+- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/schemas.py
+- path: core/summarization/integrator.py
   role: Summarization
   responsibilities: []
   inputs: []


### PR DESCRIPTION
## Summary
- ensure planner normalization backfills summary/description to retain tasks and fail fast with debug dumps
- regenerate repository map documentation

## Testing
- `pytest tests/test_normalizer_coerce_and_fill.py tests/test_plan_backfill.py tests/test_planner_coercion_extra.py tests/test_router_prefix.py tests/test_routing_prefix_and_fallback.py tests/test_router_unknown_role.py tests/test_planner_normalization_guards.py tests/test_executor_zero_guard.py`
- `python scripts/generate_repo_map.py`


------
https://chatgpt.com/codex/tasks/task_e_68b860d91ab0832c80102eb6253265a9