### PR TITLE
Add schema-aware retry ladder with escalation

### DIFF
--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-09-05T00:42:08.868964Z from commit 203fe4f_
+_Last generated at 2025-09-05T00:50:58.245877Z from commit 34902fe_

--- a/docs/RETRY_LADDER.md
+++ b/docs/RETRY_LADDER.md
@@ -1,0 +1,32 @@
+# Retry Ladder and Placeholder Behavior
+
+Agent outputs are validated for a strict JSON contract. Validation proceeds in
+two steps:
+
+1. **Self‑check retry** – The initial response is parsed and checked for the
+   required keys (`role`, `task`, `findings`, `risks`, `next_steps`,
+   `sources`). If the payload is missing data, the agent is reminded with the
+   same model to return the JSON object only.
+2. **Escalation** – If the corrected attempt is still invalid, the orchestrator
+   escalates to a stronger model profile
+   (`select_model("agent_high", agent_name=role)`) and appends a concise keys
+   reminder. The escalated output is validated once more.
+
+If the escalated attempt remains invalid, a placeholder JSON object is emitted
+with
+
+```json
+{
+  "role": "<role>",
+  "task": "<task title>",
+  "findings": "TODO",
+  "risks": "TODO",
+  "next_steps": "TODO",
+  "sources": []
+}
+```
+
+Logs record when escalation starts, which model was chosen, and when a
+placeholder is produced. Downstream components always receive a JSON string—
+either the validated agent output or the placeholder—avoiding silent drops.
+

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-09-05T00:42:08.868964Z'
-git_sha: 203fe4f79ad89cf53b764942f5c6a4ea95778f3e
+generated_at: '2025-09-05T00:50:58.245877Z'
+git_sha: 34902fe2de5013bf85e28454c721aeb82bff53c3
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -181,28 +181,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/executor.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/app_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/__init__.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/plan_utils.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -223,8 +202,22 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
-  role: Summarization
+- path: orchestrators/plan_utils.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/executor.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/app_builder.py
+  role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
@@ -245,6 +238,13 @@ modules:
   invoked_by: []
   invokes: []
 - path: core/summarization/schemas.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/integrator.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_retry_ladder.py
+++ b/tests/test_retry_ladder.py
@@ -1,0 +1,83 @@
+import json
+import logging
+from collections import deque
+
+import config.feature_flags as ff
+from core import orchestrator
+
+
+def _setup(monkeypatch, outputs):
+    monkeypatch.setattr(ff, "PARALLEL_EXEC_ENABLED", False)
+
+    class DummyAgent:
+        def __init__(self, model):
+            self.model = model
+
+    monkeypatch.setattr(
+        orchestrator,
+        "route_task",
+        lambda t, ui_model=None: (t["role"], DummyAgent, "m", t),
+    )
+    monkeypatch.setattr(
+        orchestrator, "pseudonymize_for_model", lambda x: (x, {})
+    )
+    monkeypatch.setattr(
+        orchestrator,
+        "select_model",
+        lambda purpose, agent_name=None: "m-high" if purpose == "agent_high" else "m",
+    )
+    monkeypatch.setattr(
+        "core.evaluation.self_check._load_schema", lambda role: None
+    )
+
+    call_outputs = deque(outputs)
+
+    def fake_invoke(agent, task, model=None, meta=None, run_id=None):
+        return call_outputs.popleft()
+
+    monkeypatch.setattr(orchestrator, "invoke_agent_safely", fake_invoke)
+    return call_outputs
+
+
+def test_retry_ladder_escalates_and_accepts(monkeypatch, caplog):
+    outputs = [
+        "bad",
+        "bad",
+        json.dumps(
+            {
+                "role": "Research Scientist",
+                "task": "t",
+                "findings": ["ok"],
+                "risks": ["r"],
+                "next_steps": ["n"],
+                "sources": ["s"],
+            }
+        ),
+    ]
+    _setup(monkeypatch, outputs)
+    caplog.set_level(logging.INFO)
+    answers = orchestrator.execute_plan(
+        "idea", [{"role": "Research Scientist", "title": "T", "description": "d"}], agents={}
+    )
+    assert any("self_check escalate start" in r.getMessage() for r in caplog.records)
+    assert any("self_check escalate model m-high" in r.getMessage() for r in caplog.records)
+    assert not any("placeholder emitted" in r.getMessage() for r in caplog.records)
+    parsed = json.loads(answers["Research Scientist"])
+    assert parsed["findings"] == ["ok"]
+
+
+def test_retry_ladder_emits_placeholder(monkeypatch, caplog):
+    outputs = ["bad", "bad", "bad", "bad"]
+    _setup(monkeypatch, outputs)
+    caplog.set_level(logging.INFO)
+    answers = orchestrator.execute_plan(
+        "idea", [{"role": "Research Scientist", "title": "T", "description": "d"}], agents={}
+    )
+    assert any("placeholder emitted" in r.getMessage() for r in caplog.records)
+    parsed = json.loads(answers["Research Scientist"])
+    assert parsed["findings"] == "TODO"
+
+    # E2E synth step consumes placeholder without crashing
+    monkeypatch.setattr(orchestrator, "complete", lambda *a, **k: type("R", (), {"content": "ok"})())
+    final = orchestrator.compose_final_proposal("idea", answers)
+    assert final == "ok"

--- a/tests/test_self_check_tolerant.py
+++ b/tests/test_self_check_tolerant.py
@@ -4,7 +4,10 @@ from core.evaluation.self_check import validate_and_retry
 
 
 def test_self_check_repairs_trailing_comma():
-    text = "```json {\"role\":\"r\",\"task\":\"t\",\"findings\":[],\"risks\":[],\"next_steps\":[],\"sources\":[],} ```"
+    text = (
+        "```json {\"role\":\"r\",\"task\":\"t\",\"findings\":[1],"
+        "\"risks\":[2],\"next_steps\":[3],\"sources\":[],} ```"
+    )
     result, meta = validate_and_retry("r", {"id": 1, "title": "t"}, text, lambda _: text)
     assert meta["valid_json"] is True
     parsed = json.loads(result)


### PR DESCRIPTION
## Summary
- enforce non-empty JSON fields and optional schema validation in self-check
- escalate to high-profile model when JSON validation fails and emit TODO placeholders if still invalid
- document retry ladder behavior and add tests for validation and escalation

## Testing
- `pytest tests/test_self_check.py tests/test_self_check_tolerant.py tests/test_orchestrator_unified_path.py tests/test_retry_ladder.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba3292f3f0832c9595826330a247fa