### PR TITLE
Align dynamic agent specs and restore redaction utilities

### DIFF
--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-09-05T04:01:39.159004Z from commit 2fccd17_
+_Last generated at 2025-09-05T04:25:34.624937Z from commit 06d50f3_

--- a/dr_rd/agents/dynamic_agent.py
+++ b/dr_rd/agents/dynamic_agent.py
@@ -61,6 +61,7 @@ class DynamicAgent:
         prompt_spec = {
             "role": role,
             "task": task,
+            "inputs": {"idea": task, "task": task},
             "io_schema_ref": self.IO_SCHEMA,
             "retrieval_policy": spec.get("retrieval_policy", RetrievalPolicy.NONE),
         }

--- a/dr_rd/prompting/prompt_factory.py
+++ b/dr_rd/prompting/prompt_factory.py
@@ -35,6 +35,8 @@ class PromptFactory:
         role = spec.get("role")
         task_key = spec.get("task_key")
         inputs = spec.get("inputs") or {}
+        if isinstance(inputs.get("idea"), (dict, list)):
+            inputs["idea"] = ""
         template = self.registry.get(role, task_key)
 
         if template:

--- a/dr_rd/prompting/prompt_registry.py
+++ b/dr_rd/prompting/prompt_registry.py
@@ -355,12 +355,13 @@ registry.register(
         task_key=None,
         system=(
             "You are a QA engineer ensuring requirement coverage and defect "
-            "analysis. Provide a structured QA summary with defects and "
-            "recommendations."
+            "analysis. Conclude with a JSON summary using keys: role, task, "
+            "findings, risks, next_steps, sources."
         ),
         user_template=(
             "Idea: {idea}\nTask: {task}\nList any detected defects and missing "
-            "requirements. Conclude with a JSON summary."
+            "requirements. Provide a concise assessment and conclude with the "
+            "JSON summary."
         ),
         io_schema_ref="dr_rd/schemas/qa_v1.json",
         retrieval_policy=RetrievalPolicy.NONE,

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-09-05T04:01:39.159004Z'
-git_sha: 2fccd179ab1aa5b80e35b0d67298495ce7b30a20
+generated_at: '2025-09-05T04:25:34.624937Z'
+git_sha: 06d50f3f1e004f1e91c99aed285b2d67a21a5a43
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -187,6 +187,13 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
+- path: orchestrators/spec_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
 - path: orchestrators/qa_router.py
   role: Orchestrator
   responsibilities: []
@@ -201,7 +208,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/spec_builder.py
+- path: orchestrators/plan_utils.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -215,21 +222,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/plan_utils.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: core/summarization/role_summarizer.py
+- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/schemas.py
+- path: core/summarization/integrator.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -243,7 +243,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_dynamic_agent_spec.py
+++ b/tests/test_dynamic_agent_spec.py
@@ -1,6 +1,8 @@
 import json
+import streamlit as st
 from core import orchestrator
 from core.orchestrator import execute_plan
+from dr_rd.prompting.prompt_registry import RetrievalPolicy
 
 class DummyAgent:
     def __init__(self, model):
@@ -18,13 +20,23 @@ class DummyAgent:
 
 def test_dynamic_agent_spec_construction(monkeypatch):
     captured = {}
+
     def fake_invoke(agent, task, model=None, meta=None, run_id=None):
         captured.update(task)
         return agent.run(task)
+
     monkeypatch.setattr(orchestrator, "invoke_agent_safely", fake_invoke)
+    st.session_state.clear()
+    st.session_state["run_id"] = "r1"
+    st.session_state["support_id"] = "s1"
     agents = {"Dynamic Specialist": DummyAgent("m")}
-    tasks = [{"id": "T1", "title": "Title", "description": "Desc", "role": "Dynamic Specialist"}]
+    tasks = [
+        {"id": "T1", "title": "Title", "description": "Desc", "role": "Dynamic Specialist"}
+    ]
     execute_plan("idea", tasks, agents=agents, run_id="r")
     assert captured["role_name"] == "Dynamic Specialist"
     assert "task_brief" in captured and captured["task_brief"].startswith("Title")
     assert captured["io_schema_ref"] == "dr_rd/schemas/generic_v1.json"
+    assert captured["retrieval_policy"] == RetrievalPolicy.LIGHT
+    assert captured["context"]["run_id"] == "r1"
+    assert captured["context"]["support_id"] == "s1"

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -64,3 +64,17 @@ def test_redact_tokens_and_roundtrip():
     assert data["kind"] == "api"
     assert data["support_id"] == "abcdef12"
 
+
+def test_as_json_handles_sets():
+    safe = SafeError(
+        kind="api",
+        user_message="u",
+        tech_message="t",
+        traceback=None,
+        support_id="id",
+        context={"tags": {"a", "b"}},
+    )
+    blob = as_json(safe)
+    data = json.loads(blob.decode("utf-8"))
+    assert sorted(data["context"]["tags"]) == ["a", "b"]
+

--- a/tests/test_execute_plan_placeholder.py
+++ b/tests/test_execute_plan_placeholder.py
@@ -1,0 +1,20 @@
+import json
+import streamlit as st
+from core import orchestrator
+from core.orchestrator import execute_plan
+
+class BadAgent:
+    def __init__(self, model):
+        self.model = model
+    def run(self, spec):
+        return {}
+
+def test_placeholder_open_issue(monkeypatch):
+    def fake_invoke(agent, task, model=None, meta=None, run_id=None):
+        return {}
+    monkeypatch.setattr(orchestrator, "invoke_agent_safely", fake_invoke)
+    st.session_state.clear()
+    agents = {"CTO": BadAgent("m")}
+    tasks = [{"id": "T1", "title": "A", "description": "B", "role": "CTO"}]
+    execute_plan("idea", tasks, agents=agents, run_id="r1")
+    assert st.session_state.get("open_issues")

--- a/tests/test_finance_specialist_agent.py
+++ b/tests/test_finance_specialist_agent.py
@@ -31,3 +31,4 @@ def test_finance_agent(monkeypatch):
     res = agent.run("eval", items, [10.0], {"x": {"mean": 1.0, "std": 0.1}})
     assert res["unit_economics"]["gross_margin"] == 40
     assert res["npv"] == 10.0
+    assert {"assumptions", "risks", "next_steps", "sources"}.issubset(res)

--- a/tests/test_materials_agent.py
+++ b/tests/test_materials_agent.py
@@ -11,6 +11,7 @@ def test_materials_agent(monkeypatch):
         "role": "Materials",
         "task": "check",
         "summary": "ok",
+        "findings": "info",
         "properties": [
             {
                 "name": "Aluminum",
@@ -37,5 +38,6 @@ def test_materials_agent(monkeypatch):
     res = agent.run("check", "Aluminum")
     assert res["role"] == "Materials"
     assert call_count["n"] == 2
+    assert {"summary", "findings", "sources"}.issubset(res)
     prov = tool_router.get_provenance()
     assert any(p["tool"] == "lookup_materials" for p in prov)

--- a/tests/test_redaction_whitelist.py
+++ b/tests/test_redaction_whitelist.py
@@ -1,6 +1,21 @@
 from core.redaction import Redactor
 
+
 def test_role_names_not_redacted():
-    text = "CTO and Marketing Analyst reviewed"
+    text = (
+        "CTO, Marketing Analyst, Dynamic Specialist, QA, Regulatory, "
+        "Finance, Materials Engineer, Research Scientist, Planner"
+    )
     red, _, _ = Redactor().redact(text, mode="heavy")
-    assert "CTO" in red and "Marketing Analyst" in red
+    for role in [
+        "CTO",
+        "Marketing Analyst",
+        "Dynamic Specialist",
+        "QA",
+        "Regulatory",
+        "Finance",
+        "Materials Engineer",
+        "Research Scientist",
+        "Planner",
+    ]:
+        assert role in red

--- a/utils/errors.py
+++ b/utils/errors.py
@@ -100,5 +100,21 @@ def make_safe_error(
     return safe
 
 
+def redact(text: str) -> str:
+    """Back-compat wrapper for redaction."""
+    return redact_text(text)
+
+
+def _coerce_sets(obj: Any) -> Any:
+    if isinstance(obj, set):
+        return list(obj)
+    if isinstance(obj, dict):
+        return {k: _coerce_sets(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_coerce_sets(v) for v in obj]
+    return obj
+
+
 def as_json(safe: SafeError) -> bytes:
-    return json.dumps(asdict(safe), ensure_ascii=False).encode("utf-8")
+    data = _coerce_sets(asdict(safe))
+    return json.dumps(data, ensure_ascii=False).encode("utf-8")

--- a/utils/redaction.py
+++ b/utils/redaction.py
@@ -2,11 +2,9 @@
 from core.redaction import Redactor, redact_text
 
 
-def redact_public(text: str, role: str | None = None) -> str:
+def redact_public(text: str) -> str:
     """Redact ``text`` for public logs using heavy mode."""
-    r = Redactor()
-    red, _, _ = r.redact(text, mode="heavy", role=role)
-    return red
+    return Redactor().redact(text, mode="heavy")[0]
 
 def redact_dict(obj, mode: str = "heavy"):
     r = Redactor()


### PR DESCRIPTION
## Summary
- Build dynamic specialist specs with role name, task brief, standard schema, and light retrieval
- Sanitize idea inputs and update QA and other templates for uniform JSON summaries
- Re-export redact_public and harden error serialization for non-JSON types

## Testing
- `pytest tests/test_dynamic_agent_spec.py tests/test_business_agents.py tests/test_materials_agent.py tests/test_finance_specialist_agent.py tests/test_redaction_whitelist.py tests/test_open_issues_report.py tests/test_execute_plan_placeholder.py tests/test_errors.py`
- `python scripts/generate_repo_map.py`

------
https://chatgpt.com/codex/tasks/task_e_68ba642a365c832c8bebc55883985f35