### PR TITLE
Handle missing prompt pins in run metadata

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -368,6 +368,8 @@ def main() -> None:
         cfg = replace(cfg, mode="demo")
 
     kwargs = to_orchestrator_kwargs(cfg)
+    # Extract any pinned prompts so they can be recorded with the run metadata.
+    prompt_pins = kwargs.get("prompts") or kwargs.get("prompt_pins")
     os.environ["DRRD_PSEUDONYMIZE_TO_MODEL"] = (
         "1" if kwargs.get("pseudonymize_to_model", True) else "0"
     )
@@ -436,7 +438,8 @@ def main() -> None:
         prompts=prompt_pins,
     )
     cfg_dict = asdict(cfg)
-    cfg_dict["prompts"] = prompt_pins
+    if prompt_pins:
+        cfg_dict["prompts"] = prompt_pins
     write_text(run_id, "run_config", "lock.json", json.dumps(to_lockfile(cfg_dict)))
     write_text(run_id, "env", "snapshot.json", json.dumps(capture_env()))
     if origin_run_id:

--- a/utils/notebook_export.py
+++ b/utils/notebook_export.py
@@ -95,7 +95,7 @@ def build_notebook(
     budgets = lock.get("budgets")
     if budgets:
         repro_lines.append(f"- Budgets: `{json.dumps(budgets)}`")
-    pins = lock.get("prompt_pins")
+    pins = lock.get("prompts")
     if pins:
         repro_lines.append("- Prompt pins:")
         for k, v in pins.items():


### PR DESCRIPTION
## Summary
- prevent NameError when recording run metadata by capturing any provided prompt pins
- read prompt pin data from lockfiles using the updated `prompts` key

## Testing
- `pytest` *(fails: tests/gtm/test_generate_deck.py, tests/integrations/test_jira_bridge.py, tests/integrations/test_slack_bridge.py, tests/integrations/test_teams_bridge.py, tests/test_errors.py, tests/test_notebook_export.py, tests/utils/test_redaction.py)*
- `pytest tests/test_run_config_io.py`

------
https://chatgpt.com/codex/tasks/task_e_68ba4ae9a63c832c9fc003d90484072a