### PR TITLE
Fix trace writer concurrency race

### DIFF
--- a/tests/test_trace_writer_concurrency.py
+++ b/tests/test_trace_writer_concurrency.py
@@ -1,0 +1,21 @@
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+from utils import trace_writer
+from utils.paths import ensure_run_dirs
+
+
+def test_append_step_concurrent(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    run_id = ""
+    ensure_run_dirs(run_id)
+    barrier = threading.Barrier(5)
+
+    def worker(i: int) -> None:
+        barrier.wait()
+        trace_writer.append_step(run_id, {"i": i})
+
+    with ThreadPoolExecutor(max_workers=5) as ex:
+        futures = [ex.submit(worker, i) for i in range(5)]
+        for f in futures:
+            f.result()

--- a/utils/trace_writer.py
+++ b/utils/trace_writer.py
@@ -28,9 +28,10 @@ def read_trace(run_id: str) -> list[Any]:
 
 def _atomic_write(p: Path, data: bytes | str) -> None:
     from .paths import ensure_dir
+    import uuid
 
     ensure_dir(p.parent)
-    tmp = p.with_suffix(p.suffix + ".tmp")
+    tmp = p.with_suffix(p.suffix + f".{uuid.uuid4().hex}.tmp")
     if isinstance(data, bytes):
         tmp.write_bytes(data)
     else:


### PR DESCRIPTION
## Summary
- avoid FileNotFoundError in trace_writer by using unique temp file during atomic writes
- add test covering concurrent writes to the trace file

## Testing
- `pytest tests/test_trace_writer_concurrency.py -q`
- `pytest tests/test_trace_writer.py tests/test_trace_writer_atomic.py tests/test_trace_writer_concurrency.py tests/test_agent_invocation_signatures.py tests/test_executor_no_silent_fail.py tests/test_resume_flow.py -q`
- `pytest tests/test_safety_integration.py::test_step_meta_contains_safety -q` *(fails: assertion error)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c74089d0832c87199634305a6051