### PR TITLE
Fix missing RunConfig mode option

### DIFF
--- a/utils/run_config.py
+++ b/utils/run_config.py
@@ -11,6 +11,7 @@ class RunConfig:
     """Typed configuration for a single run."""
 
     idea: str = ""
+    mode: str = "standard"
     rag_enabled: bool = False
     live_search_enabled: bool = False
     enforce_budget: bool = False
@@ -68,5 +69,6 @@ def to_orchestrator_kwargs(cfg: RunConfig) -> Dict[str, Any]:
         "knowledge_sources": list(cfg.knowledge_sources),
         "pseudonymize_to_model": cfg.pseudonymize_to_model,
     }
+    kwargs["mode"] = cfg.mode
     kwargs.update(cfg.advanced)
     return kwargs


### PR DESCRIPTION
## Summary
- support configuring run mode by adding `mode` field to `RunConfig`
- include mode in orchestrator kwargs

## Testing
- `pytest tests/test_run_config.py tests/test_query_params.py tests/test_run_config_io.py tests/test_run_reproduce.py`
- `pytest` *(fails: tests/utils/test_redaction.py, tests/test_notebook_export.py, tests/test_errors.py, tests/integrations/test_jira_bridge.py, tests/integrations/test_slack_bridge.py, tests/integrations/test_teams_bridge.py, tests/gtm/test_generate_deck.py)*
- `ruff check utils/run_config.py`

------
https://chatgpt.com/codex/tasks/task_e_68ba494536d8832c8eb27785554b67f2