### PR TITLE
Fix executor agent invocation; enforce tolerant role routing; keep tasks intact; surface agent failures

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -717,22 +717,19 @@ def _run(run_id: str, kwargs: dict, prefs: dict, origin_run_id: str | None) -> N
         return
     except RuntimeError as e:  # pragma: no cover - UI display
         if current_box is not None:
-            current_box.update(label="Cancelled", state="error")
+            current_box.update(label="Error", state="error")
         err = make_safe_error(e, run_id=run_id, phase=current_phase, step_id=None)
-        st.session_state["active_run"]["status"] = "cancelled"
-        complete_run_meta(run_id, status="cancelled")
-        run_cancelled(run_id, current_phase)
-        log_event({"event": "run_completed", "run_id": run_id, "status": "cancelled"})
-        evt = "budget_exceeded" if str(e) == "usage_exceeded" else "run_cancelled"
-        status = "error" if evt == "budget_exceeded" else "cancelled"
-        send_note(evt, status, run_id, kwargs)
+        st.session_state["active_run"]["status"] = "error"
+        complete_run_meta(run_id, status="error")
+        log_event({"event": "run_completed", "run_id": run_id, "status": "error"})
+        send_note("run_failed", "error", run_id, kwargs)
         if origin_run_id:
             log_event(
                 {
                     "event": "reproduce_completed",
                     "run_id": run_id,
                     "origin_run_id": origin_run_id,
-                    "status": "cancelled",
+                    "status": "error",
                 }
             )
         log_event(

--- a/core/agents/runtime.py
+++ b/core/agents/runtime.py
@@ -1,0 +1,72 @@
+import inspect
+import json
+import streamlit as st
+from utils import trace_writer
+
+
+def _resolve_callable(agent):
+    for name in ("__call__", "run", "act"):
+        fn = getattr(agent, name, None)
+        if callable(fn):
+            return fn
+    return None
+
+
+def invoke_agent_safely(agent, task, model=None, meta=None):
+    fn = _resolve_callable(agent)
+    if fn is None:
+        run_id = st.session_state.get("run_id", "")
+        role = task.get("role") if isinstance(task, dict) else None
+        try:
+            trace_writer.append_step(
+                run_id,
+                {
+                    "phase": "executor",
+                    "event": "agent_error",
+                    "role": role,
+                    "task_id": task.get("id") if isinstance(task, dict) else None,
+                    "error": "no_callable_interface",
+                },
+            )
+        except Exception:
+            pass
+        raise RuntimeError(f"{agent.__class__.__name__} has no callable interface")
+    sig = inspect.signature(fn)
+    params = list(sig.parameters.values())
+    try:
+        if len(params) == 1:
+            name = params[0].name
+            if name in {"spec", "payload"}:
+                spec = {"task": task, "model": model, "meta": meta}
+                return fn(spec)
+            try:
+                return fn(task)
+            except TypeError:
+                spec = {"task": task, "model": model, "meta": meta}
+                return fn(spec)
+        if len(params) == 2:
+            return fn(task, model)
+        if len(params) == 3:
+            return fn(task, model, meta)
+        spec = {"task": task, "model": model, "meta": meta}
+        return fn(spec)
+    except Exception as e:
+        run_id = st.session_state.get("run_id", "")
+        role = task.get("role") if isinstance(task, dict) else None
+        try:
+            trace_writer.append_step(
+                run_id,
+                {
+                    "phase": "executor",
+                    "event": "agent_error",
+                    "role": role,
+                    "task_id": task.get("id") if isinstance(task, dict) else None,
+                    "error": str(e),
+                },
+            )
+        except Exception:
+            pass
+        raise
+
+
+__all__ = ["invoke_agent_safely"]

--- a/core/agents/unified_registry.py
+++ b/core/agents/unified_registry.py
@@ -132,7 +132,14 @@ def choose_agent_for_task(
 ) -> Tuple[str, BaseAgent]:
     from core.router import choose_agent_for_task as router_choose
 
-    resolved, _cls, _model = router_choose(planned_role, title, desc or "", None)
+    resolved, _cls, _model = router_choose(
+        planned_role,
+        title,
+        desc or "",
+        None,
+        None,
+        {"title": title, "description": desc or "", "role": planned_role},
+    )
     agent = agents.get(resolved) or agents.get("Research Scientist")
     return resolved, agent
 

--- a/core/roles.py
+++ b/core/roles.py
@@ -31,6 +31,8 @@ CANON = {
     "materials engineer": "Materials Engineer",
     "reflection": "Reflection",
     "dynamic specialist": "Dynamic Specialist",
+    "qa": "QA",
+    "quality assurance": "QA",
 }
 
 # Additional explicit role remappings to stop Synthesizer fallbacks. The keys
@@ -46,13 +48,8 @@ CANONICAL = {
     "Software Engineer": "Research Scientist",
     # UX/UI planning feeds into market analysis for the product.
     "UX/UI Designer": "Marketing Analyst",
-    # QA work relates to compliance and regulatory oversight.
-    "Quality Assurance": "Regulatory",
     # Materials research is handled by the Mechanical Systems Lead today.
     "Materials Scientist": "Mechanical Systems Lead",
-    # Quality assurance and consistency review maps to Reflection agent.
-    "QA": "Reflection",
-    "Quality Assurance": "Reflection",
     # HR related planning maps to HRM agent
     "Human Resources": "HRM",
 }

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-09-03T16:51:48.923934Z from commit 483db14_
+_Last generated at 2025-09-03T18:31:13.544707Z from commit 577f36e_

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-09-03T16:51:48.923934Z'
-git_sha: 483db14f454627bea616e400131b1c592dc70eba
+generated_at: '2025-09-03T18:31:13.544707Z'
+git_sha: 577f36e78a64b9ff768b4dd54156285fd498e17c
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -181,6 +181,27 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
+- path: orchestrators/__init__.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/app_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/executor.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
 - path: orchestrators/qa_router.py
   role: Orchestrator
   responsibilities: []
@@ -195,27 +216,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/__init__.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/executor.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
@@ -223,7 +223,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -237,7 +237,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/__init__.py
+- path: core/summarization/integrator.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_agent_invocation_signatures.py
+++ b/tests/test_agent_invocation_signatures.py
@@ -1,0 +1,59 @@
+import json
+import pytest
+import streamlit as st
+
+from core.agents.runtime import invoke_agent_safely
+from utils import trace_writer, paths
+
+
+class TaskOnly:
+    def __call__(self, task):
+        return task["id"]
+
+
+class TaskModel:
+    def run(self, task, model):
+        return model
+
+
+class TaskModelMeta:
+    def act(self, task, model, meta):
+        return meta["foo"]
+
+
+class SpecOnly:
+    def __call__(self, spec):
+        return spec["task"]["id"]
+
+
+class BadAgent:
+    pass
+
+
+@pytest.mark.parametrize(
+    "agent, kwargs, expected",
+    [
+        (TaskOnly(), {}, "T"),
+        (TaskModel(), {"model": "m"}, "m"),
+        (TaskModelMeta(), {"model": "m", "meta": {"foo": "bar"}}, "bar"),
+        (SpecOnly(), {"model": "m"}, "T"),
+    ],
+)
+def test_invoke_agent_variants(agent, kwargs, expected, tmp_path, monkeypatch):
+    paths.RUNS_ROOT = tmp_path
+    st.session_state.clear()
+    st.session_state["run_id"] = "R1"
+    task = {"id": "T", "role": "X"}
+    assert invoke_agent_safely(agent, task, **kwargs) == expected
+
+
+def test_uncallable_agent_logs_error(tmp_path, monkeypatch):
+    paths.RUNS_ROOT = tmp_path
+    st.session_state.clear()
+    st.session_state["run_id"] = "R2"
+    paths.ensure_run_dirs("R2")
+    task = {"id": "T2", "role": "Y"}
+    with pytest.raises(RuntimeError):
+        invoke_agent_safely(BadAgent(), task)
+    trace = trace_writer.read_trace("R2")
+    assert any(e.get("event") == "agent_error" for e in trace)

--- a/tests/test_executor_no_silent_fail.py
+++ b/tests/test_executor_no_silent_fail.py
@@ -1,0 +1,29 @@
+import pytest
+import streamlit as st
+
+from core.orchestrator import execute_plan
+from core.agents.unified_registry import AGENT_REGISTRY
+from utils import paths, trace_writer
+
+
+class BoomAgent:
+    def __init__(self, model=None):
+        pass
+
+    def __call__(self, task):
+        raise RuntimeError("boom")
+
+
+def test_agent_failure_propagates(tmp_path, monkeypatch):
+    paths.RUNS_ROOT = tmp_path
+    st.session_state.clear()
+    run_id = "RUN"
+    st.session_state["run_id"] = run_id
+    paths.ensure_run_dirs(run_id)
+    monkeypatch.setitem(AGENT_REGISTRY, "Boom", BoomAgent)
+    tasks = [{"id": "T1", "title": "t", "description": "d", "role": "Boom"}]
+    with pytest.raises(RuntimeError):
+        execute_plan("idea", tasks, run_id=run_id)
+    trace = trace_writer.read_trace(run_id)
+    assert any(e.get("event") == "agent_start" for e in trace)
+    assert any(e.get("event") == "agent_error" for e in trace)

--- a/tests/test_routing_fallback_roles.py
+++ b/tests/test_routing_fallback_roles.py
@@ -1,0 +1,26 @@
+import streamlit as st
+
+from core.router import route_task
+from core.agents.unified_registry import AGENT_REGISTRY
+
+
+def test_unknown_role_falls_back(tmp_path, monkeypatch):
+    st.session_state.clear()
+    task = {"id": "1", "title": "t", "description": "d", "role": "Unknown"}
+    role, *_ = route_task(task)
+    assert role == "Dynamic Specialist"
+    task2 = {"id": "2", "title": "t", "description": "d"}
+    role2, *_ = route_task(task2)
+    assert role2 == "Dynamic Specialist"
+
+
+def test_qa_synonyms(monkeypatch):
+    task = {"id": "3", "title": "t", "description": "d", "role": "qa"}
+    role, *_ = route_task(task)
+    assert role == "QA"
+    task2 = {"id": "4", "title": "t", "description": "d", "role": "quality assurance"}
+    role2, *_ = route_task(task2)
+    assert role2 == "QA"
+    monkeypatch.delitem(AGENT_REGISTRY, "QA", raising=False)
+    role3, *_ = route_task(task)
+    assert role3 == "Dynamic Specialist"


### PR DESCRIPTION
## Summary
- Ensure executor tasks persist and log agent start/end while invoking agents via a new `invoke_agent_safely` helper
- Normalize roles to keep unknown ones and default missing/unregistered roles to **Dynamic Specialist**
- Surface runtime errors in the Streamlit app and add tests for invocation signatures, routing fallbacks, and executor failures

## Testing
- `pytest tests/test_agent_invocation_signatures.py tests/test_routing_fallback_roles.py tests/test_executor_no_silent_fail.py`
- `python scripts/generate_repo_map.py`

------
https://chatgpt.com/codex/tasks/task_e_68b886d0f128832ca22a50a662331a2b