### PR TITLE
Make executor reliable — safe trace writes, sanitize OpenAI kwargs, and adaptive agent invocation

### DIFF
--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-09-03T23:22:54.645418Z from commit f37c612_
+_Last generated at 2025-09-04T00:19:59.192880Z from commit 8ac409d_

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-09-03T23:22:54.645418Z'
-git_sha: f37c6122a7eaa760c00bbad651d0125790b472d8
+generated_at: '2025-09-04T00:19:59.192880Z'
+git_sha: 8ac409dee2c15bb02d5f580d2d67a57e61248fbe
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -181,20 +181,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/__init__.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/plan_utils.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/qa_router.py
   role: Orchestrator
   responsibilities: []
@@ -209,7 +195,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
+- path: orchestrators/plan_utils.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -218,6 +204,27 @@ modules:
   invokes: []
 - path: orchestrators/executor.py
   role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/__init__.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/app_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/role_summarizer.py
+  role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
@@ -238,13 +245,6 @@ modules:
   invoked_by: []
   invokes: []
 - path: core/summarization/schemas.py
-  role: Summarization
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_agent_invocation_signatures.py
+++ b/tests/test_agent_invocation_signatures.py
@@ -1,0 +1,29 @@
+from core.agents.runtime import invoke_agent_safely
+
+
+class A:
+    def __call__(self, task):
+        return task
+
+
+class B:
+    def run(self, task, model):
+        return task, model
+
+
+class C:
+    def act(self, task, model, meta):
+        return task, model, meta
+
+
+class D:
+    def __call__(self, spec):
+        return spec
+
+
+def test_invoke_agent_signatures():
+    t = {"id": "t1"}
+    assert invoke_agent_safely(A(), t, model="m", meta="x") == t
+    assert invoke_agent_safely(B(), t, model="m", meta="x") == (t, "m")
+    assert invoke_agent_safely(C(), t, model="m", meta="x") == (t, "m", "x")
+    assert invoke_agent_safely(D(), {"foo": 1}) == {"foo": 1}

--- a/tests/test_trace_writer_atomic.py
+++ b/tests/test_trace_writer_atomic.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 from utils import trace_writer
 
 
@@ -8,6 +9,7 @@ def test_atomic_write_creates_parent(tmp_path, monkeypatch):
     step = {"event": "start"}
     trace_writer.append_step(run_id, step)
     p = trace_writer.trace_path(run_id)
+    assert p == Path(".dr_rd") / "runs" / run_id / "trace.json"
     assert p.exists()
     data = json.loads(p.read_text(encoding="utf-8"))
     assert data == [step]


### PR DESCRIPTION
## Summary
- ensure trace writer uses atomic file replacement to avoid missing directory failures
- strip unsupported kwargs before calling the OpenAI Responses API and log keys on TypeError
- use signature-aware `invoke_agent_safely` for agent execution and surface errors in orchestrator

## Testing
- `pytest tests/test_trace_writer_atomic.py tests/test_llm_payload_sanitize.py tests/test_agent_invocation_signatures.py`
- `python scripts/generate_repo_map.py`

------
https://chatgpt.com/codex/tasks/task_e_68b8da95c7fc832c8d96e50b14b4c2b9