### PR TITLE
Improve JSON handling and agent telemetry

### DIFF
--- a/core/agents/qa_agent.py
+++ b/core/agents/qa_agent.py
@@ -27,7 +27,10 @@ class QAAgent:
         self.factory = PromptFactory()
         allow_tools(self.ROLE, self.ALLOWLIST)
 
-    def run(self, task: str, requirements: List[str], tests: List[str], defects: List[dict]) -> Any:
+    def run(
+        self, task: Any, requirements: List[str], tests: List[str], defects: List[dict]
+    ) -> Any:
+        task_txt = task if isinstance(task, str) else json.dumps(task)
         matrix = call_tool(
             self.ROLE, "build_requirements_matrix", {"reqs": requirements, "tests": tests}
         )
@@ -35,7 +38,7 @@ class QAAgent:
         stats = call_tool(self.ROLE, "classify_defects", {"defects": defects})
         spec = {
             "role": self.ROLE,
-            "task": task,
+            "task": task_txt,
             "inputs": {
                 "matrix": matrix,
                 "coverage": coverage,

--- a/core/llm/__init__.py
+++ b/core/llm/__init__.py
@@ -127,8 +127,7 @@ def complete(
         result = call_openai(model=mdl, messages=messages, **scrub)
         resp = result["raw"]
         content = result["text"] or ""
-        raw = resp.model_dump() if hasattr(resp, "model_dump") else resp
-        return ChatResult(content=content, raw=raw)
+        return ChatResult(content=content, raw=resp)
     except Exception as e:
         _log_400(e)
         raise

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,3 +26,7 @@ Against deployed app:
 APP_EXTERNAL=1 APP_BASE_URL=https://dr-rnd.streamlit.app \
 pytest -q e2e
 ```
+
+## Agents
+
+Schema-constrained agents enforce OpenAI's `response_format={"type":"json_object"}` and fall back to a tolerant JSON parser when validating model output.

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-09-04T02:53:54.024046Z from commit fea511d_
+_Last generated at 2025-09-04T03:29:02.988638Z from commit 3154bd4_

--- a/dr_rd/agents/dynamic_agent.py
+++ b/dr_rd/agents/dynamic_agent.py
@@ -3,14 +3,39 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Tuple
 
 from jsonschema import validate
 
 from core.llm import complete
+from core.llm_client import extract_text
 from core.tool_router import allow_tools
 from dr_rd.prompting import PromptFactory, RetrievalPolicy
+from utils.json_safety import parse_json_loose
+from utils.logging import log_dynamic_agent_failure
+
+
+@dataclass
+class EmptyModelOutput(Exception):
+    """Raised when the model returns empty or invalid JSON."""
+
+    role: str
+    task: str
+    error: str
+    raw_head: str = ""
+    run_id: str | None = None
+    support_id: str | None = None
+
+    def __post_init__(self) -> None:  # pragma: no cover - dataclass hook
+        super().__init__(self.error)
+        self.payload = {
+            "role": self.role,
+            "task": self.task,
+            "error": self.error,
+            "raw_head": self.raw_head,
+        }
 
 
 class DynamicAgent:
@@ -23,6 +48,9 @@ class DynamicAgent:
     def run(self, spec: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         role = spec.get("role_name", "Ad Hoc Specialist")
         task = spec.get("task_brief", "")
+        context = spec.get("context", {})
+        run_id = context.get("run_id")
+        support_id = context.get("support_id")
         io_schema_ref = spec.get("io_schema_ref")
         schema: Dict[str, Any] | None = None
         if not io_schema_ref:
@@ -39,19 +67,33 @@ class DynamicAgent:
         prompt = self.factory.build_prompt(prompt_spec)
         schema_obj = json.loads(Path(self.IO_SCHEMA).read_text())
         resp = complete(prompt["system"], prompt["user"], model=self.model, **prompt["llm_hints"])
-        data = self._validate(resp.content, schema_obj, prompt)
+        data = self._validate(resp.raw, schema_obj, role, task, run_id, support_id)
         return data, (schema or schema_obj)
 
     def _validate(
-        self, text: str, schema: Dict[str, Any], prompt: Dict[str, Any]
+        self,
+        resp: Any,
+        schema: Dict[str, Any],
+        role: str,
+        task: str,
+        run_id: str | None,
+        support_id: str | None,
     ) -> Dict[str, Any]:
-        try:
-            data = json.loads(text)
-            validate(data, schema)
-            return data
-        except Exception:
-            repair_user = prompt["user"] + "\nFix to schema."
-            resp = complete(prompt["system"], repair_user, model=self.model, **prompt["llm_hints"])
-            data = json.loads(resp.content)
-            validate(data, schema)
-            return data
+        if isinstance(resp, dict):
+            data = resp
+        else:
+            text = extract_text(resp) or ""
+            head = (text or "")[:256]
+            if not text.strip():
+                log_dynamic_agent_failure(run_id, support_id, "empty", head)
+                raise EmptyModelOutput(role, task, "empty", head, run_id, support_id)
+            try:
+                data = parse_json_loose(text)
+            except Exception:
+                try:
+                    data = json.loads(text)
+                except Exception as e:
+                    log_dynamic_agent_failure(run_id, support_id, str(e), head)
+                    raise EmptyModelOutput(role, task, str(e), head, run_id, support_id) from e
+        validate(data, schema)
+        return data

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-09-04T02:53:54.024046Z'
-git_sha: fea511dbeb081e9a64db5392bd292b49372c2c09
+generated_at: '2025-09-04T03:29:02.988638Z'
+git_sha: 3154bd4684568828c9c71436a206121b9806c908
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -188,14 +188,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/__init__.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/spec_builder.py
+- path: orchestrators/plan_utils.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -209,7 +202,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/plan_utils.py
+- path: orchestrators/__init__.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -223,8 +216,8 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/__init__.py
-  role: Summarization
+- path: orchestrators/spec_builder.py
+  role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
@@ -237,14 +230,21 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/schemas.py
+- path: core/summarization/integrator.py
   role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
+- path: core/summarization/__init__.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_dynamic_agent_validate.py
+++ b/tests/test_dynamic_agent_validate.py
@@ -1,0 +1,40 @@
+import pytest
+
+from dr_rd.agents.dynamic_agent import DynamicAgent, EmptyModelOutput
+
+
+class Obj:
+    def __init__(self, text: str):
+        self.output_text = text
+
+
+def make_agent():
+    return DynamicAgent("gpt-4o")
+
+
+def test_validate_valid_json():
+    agent = make_agent()
+    resp = Obj('{"a":1}')
+    data = agent._validate(resp, {"type": "object"}, "r", "t", None, None)
+    assert data["a"] == 1
+
+
+def test_validate_json_with_preamble():
+    agent = make_agent()
+    resp = Obj('note: {"a":1}')
+    data = agent._validate(resp, {"type": "object"}, "r", "t", None, None)
+    assert data["a"] == 1
+
+
+def test_validate_empty_output():
+    agent = make_agent()
+    resp = Obj("   ")
+    with pytest.raises(EmptyModelOutput):
+        agent._validate(resp, {"type": "object"}, "r", "t", None, None)
+
+
+def test_validate_dict_pass():
+    agent = make_agent()
+    resp = {"a": 1}
+    data = agent._validate(resp, {"type": "object"}, "r", "t", None, None)
+    assert data["a"] == 1

--- a/tests/test_llm_client_params.py
+++ b/tests/test_llm_client_params.py
@@ -1,0 +1,48 @@
+import json
+
+from core.llm_client import call_openai, llm_call
+
+
+class StubClient:
+    def __init__(self, captured):
+        self.captured = captured
+        self.responses = self
+
+    def create(self, **payload):
+        self.captured.update(payload)
+        class Resp:
+            http_status = 200
+            output_text = "{}"
+        return Resp()
+
+
+def test_param_sanitization(monkeypatch):
+    cap = {}
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setattr("core.llm_client._client", lambda: StubClient(cap))
+    call_openai(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "hi"}],
+        response_params={"temperature": 0.5, "openai": {"foo": 1}, "anthropic": {}, "gemini": {}},
+    )
+    assert "openai" not in cap and "anthropic" not in cap and "gemini" not in cap
+
+
+def test_response_format_application(monkeypatch):
+    cap = {}
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setattr("core.llm_client._client", lambda: StubClient(cap))
+    llm_call(None, "gpt-4o", "stage", [{"role": "user", "content": "hi"}], json_response=True)
+    assert cap.get("response_format") == {"type": "json_object"}
+
+
+def test_model_gating(monkeypatch):
+    cap = {}
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setattr("core.llm_client._client", lambda: StubClient(cap))
+    call_openai(
+        model="gpt-3.5",  # unsupported
+        messages=[{"role": "user", "content": "hi"}],
+        enable_web_search=True,
+    )
+    assert cap["model"] in {"gpt-4o", "gpt-4o-mini"}

--- a/tests/test_qa_agent.py
+++ b/tests/test_qa_agent.py
@@ -1,5 +1,7 @@
 import json
 
+import json
+
 from core.agents.qa_agent import QAAgent
 from core.llm import ChatResult
 
@@ -24,3 +26,24 @@ def test_qa_agent(monkeypatch):
     res = agent.run("assess", ["req1"], ["req1 test"], [])
     assert res["coverage"]["coverage"] == 1.0
     assert res["requirements_matrix"]["total"] == 1
+
+
+def test_qa_agent_dict_task(monkeypatch):
+    output = {
+        "role": "QA",
+        "task": "assess",
+        "requirements_matrix": {"total": 1, "covered": ["req1"], "uncovered": []},
+        "coverage": {"coverage": 1.0, "uncovered": []},
+        "defect_stats": {"critical": [], "major": [], "minor": []},
+        "risks": [],
+        "next_steps": [],
+        "sources": [],
+    }
+
+    def fake_complete(system, user, model=None, **kwargs):
+        return ChatResult(content=json.dumps(output), raw={})
+
+    monkeypatch.setattr("core.agents.qa_agent.complete", fake_complete)
+    agent = QAAgent("gpt")
+    res = agent.run({"brief": "assess"}, ["req1"], ["req1 test"], [])
+    assert res["role"] == "QA"

--- a/tests/test_self_check_tolerant.py
+++ b/tests/test_self_check_tolerant.py
@@ -1,0 +1,18 @@
+import json
+
+from core.evaluation.self_check import validate_and_retry
+
+
+def test_self_check_tolerant_success():
+    raw = "Here:\n```json\n{\"role\":\"R\",\"task\":\"t\",\"findings\":[],\"risks\":[],\"next_steps\":[],\"sources\":[]}\n```"
+    fixed, meta = validate_and_retry("R", {"title": "t"}, raw, lambda r: raw)
+    assert meta["valid_json"] is True
+    assert json.loads(fixed)["role"] == "R"
+
+
+def test_self_check_tolerant_failure():
+    raw = "not json"
+    fixed, meta = validate_and_retry("R", {"title": "t"}, raw, lambda r: raw)
+    assert isinstance(fixed, dict)
+    assert fixed["valid_json"] is False
+    assert meta["valid_json"] is False

--- a/utils/logging.py
+++ b/utils/logging.py
@@ -1,4 +1,5 @@
 import logging
+from core.privacy import redact_for_logging
 
 logger = logging.getLogger("drrd")
 logger.setLevel(logging.INFO)
@@ -16,3 +17,30 @@ def safe_exc(log, idea, msg, exc, request_id: str | None = None):
     if request_id:
         base = f"{base} [req={request_id}]"
     (log or logger).error(obfuscate_query("error", idea or "", base))
+
+
+def _preview(raw: str | None) -> str:
+    try:
+        return str(redact_for_logging(raw or ""))[:256]
+    except Exception:
+        return (raw or "")[:256]
+
+
+def log_self_check(run_id: str | None, support_id: str | None, result: dict, raw_head: str) -> None:
+    logger.info(
+        "self_check run_id=%s support_id=%s result=%s head=%r",
+        run_id,
+        support_id,
+        result,
+        _preview(raw_head),
+    )
+
+
+def log_dynamic_agent_failure(run_id: str | None, support_id: str | None, reason: str, raw_head: str) -> None:
+    logger.warning(
+        "dynamic_agent_failure run_id=%s support_id=%s reason=%s head=%r",
+        run_id,
+        support_id,
+        reason,
+        _preview(raw_head),
+    )


### PR DESCRIPTION
## Summary
- Harden dynamic agent validation with tolerant JSON parsing, structured error payloads, and logging
- Sanitize and gate OpenAI client params, add json_response flag, and guard QA tasks
- Add tolerant self-check parsing with structured failures and orchestration error containment

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pptx'; No module named 'fastapi')*
- `python scripts/generate_repo_map.py`


------
https://chatgpt.com/codex/tasks/task_e_68b905ff7198832caa6a9e5715dd3591