### PR TITLE
Refactor prompts and dynamic agent handling

### DIFF
--- a/core/redaction.py
+++ b/core/redaction.py
@@ -20,16 +20,38 @@ PATTERNS = {
     "DEVICE": re.compile(r'\b([A-Z]{2,}-\d{2,}|\bv\d+\.\d+\b|Rev\s+[A-Z])\b', re.I),
 }
 
+ROLE_NAMES = {
+    "Planner",
+    "CTO",
+    "Regulatory",
+    "Finance",
+    "Marketing Analyst",
+    "IP Analyst",
+    "HRM",
+    "Materials Engineer",
+    "QA",
+    "Dynamic Specialist",
+    "Synthesizer",
+    "Research Scientist",
+    "Chief Scientist",
+    "Regulatory Specialist",
+    "Evaluation",
+    "Finance Specialist",
+    "Simulation",
+    "Materials",
+    "Reflection",
+    "Mechanical Systems Lead",
+}
+
 DEFAULT_GLOBAL_WHITELIST = {
-    "PERSON": {"Alice","Bob"},  # example demo names
+    "PERSON": {"Alice", "Bob", *ROLE_NAMES},
     "ORG": set(),
     "ADDRESS": set(),
     "IP": set(),
     "DEVICE": set(),
 }
-DEFAULT_ROLE_WHITELIST = {
-    "Regulatory": {"FAA","FDA","ISO","IEC","CE"},
-}
+DEFAULT_ROLE_WHITELIST = {role: set() for role in ROLE_NAMES}
+DEFAULT_ROLE_WHITELIST["Regulatory"].update({"FAA", "FDA", "ISO", "IEC", "CE"})
 
 @dataclass
 class Redactor:

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-09-05T02:53:54.604636Z from commit 313a477_
+_Last generated at 2025-09-05T04:01:39.159004Z from commit 2fccd17_

--- a/dr_rd/prompting/prompt_registry.py
+++ b/dr_rd/prompting/prompt_registry.py
@@ -151,7 +151,11 @@ registry.register(
             "Return clear, structured guidance and conclude with a JSON summary "
             "using keys: role, task, findings, risks, next_steps, sources."
         ),
-        user_template="Idea: {idea}\nTask: {task}\nProvide technical architecture and risk guidance.",
+        user_template=(
+            "Idea: {idea}\nTask: {task}\nProvide technical architecture and risk "
+            "guidance. Summarize with summary, findings, next_steps, and sources "
+            "in JSON."
+        ),
         io_schema_ref="dr_rd/schemas/cto_v1.json",
         retrieval_policy=RetrievalPolicy.LIGHT,
     )
@@ -170,10 +174,13 @@ registry.register(
             "meets (or needs modifications to meet) each requirement and adjust "
             "recommendations if testing/simulation reveals new issues."
         ),
-        user_template=(
-            "Idea: {idea}\nTask: {task}\nProvide a thorough regulatory analysis "
-            "including compliance steps and relevant standards."
-        ),
+        user_template=
+            (
+                "Idea: {idea}\nTask: {task}\nProvide a thorough regulatory "
+                "analysis including compliance steps and relevant standards. "
+                "Summarize with summary, findings, next_steps, and sources in "
+                "JSON."
+            ),
         io_schema_ref="dr_rd/schemas/regulatory_v1.json",
         retrieval_policy=RetrievalPolicy.LIGHT,
     )
@@ -187,7 +194,9 @@ registry.register(
         task_key=None,
         system="You evaluate budgets, BOM costs and financial risks.",
         user_template=(
-            "Idea: {idea}\nTask: {task}\nProvide budget estimates and financial risk analysis."
+            "Idea: {idea}\nTask: {task}\nProvide budget estimates and financial "
+            "risk analysis. Include unit_economics, npv, simulations, "
+            "assumptions, risks, next_steps, and sources in the JSON summary."
         ),
         io_schema_ref="dr_rd/schemas/finance_v1.json",
         retrieval_policy=RetrievalPolicy.LIGHT,
@@ -206,7 +215,8 @@ registry.register(
             "strategies."
         ),
         user_template=(
-            "Idea: {idea}\nTask: {task}\nProvide a marketing overview in Markdown."
+            "Idea: {idea}\nTask: {task}\nProvide marketing analysis and conclude "
+            "with summary, findings, next_steps, and sources in JSON."
         ),
         io_schema_ref="dr_rd/schemas/marketing_v1.json",
         retrieval_policy=RetrievalPolicy.LIGHT,
@@ -225,7 +235,8 @@ registry.register(
             "risk."
         ),
         user_template=(
-            "Idea: {idea}\nTask: {task}\nProvide an IP analysis in Markdown."
+            "Idea: {idea}\nTask: {task}\nProvide IP analysis and conclude with "
+            "summary, findings, next_steps, and sources in JSON."
         ),
         io_schema_ref="dr_rd/schemas/ip_analyst_v1.json",
         retrieval_policy=RetrievalPolicy.AGGRESSIVE,
@@ -246,7 +257,8 @@ registry.register(
             "strategy if new technical feedback warrants it."
         ),
         user_template=(
-            "Idea: {idea}\nTask: {task}\nProvide a patentability analysis in Markdown."
+            "Idea: {idea}\nTask: {task}\nProvide a patentability analysis and "
+            "summarize findings, risks, next_steps, and sources in JSON."
         ),
         io_schema_ref="dr_rd/schemas/generic_v1.json",
         retrieval_policy=RetrievalPolicy.AGGRESSIVE,
@@ -264,7 +276,10 @@ registry.register(
             "analysis with concrete details. Conclude with a JSON summary using "
             "keys: role, task, findings, risks, next_steps, sources."
         ),
-        user_template="Idea: {idea}\nTask: {task}\nProvide detailed scientific analysis.",
+        user_template=(
+            "Idea: {idea}\nTask: {task}\nProvide detailed scientific analysis "
+            "with findings, risks, next_steps, and sources in JSON."
+        ),
         io_schema_ref="dr_rd/schemas/research_v1.json",
         retrieval_policy=RetrievalPolicy.AGGRESSIVE,
     )
@@ -282,7 +297,10 @@ registry.register(
             "summary using keys: role, task, findings, risks, next_steps, "
             "sources."
         ),
-        user_template="Idea: {idea}\nTask: {task}\nIdentify the expert roles required.",
+        user_template=(
+            "Idea: {idea}\nTask: {task}\nIdentify the expert roles required and "
+            "summarize with summary, findings, next_steps, and sources in JSON."
+        ),
         io_schema_ref="dr_rd/schemas/hrm_v1.json",
         retrieval_policy=RetrievalPolicy.NONE,
     )
@@ -299,7 +317,11 @@ registry.register(
             "engineering feasibility. Conclude with a JSON summary using keys: "
             "role, task, findings, risks, next_steps, sources."
         ),
-        user_template="Idea: {idea}\nTask: {task}\nProvide material selection and feasibility analysis.",
+        user_template=(
+            "Idea: {idea}\nTask: {task}\nProvide material selection and "
+            "feasibility analysis, summarizing with summary, findings, "
+            "next_steps, and sources in JSON."
+        ),
         io_schema_ref="dr_rd/schemas/materials_engineer_v1.json",
         retrieval_policy=RetrievalPolicy.LIGHT,
     )
@@ -311,8 +333,15 @@ registry.register(
         version="v1",
         role="Dynamic Specialist",
         task_key=None,
-        system="You are a flexible domain expert providing analysis for any topic.",
-        user_template="Idea: {idea}\nTask: {task}",
+        system=(
+            "You are a flexible domain expert providing analysis for any topic. "
+            "Conclude with a JSON summary using keys: role, task, findings, risks, "
+            "next_steps, sources."
+        ),
+        user_template=(
+            "Idea: {idea}\nTask: {task}\nProvide a concise analysis and "
+            "recommendations."
+        ),
         io_schema_ref="dr_rd/schemas/generic_v1.json",
         retrieval_policy=RetrievalPolicy.LIGHT,
     )
@@ -324,9 +353,14 @@ registry.register(
         version="v1",
         role="QA",
         task_key=None,
-        system="You are a QA engineer ensuring requirement coverage and defect analysis.",
+        system=(
+            "You are a QA engineer ensuring requirement coverage and defect "
+            "analysis. Provide a structured QA summary with defects and "
+            "recommendations."
+        ),
         user_template=(
-            "Idea: {idea}\nTask: {task}\nRequirements Matrix: {matrix}\nCoverage: {coverage}\nDefects: {defects}"
+            "Idea: {idea}\nTask: {task}\nList any detected defects and missing "
+            "requirements. Conclude with a JSON summary."
         ),
         io_schema_ref="dr_rd/schemas/qa_v1.json",
         retrieval_policy=RetrievalPolicy.NONE,

--- a/dr_rd/schemas/qa_v1.json
+++ b/dr_rd/schemas/qa_v1.json
@@ -7,7 +7,9 @@
     "findings": {"type": "string"},
     "risks": {"type": "array", "items": {"type": "string"}},
     "next_steps": {"type": "array", "items": {"type": "string"}},
-    "sources": {"type": "array", "items": {"type": "string"}}
+    "sources": {"type": "array", "items": {"type": "string"}},
+    "defects": {"type": "array", "items": {"type": "string"}},
+    "coverage": {"type": "string"}
   },
   "required": ["role", "task", "findings", "risks", "next_steps", "sources"],
   "additionalProperties": false

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-09-05T02:53:54.604636Z'
-git_sha: 313a4773daf444ffb033447262ffd3986961295c
+generated_at: '2025-09-05T04:01:39.159004Z'
+git_sha: 2fccd179ab1aa5b80e35b0d67298495ce7b30a20
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -180,6 +180,27 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
+- path: orchestrators/executor.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/qa_router.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/__init__.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
 - path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
@@ -201,28 +222,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/__init__.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/qa_router.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/executor.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: core/summarization/role_summarizer.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -237,13 +244,6 @@ modules:
   invoked_by: []
   invokes: []
 - path: core/summarization/integrator.py
-  role: Summarization
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_dynamic_agent_spec.py
+++ b/tests/test_dynamic_agent_spec.py
@@ -1,0 +1,30 @@
+import json
+from core import orchestrator
+from core.orchestrator import execute_plan
+
+class DummyAgent:
+    def __init__(self, model):
+        self.model = model
+    def run(self, spec):
+        # return minimal valid JSON
+        return {
+            "role": "Dynamic Specialist",
+            "task": spec.get("task_brief", ""),
+            "findings": "ok",
+            "risks": [],
+            "next_steps": [],
+            "sources": [],
+        }
+
+def test_dynamic_agent_spec_construction(monkeypatch):
+    captured = {}
+    def fake_invoke(agent, task, model=None, meta=None, run_id=None):
+        captured.update(task)
+        return agent.run(task)
+    monkeypatch.setattr(orchestrator, "invoke_agent_safely", fake_invoke)
+    agents = {"Dynamic Specialist": DummyAgent("m")}
+    tasks = [{"id": "T1", "title": "Title", "description": "Desc", "role": "Dynamic Specialist"}]
+    execute_plan("idea", tasks, agents=agents, run_id="r")
+    assert captured["role_name"] == "Dynamic Specialist"
+    assert "task_brief" in captured and captured["task_brief"].startswith("Title")
+    assert captured["io_schema_ref"] == "dr_rd/schemas/generic_v1.json"

--- a/tests/test_open_issues_report.py
+++ b/tests/test_open_issues_report.py
@@ -1,0 +1,13 @@
+import json
+import streamlit as st
+from core.orchestrator import compose_final_proposal
+
+def test_open_issues_section_in_report():
+    st.session_state.clear()
+    valid = {"role": "CTO", "task": "t", "findings": "x", "risks": [], "next_steps": [], "sources": []}
+    st.session_state["answers_raw"] = {"CTO": [json.dumps(valid)]}
+    placeholder = {"role": "CTO", "task": "t", "findings": "TODO", "risks": "TODO", "next_steps": "TODO", "sources": []}
+    st.session_state["open_issues"] = [{"task_id": "T1", "role": "CTO", "result": placeholder, "title": "t"}]
+    report = compose_final_proposal("idea", {"CTO": json.dumps(valid)})
+    assert "## Open Issues" in report
+    assert "T1" in report

--- a/tests/test_prompt_templates_schema.py
+++ b/tests/test_prompt_templates_schema.py
@@ -1,0 +1,23 @@
+from dr_rd.prompting.prompt_registry import registry
+
+def test_marketing_template_has_fields():
+    tpl = registry.get("Marketing Analyst")
+    assert "summary" in tpl.user_template and "findings" in tpl.user_template
+    assert "next_steps" in tpl.user_template and "sources" in tpl.user_template
+
+def test_finance_template_has_fields():
+    tpl = registry.get("Finance")
+    for key in ["unit_economics", "npv", "simulations", "assumptions", "risks", "next_steps", "sources"]:
+        assert key in tpl.user_template
+
+def test_cto_template_has_fields():
+    tpl = registry.get("CTO")
+    for key in ["summary", "findings", "next_steps", "sources"]:
+        assert key in tpl.user_template
+
+def test_dynamic_and_qa_templates():
+    dyn = registry.get("Dynamic Specialist")
+    qa = registry.get("QA")
+    assert "findings" in dyn.system and dyn.io_schema_ref.endswith("generic_v1.json")
+    assert qa.io_schema_ref.endswith("qa_v1.json")
+    assert "JSON summary" in qa.user_template

--- a/tests/test_redaction_whitelist.py
+++ b/tests/test_redaction_whitelist.py
@@ -1,0 +1,6 @@
+from core.redaction import Redactor
+
+def test_role_names_not_redacted():
+    text = "CTO and Marketing Analyst reviewed"
+    red, _, _ = Redactor().redact(text, mode="heavy")
+    assert "CTO" in red and "Marketing Analyst" in red

--- a/tests/test_self_check_escalate.py
+++ b/tests/test_self_check_escalate.py
@@ -1,0 +1,16 @@
+from core.evaluation.self_check import validate_and_retry
+
+def test_self_check_escalates_and_places_placeholder():
+    def retry(_rem):
+        return "{}"  # still invalid
+    def escalate(_rem):
+        return "{}"  # still invalid
+    result, meta = validate_and_retry(
+        "Dynamic Specialist",
+        {"id": "T1", "title": "t"},
+        "{}",
+        retry,
+        escalate_fn=escalate,
+    )
+    assert meta.get("escalated") and not meta.get("valid_json")
+    assert result["findings"] == "TODO"

--- a/utils/redaction.py
+++ b/utils/redaction.py
@@ -1,6 +1,13 @@
 # utils/redaction.py
 from core.redaction import Redactor, redact_text
 
+
+def redact_public(text: str, role: str | None = None) -> str:
+    """Redact ``text`` for public logs using heavy mode."""
+    r = Redactor()
+    red, _, _ = r.redact(text, mode="heavy", role=role)
+    return red
+
 def redact_dict(obj, mode: str = "heavy"):
     r = Redactor()
     def walk(x):


### PR DESCRIPTION
## Summary
- overhaul prompt templates with explicit schema fields and new Dynamic Specialist and QA definitions
- add schema-aware self-check retries with high-capability escalation and placeholder reporting
- expand redaction with role whitelists and public redaction helper; track open issues in final reports

## Testing
- `python scripts/generate_repo_map.py`
- `pytest tests/test_dynamic_agent_spec.py tests/test_prompt_templates_schema.py tests/test_self_check_escalate.py tests/test_redaction_whitelist.py tests/test_open_issues_report.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba5f29f600832ca916dfe7cb462a63