### PR TITLE
fix: pass task fields and guard streamlit in executor

### DIFF
--- a/core/agents/runtime.py
+++ b/core/agents/runtime.py
@@ -42,6 +42,7 @@ def invoke_agent_safely(agent: Any, task: dict, model: Any = None, meta: Any = N
 
     sig = inspect.signature(fn)
     mapping: dict[str, Any] = {}
+    task_dict = task if isinstance(task, dict) else {}
     for name in sig.parameters:
         if name == "self":
             continue
@@ -51,6 +52,8 @@ def invoke_agent_safely(agent: Any, task: dict, model: Any = None, meta: Any = N
             mapping[name] = model
         elif name in {"meta", "ctx", "context"}:
             mapping[name] = meta
+        elif name in task_dict:
+            mapping[name] = task_dict.get(name)
 
     bound = sig.bind_partial(**mapping)
     try:

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -473,10 +473,9 @@ def execute_plan(
                     run_id or "",
                     {
                         "phase": "executor",
-                        "event": "agent_end",
+                        "event": "agent_error",
                         "role": role,
                         "task_id": routed.get("id"),
-                        "ok": False,
                         "error": str(e),
                     },
                 )
@@ -601,9 +600,12 @@ def execute_plan(
             if save_decision_log:
                 log_decision(project_id, "agent_result", {"role": role, "has_json": bool(payload)})
             try:  # light budget telemetry
-                tracker = st.session_state.get("cost_tracker")
-                if tracker:
-                    tracker.spend += float(norm.get("cost", 0.0))
+                from streamlit.runtime.scriptrunner import get_script_run_ctx
+
+                if get_script_run_ctx() is not None:
+                    tracker = st.session_state.get("cost_tracker")
+                    if tracker:
+                        tracker.spend += float(norm.get("cost", 0.0))
             except Exception:
                 pass
             span.add_event(

--- a/tests/test_agent_invocation_adaptive.py
+++ b/tests/test_agent_invocation_adaptive.py
@@ -24,6 +24,11 @@ class SpecOnly:
         return spec["id"]
 
 
+class TaskFields:
+    def __call__(self, idea, requirements, tests, defects):
+        return idea, requirements, tests, defects
+
+
 class BadAgent:
     pass
 
@@ -40,6 +45,24 @@ class BadAgent:
 def test_invoke_agent_variants(agent, kwargs, expected):
     task = {"id": "T", "role": "X"}
     assert invoke_agent_safely(agent, task, **kwargs) == expected
+
+
+def test_passes_named_task_fields():
+    agent = TaskFields()
+    task = {
+        "id": "T3",
+        "role": "Z",
+        "idea": "concept",
+        "requirements": ["r1"],
+        "tests": ["t1"],
+        "defects": ["d1"],
+    }
+    assert invoke_agent_safely(agent, task) == (
+        "concept",
+        ["r1"],
+        ["t1"],
+        ["d1"],
+    )
 
 
 def test_uncallable_agent_logs_error(tmp_path):


### PR DESCRIPTION
## Summary
- map task-specific fields when invoking agents
- log agent errors and guard Streamlit access during execution
- cover invocation edge cases with new tests

## Testing
- `pytest tests/test_agent_invocation_adaptive.py tests/test_executor_no_silent_fail.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8ed44d2f8832c8e370456c8541b64