### PR TITLE
Add public redaction helper

### DIFF
--- a/utils/redaction.py
+++ b/utils/redaction.py
@@ -1,19 +1,44 @@
 from __future__ import annotations
 
+import re
 from typing import Any
 
 import yaml
 
-from core.redaction import Redactor, redact_text
+from core.redaction import Redactor
+
+_PLACEHOLDER_RE = re.compile(r"\[(SECRET|EMAIL|PHONE|IPV4|IPV6|IP|ADDRESS|PERSON|ORG|DEVICE)_\d+\]")
+REDACTION_TOKEN = "•••"
 
 
-def redact_dict(obj: Any, mode: str = "heavy") -> Any:
-    """Recursively redact strings within *obj* using ``Redactor``."""
+def _strip_placeholders(text: str) -> str:
+    """Replace redaction placeholders with a fixed token."""
+    return _PLACEHOLDER_RE.sub(REDACTION_TOKEN, text)
+
+
+def redact_text(text: str, mode: str = "heavy", role: str | None = None) -> str:
+    """Return *text* with sensitive values replaced by ``REDACTION_TOKEN``."""
+
+    redacted, _, _ = Redactor().redact(text, mode=mode, role=role)
+    return _strip_placeholders(redacted)
+
+
+def redact_dict(obj: Any, max_len: int | None = None, mode: str = "heavy") -> Any:
+    """Recursively redact strings within *obj* using ``Redactor``.
+
+    ``max_len`` limits the length of resulting strings. When specified, any
+    redacted string longer than this value will be truncated and suffixed with
+    an ellipsis.
+    """
+
     redactor = Redactor()
 
     def _walk(o: Any):
         if isinstance(o, str):
             r, _, _ = redactor.redact(o, mode=mode)
+            r = _strip_placeholders(r)
+            if max_len is not None and len(r) > max_len:
+                return r[:max_len] + "…"
             return r
         if isinstance(o, list):
             return [_walk(v) for v in o]
@@ -32,4 +57,16 @@ def load_policy(path_or_dict: Any) -> dict:
         return yaml.safe_load(f) or {}
 
 
-__all__ = ["Redactor", "redact_text", "redact_dict", "load_policy"]
+def redact_public(text: str) -> str:
+    """Return text safe for public sharing."""
+
+    return redact_text(text, mode="heavy")
+
+
+__all__ = [
+    "Redactor",
+    "redact_text",
+    "redact_dict",
+    "load_policy",
+    "redact_public",
+]


### PR DESCRIPTION
## Summary
- add redaction helpers that strip placeholders and expose redact_public
- allow redact_dict to truncate long strings and replace placeholders
## Testing
- `pre-commit run --files utils/redaction.py`
- `pytest tests/test_redaction.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba4de8cb74832cb7193e60cf76bd25