### PR TITLE
chore: bump agent prompts to v2 with explicit JSON keys and examples

### DIFF
--- a/core/agents/cto_agent.py
+++ b/core/agents/cto_agent.py
@@ -25,7 +25,7 @@ class CTOAgent(PromptFactoryAgent):
                 "idea": idea,
                 "task": task.get("description", "") if isinstance(task, dict) else str(task or ""),
             },
-            "io_schema_ref": "dr_rd/schemas/cto_v1.json",
+            "io_schema_ref": "dr_rd/schemas/cto_v2.json",
             "retrieval_policy": RetrievalPolicy.LIGHT,
             "capabilities": "technical strategy",
             "evaluation_hooks": ["self_check_minimal"],

--- a/core/agents/finance_agent.py
+++ b/core/agents/finance_agent.py
@@ -15,7 +15,7 @@ class FinanceAgent(PromptFactoryAgent):
                 "idea": idea,
                 "task": task.get("description", "") if isinstance(task, dict) else str(task or ""),
             },
-            "io_schema_ref": "dr_rd/schemas/finance_v1.json",
+            "io_schema_ref": "dr_rd/schemas/finance_v2.json",
             "retrieval_policy": RetrievalPolicy.LIGHT,
             "capabilities": "budgeting and costs",
             "evaluation_hooks": ["self_check_minimal"],

--- a/core/agents/finance_specialist_agent.py
+++ b/core/agents/finance_specialist_agent.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, List
+from typing import Any
 
 from jsonschema import validate
 
@@ -15,7 +15,7 @@ from dr_rd.prompting import PromptFactory, RetrievalPolicy
 
 class FinanceSpecialistAgent:
     ROLE = "Finance Specialist"
-    IO_SCHEMA = "dr_rd/schemas/finance_v1.json"
+    IO_SCHEMA = "dr_rd/schemas/finance_v2.json"
     ALLOWLIST = ["calc_unit_economics", "npv", "monte_carlo"]
 
     def __init__(self, model: str) -> None:
@@ -23,7 +23,7 @@ class FinanceSpecialistAgent:
         self.factory = PromptFactory()
         allow_tools(self.ROLE, self.ALLOWLIST)
 
-    def run(self, task: str, line_items: List[dict], cash_flows: List[float], params: dict) -> Any:
+    def run(self, task: str, line_items: list[dict], cash_flows: list[float], params: dict) -> Any:
         econ = call_tool(self.ROLE, "calc_unit_economics", {"line_items": line_items})
         npv_val = call_tool(self.ROLE, "npv", {"cash_flows": cash_flows, "discount_rate": 0.1})
         sim = call_tool(self.ROLE, "monte_carlo", {"params": params, "trials": 100})

--- a/core/agents/hrm_agent.py
+++ b/core/agents/hrm_agent.py
@@ -12,7 +12,7 @@ class HRMAgent(PromptFactoryAgent):
             "role": "HRM",
             "task": str(task or ""),
             "inputs": {"idea": idea, "task": str(task or "")},
-            "io_schema_ref": "dr_rd/schemas/hrm_v1.json",
+            "io_schema_ref": "dr_rd/schemas/hrm_v2.json",
             "retrieval_policy": RetrievalPolicy.NONE,
             "capabilities": "role mapping",
             "evaluation_hooks": ["self_check_minimal"],

--- a/core/agents/ip_analyst_agent.py
+++ b/core/agents/ip_analyst_agent.py
@@ -13,7 +13,7 @@ from dr_rd.prompting.prompt_registry import RetrievalPolicy
 class IPAnalystAgent(PromptFactoryAgent):
     def act(self, idea: str, task: Any = None, **kwargs) -> str:
         budgets_path = Path(__file__).resolve().parents[2] / "config" / "budgets.yaml"
-        with open(budgets_path, "r", encoding="utf-8") as fh:
+        with open(budgets_path, encoding="utf-8") as fh:
             budgets = yaml.safe_load(fh) or {}
         top_k = budgets.get(feature_flags.BUDGET_PROFILE, {}).get("exec", {}).get("top_k", 5)
         spec = {
@@ -23,7 +23,7 @@ class IPAnalystAgent(PromptFactoryAgent):
                 "idea": idea,
                 "task": task.get("description", "") if isinstance(task, dict) else str(task or ""),
             },
-            "io_schema_ref": "dr_rd/schemas/ip_analyst_v1.json",
+            "io_schema_ref": "dr_rd/schemas/ip_analyst_v2.json",
             "retrieval_policy": RetrievalPolicy.AGGRESSIVE,
             "top_k": top_k,
             "capabilities": "prior art search",

--- a/core/agents/marketing_agent.py
+++ b/core/agents/marketing_agent.py
@@ -15,7 +15,7 @@ class MarketingAgent(PromptFactoryAgent):
                 "idea": idea,
                 "task": task.get("description", "") if isinstance(task, dict) else str(task or ""),
             },
-            "io_schema_ref": "dr_rd/schemas/marketing_v1.json",
+            "io_schema_ref": "dr_rd/schemas/marketing_v2.json",
             "retrieval_policy": RetrievalPolicy.LIGHT,
             "capabilities": "market analysis",
             "evaluation_hooks": ["self_check_minimal"],

--- a/core/agents/materials_engineer_agent.py
+++ b/core/agents/materials_engineer_agent.py
@@ -18,7 +18,7 @@ class MaterialsEngineerAgent(PromptFactoryAgent):
             "role": "Materials Engineer",
             "task": text,
             "inputs": {"idea": idea, "task": text},
-            "io_schema_ref": "dr_rd/schemas/materials_engineer_v1.json",
+            "io_schema_ref": "dr_rd/schemas/materials_engineer_v2.json",
             "retrieval_policy": RetrievalPolicy.LIGHT,
             "capabilities": "materials selection",
             "evaluation_hooks": ["self_check_minimal"],

--- a/core/agents/patent_agent.py
+++ b/core/agents/patent_agent.py
@@ -17,7 +17,7 @@ class PatentAgent(PromptFactoryAgent):
                 "idea": idea,
                 "task": task.get("description", "") if isinstance(task, dict) else str(task or ""),
             },
-            "io_schema_ref": "dr_rd/schemas/generic_v1.json",
+            "io_schema_ref": "dr_rd/schemas/generic_v2.json",
             "retrieval_policy": RetrievalPolicy.AGGRESSIVE,
             "capabilities": "patent analysis",
             "evaluation_hooks": ["self_check_minimal"],

--- a/core/agents/qa_agent.py
+++ b/core/agents/qa_agent.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, List
+from typing import Any
 
 from jsonschema import validate
 
@@ -15,7 +15,7 @@ from dr_rd.prompting import PromptFactory, RetrievalPolicy
 
 class QAAgent:
     ROLE = "QA"
-    IO_SCHEMA = "dr_rd/schemas/qa_v1.json"
+    IO_SCHEMA = "dr_rd/schemas/qa_v2.json"
     ALLOWLIST = [
         "build_requirements_matrix",
         "compute_test_coverage",
@@ -30,9 +30,9 @@ class QAAgent:
     def run(
         self,
         task: Any,
-        requirements: List[str],
-        tests: List[str],
-        defects: List[dict],
+        requirements: list[str],
+        tests: list[str],
+        defects: list[dict],
         idea: str = "",
     ) -> Any:
         task_txt = task if isinstance(task, str) else json.dumps(task, ensure_ascii=False)
@@ -70,8 +70,14 @@ class QAAgent:
                 return data
             except Exception:
                 repair_user = prompt["user"] + "\nFix to schema."
-                resp = complete(prompt["system"], repair_user, model=self.model, **prompt["llm_hints"])
-                s = resp.content if isinstance(resp.content, str) else json.dumps(resp.content, ensure_ascii=False)
+                resp = complete(
+                    prompt["system"], repair_user, model=self.model, **prompt["llm_hints"]
+                )
+                s = (
+                    resp.content
+                    if isinstance(resp.content, str)
+                    else json.dumps(resp.content, ensure_ascii=False)
+                )
                 data = json.loads(s)
                 validate(data, schema)
                 return data

--- a/core/agents/regulatory_agent.py
+++ b/core/agents/regulatory_agent.py
@@ -25,7 +25,7 @@ class RegulatoryAgent(PromptFactoryAgent):
                 "idea": idea,
                 "task": task.get("description", "") if isinstance(task, dict) else str(task or ""),
             },
-            "io_schema_ref": "dr_rd/schemas/regulatory_v1.json",
+            "io_schema_ref": "dr_rd/schemas/regulatory_v2.json",
             "retrieval_policy": policy,
             "capabilities": "compliance analysis",
             "evaluation_hooks": ["reg_citation_check"],

--- a/core/agents/research_scientist_agent.py
+++ b/core/agents/research_scientist_agent.py
@@ -25,7 +25,7 @@ class ResearchScientistAgent(PromptFactoryAgent):
                 "idea": idea,
                 "task": task.get("description", "") if isinstance(task, dict) else str(task or ""),
             },
-            "io_schema_ref": "dr_rd/schemas/research_v1.json",
+            "io_schema_ref": "dr_rd/schemas/research_v2.json",
             "retrieval_policy": RetrievalPolicy.AGGRESSIVE,
             "capabilities": "evidence gathering",
             "evaluation_hooks": ["self_check_minimal"],

--- a/dr_rd/agents/dynamic_agent.py
+++ b/dr_rd/agents/dynamic_agent.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Tuple
+from typing import Any
 
 from jsonschema import validate
 
@@ -39,13 +39,13 @@ class EmptyModelOutput(Exception):
 
 
 class DynamicAgent:
-    IO_SCHEMA = "dr_rd/schemas/generic_v1.json"
+    IO_SCHEMA = "dr_rd/schemas/generic_v2.json"
 
     def __init__(self, model: str) -> None:
         self.model = model
         self.factory = PromptFactory()
 
-    def run(self, spec: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    def run(self, spec: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
         role = spec.get("role_name", "Dynamic Specialist")
         task = spec.get("task_brief", "")
         context = spec.get("context", {})
@@ -53,7 +53,7 @@ class DynamicAgent:
         run_id = context.get("run_id")
         support_id = context.get("support_id")
         io_schema_ref = spec.get("io_schema_ref")
-        schema: Dict[str, Any] | None = None
+        schema: dict[str, Any] | None = None
         if not io_schema_ref:
             draft = spec.get("schema_draft", {"type": "object"})
             schema = {"$schema": "http://json-schema.org/draft-07/schema#"}
@@ -75,12 +75,12 @@ class DynamicAgent:
     def _validate(
         self,
         resp: Any,
-        schema: Dict[str, Any],
+        schema: dict[str, Any],
         role: str,
         task: str,
         run_id: str | None,
         support_id: str | None,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Return parsed JSON from ``resp`` or raise :class:`EmptyModelOutput`."""
 
         if isinstance(resp, dict):

--- a/dr_rd/schemas/cto_v2.json
+++ b/dr_rd/schemas/cto_v2.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "role": {"type": "string"},
+    "task": {"type": "string"},
+    "summary": {"type": "string"},
+    "findings": {"type": "string"},
+    "risks": {"type": "array", "items": {"type": "string"}},
+    "next_steps": {"type": "string"},
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string"},
+          "title": {"type": "string"},
+          "url": {"type": "string"}
+        },
+        "required": ["id", "title"]
+      }
+    }
+  },
+  "required": ["role", "task", "summary", "findings", "risks", "next_steps", "sources"],
+  "additionalProperties": false
+}

--- a/dr_rd/schemas/finance_v2.json
+++ b/dr_rd/schemas/finance_v2.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["role", "task", "summary", "findings", "unit_economics", "npv", "simulations", "assumptions", "risks", "next_steps", "sources"],
+  "properties": {
+    "role": {"type": "string"},
+    "task": {"type": "string"},
+    "summary": {"type": "string"},
+    "findings": {"type": "string"},
+    "unit_economics": {
+      "type": "object",
+      "required": ["total_revenue", "total_cost", "gross_margin", "contribution_margin"],
+      "properties": {
+        "total_revenue": {"type": "number"},
+        "total_cost": {"type": "number"},
+        "gross_margin": {"type": "number"},
+        "contribution_margin": {"type": "number"}
+      }
+    },
+    "npv": {"type": "number"},
+    "simulations": {
+      "type": "object",
+      "required": ["mean", "std_dev", "p5", "p95"],
+      "properties": {
+        "mean": {"type": "number"},
+        "std_dev": {"type": "number"},
+        "p5": {"type": "number"},
+        "p95": {"type": "number"}
+      }
+    },
+    "assumptions": {"type": "array", "items": {"type": "string"}},
+    "risks": {"type": "array", "items": {"type": "string"}},
+    "next_steps": {"type": "array", "items": {"type": "string"}},
+    "sources": {"type": "array", "items": {"type": "string"}}
+  }
+}

--- a/dr_rd/schemas/generic_v2.json
+++ b/dr_rd/schemas/generic_v2.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "role": {"type": "string"},
+    "task": {"type": "string"},
+    "summary": {"type": "string"},
+    "findings": {"type": "string"},
+    "risks": {"type": "array", "items": {"type": "string"}},
+    "next_steps": {"type": "array", "items": {"type": "string"}},
+    "sources": {"type": "array", "items": {"type": "string"}}
+  },
+  "required": ["role", "task", "summary", "findings", "risks", "next_steps", "sources"],
+  "additionalProperties": false
+}

--- a/dr_rd/schemas/hrm_v2.json
+++ b/dr_rd/schemas/hrm_v2.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "role": {"type": "string"},
+    "task": {"type": "string"},
+    "summary": {"type": "string"},
+    "findings": {"type": "string"},
+    "risks": {"type": "array", "items": {"type": "string"}},
+    "next_steps": {"type": "string"},
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string"},
+          "title": {"type": "string"},
+          "url": {"type": "string"}
+        },
+        "required": ["id", "title"]
+      }
+    }
+  },
+  "required": ["role", "task", "summary", "findings", "risks", "next_steps", "sources"],
+  "additionalProperties": false
+}

--- a/dr_rd/schemas/ip_analyst_v2.json
+++ b/dr_rd/schemas/ip_analyst_v2.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "role": {"type": "string"},
+    "task": {"type": "string"},
+    "summary": {"type": "string"},
+    "findings": {"type": "string"},
+    "risks": {"type": "array", "items": {"type": "string"}},
+    "next_steps": {"type": "string"},
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string"},
+          "title": {"type": "string"},
+          "url": {"type": "string"}
+        },
+        "required": ["id", "title"]
+      }
+    }
+  },
+  "required": ["role", "task", "summary", "findings", "risks", "next_steps", "sources"],
+  "additionalProperties": false
+}

--- a/dr_rd/schemas/marketing_v2.json
+++ b/dr_rd/schemas/marketing_v2.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "role": {"type": "string"},
+    "task": {"type": "string"},
+    "summary": {"type": "string"},
+    "findings": {"type": "string"},
+    "risks": {"type": "array", "items": {"type": "string"}},
+    "next_steps": {"type": "string"},
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string"},
+          "title": {"type": "string"},
+          "url": {"type": "string"}
+        },
+        "required": ["id", "title"]
+      }
+    }
+  },
+  "required": ["role", "task", "summary", "findings", "risks", "next_steps", "sources"],
+  "additionalProperties": false
+}

--- a/dr_rd/schemas/materials_engineer_v2.json
+++ b/dr_rd/schemas/materials_engineer_v2.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["role", "task", "summary", "findings", "properties", "tradeoffs", "risks", "next_steps", "sources"],
+  "properties": {
+    "role": {"type": "string"},
+    "task": {"type": "string"},
+    "summary": {"type": "string"},
+    "findings": {"type": "string"},
+    "properties": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "property", "value", "units", "source"],
+        "properties": {
+          "name": {"type": "string"},
+          "property": {"type": "string"},
+          "value": {},
+          "units": {"type": "string"},
+          "source": {"type": "string"}
+        }
+      }
+    },
+    "tradeoffs": {"type": "array", "items": {"type": "string"}},
+    "risks": {"type": "array", "items": {"type": "string"}},
+    "next_steps": {"type": "array", "items": {"type": "string"}},
+    "sources": {"type": "array", "items": {"type": "string"}}
+  }
+}

--- a/dr_rd/schemas/qa_v2.json
+++ b/dr_rd/schemas/qa_v2.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "role": {"type": "string"},
+    "task": {"type": "string"},
+    "summary": {"type": "string"},
+    "findings": {"type": "string"},
+    "risks": {"type": "array", "items": {"type": "string"}},
+    "next_steps": {"type": "array", "items": {"type": "string"}},
+    "sources": {"type": "array", "items": {"type": "string"}},
+    "defects": {"type": "array", "items": {"type": "string"}},
+    "coverage": {"type": "string"}
+  },
+  "required": ["role", "task", "summary", "findings", "risks", "next_steps", "sources", "defects", "coverage"],
+  "additionalProperties": false
+}

--- a/dr_rd/schemas/regulatory_v2.json
+++ b/dr_rd/schemas/regulatory_v2.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "role": {"type": "string"},
+    "task": {"type": "string"},
+    "summary": {"type": "string"},
+    "findings": {"type": "string"},
+    "risks": {"type": "array", "items": {"type": "string"}},
+    "next_steps": {"type": "string"},
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string"},
+          "title": {"type": "string"},
+          "url": {"type": "string"}
+        },
+        "required": ["id", "title"]
+      }
+    }
+  },
+  "required": ["role", "task", "summary", "findings", "risks", "next_steps", "sources"],
+  "additionalProperties": false
+}

--- a/dr_rd/schemas/research_v2.json
+++ b/dr_rd/schemas/research_v2.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Research V2",
+  "type": "object",
+  "properties": {
+    "role": {"type": "string"},
+    "task": {"type": "string"},
+    "summary": {"type": "string"},
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "claim": {"type": "string"},
+          "evidence": {"type": "string"},
+          "citations": {"type": "array", "items": {"type": "string"}}
+        },
+        "required": ["claim", "evidence"],
+        "additionalProperties": false
+      }
+    },
+    "gaps": {"type": "string"},
+    "risks": {"type": "string"},
+    "next_steps": {"type": "string"},
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string"},
+          "title": {"type": "string"},
+          "url": {"type": "string"}
+        },
+        "required": ["id", "title"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["role", "task", "summary", "findings", "risks", "next_steps", "sources"],
+  "additionalProperties": false
+}

--- a/tests/test_agents_migration_promptfactory.py
+++ b/tests/test_agents_migration_promptfactory.py
@@ -1,12 +1,13 @@
 import json
-from dr_rd.prompting.prompt_factory import PromptFactory
+
+from config import feature_flags
 from core.agents.base_agent import LLMRoleAgent
-from core.agents.research_scientist_agent import ResearchScientistAgent
-from core.agents.regulatory_agent import RegulatoryAgent
 from core.agents.marketing_agent import MarketingAgent
 from core.agents.planner_agent import PlannerAgent
+from core.agents.regulatory_agent import RegulatoryAgent
+from core.agents.research_scientist_agent import ResearchScientistAgent
 from core.agents.synthesizer_agent import SynthesizerAgent
-from config import feature_flags
+from dr_rd.prompting.prompt_factory import PromptFactory
 
 
 def _make_valid():
@@ -32,15 +33,15 @@ def test_agents_use_promptfactory(monkeypatch):
     feature_flags.RAG_ENABLED = True
     calls = _spy_factory(monkeypatch)
     ResearchScientistAgent("model").act("idea", "task")
-    assert calls["spec"]["io_schema_ref"].endswith("research_v1.json")
+    assert calls["spec"]["io_schema_ref"].endswith("research_v2.json")
 
     calls = _spy_factory(monkeypatch)
     RegulatoryAgent("model").act("idea", "task")
-    assert calls["spec"]["io_schema_ref"].endswith("regulatory_v1.json")
+    assert calls["spec"]["io_schema_ref"].endswith("regulatory_v2.json")
 
     calls = _spy_factory(monkeypatch)
     MarketingAgent("model").act("idea", "task")
-    assert calls["spec"]["io_schema_ref"].endswith("marketing_v1.json")
+    assert calls["spec"]["io_schema_ref"].endswith("marketing_v2.json")
 
     calls = _spy_factory(monkeypatch)
     PlannerAgent("model").act("idea", "task")

--- a/tests/test_dynamic_agent_spec.py
+++ b/tests/test_dynamic_agent_spec.py
@@ -1,22 +1,26 @@
-import json
 import streamlit as st
+
 from core import orchestrator
 from core.orchestrator import execute_plan
 from dr_rd.prompting.prompt_registry import RetrievalPolicy
 
+
 class DummyAgent:
     def __init__(self, model):
         self.model = model
+
     def run(self, spec):
         # return minimal valid JSON
         return {
             "role": "Dynamic Specialist",
             "task": spec.get("task_brief", ""),
+            "summary": "ok",
             "findings": "ok",
             "risks": [],
             "next_steps": [],
             "sources": [],
         }
+
 
 def test_dynamic_agent_spec_construction(monkeypatch):
     captured = {}
@@ -30,13 +34,11 @@ def test_dynamic_agent_spec_construction(monkeypatch):
     st.session_state["run_id"] = "r1"
     st.session_state["support_id"] = "s1"
     agents = {"Dynamic Specialist": DummyAgent("m")}
-    tasks = [
-        {"id": "T1", "title": "Title", "description": "Desc", "role": "Dynamic Specialist"}
-    ]
+    tasks = [{"id": "T1", "title": "Title", "description": "Desc", "role": "Dynamic Specialist"}]
     execute_plan("idea", tasks, agents=agents, run_id="r")
     assert captured["role_name"] == "Dynamic Specialist"
     assert "task_brief" in captured and captured["task_brief"].startswith("Title")
-    assert captured["io_schema_ref"] == "dr_rd/schemas/generic_v1.json"
+    assert captured["io_schema_ref"] == "dr_rd/schemas/generic_v2.json"
     assert captured["retrieval_policy"] == RetrievalPolicy.LIGHT
     assert captured["context"]["run_id"] == "r1"
     assert captured["context"]["support_id"] == "s1"

--- a/tests/test_llm_json_schema.py
+++ b/tests/test_llm_json_schema.py
@@ -13,9 +13,22 @@ def test_schema_agent_returns_valid_json(monkeypatch):
         captured["response_format"] = kwargs.get("response_format")
         return json.dumps(
             {
+                "role": "Materials Engineer",
+                "task": "t",
                 "summary": "",
                 "findings": "",
-                "next_steps": "",
+                "properties": [
+                    {
+                        "name": "mat",
+                        "property": "prop",
+                        "value": 0,
+                        "units": "",
+                        "source": "",
+                    }
+                ],
+                "tradeoffs": [],
+                "risks": [],
+                "next_steps": [],
                 "sources": [],
             }
         )
@@ -24,7 +37,7 @@ def test_schema_agent_returns_valid_json(monkeypatch):
     agent = MaterialsEngineerAgent("gpt-4o-mini")
     out = agent({"description": "t"}, model="gpt-4o-mini", meta={"context": "idea"})
     data = json.loads(out)
-    with open("dr_rd/schemas/materials_engineer_v1.json", encoding="utf-8") as fh:
+    with open("dr_rd/schemas/materials_engineer_v2.json", encoding="utf-8") as fh:
         schema = json.load(fh)
     jsonschema.validate(data, schema)
     assert captured["response_format"]["type"] == "json_schema"

--- a/tests/test_prompt_templates_schema.py
+++ b/tests/test_prompt_templates_schema.py
@@ -1,23 +1,35 @@
 from dr_rd.prompting.prompt_registry import registry
 
+
 def test_marketing_template_has_fields():
     tpl = registry.get("Marketing Analyst")
     assert "summary" in tpl.user_template and "findings" in tpl.user_template
     assert "next_steps" in tpl.user_template and "sources" in tpl.user_template
 
+
 def test_finance_template_has_fields():
     tpl = registry.get("Finance")
-    for key in ["unit_economics", "npv", "simulations", "assumptions", "risks", "next_steps", "sources"]:
+    for key in [
+        "unit_economics",
+        "npv",
+        "simulations",
+        "assumptions",
+        "risks",
+        "next_steps",
+        "sources",
+    ]:
         assert key in tpl.user_template
+
 
 def test_cto_template_has_fields():
     tpl = registry.get("CTO")
     for key in ["summary", "findings", "next_steps", "sources"]:
         assert key in tpl.user_template
 
+
 def test_dynamic_and_qa_templates():
     dyn = registry.get("Dynamic Specialist")
     qa = registry.get("QA")
-    assert "findings" in dyn.system and dyn.io_schema_ref.endswith("generic_v1.json")
-    assert qa.io_schema_ref.endswith("qa_v1.json")
+    assert "findings" in dyn.system and dyn.io_schema_ref.endswith("generic_v2.json")
+    assert qa.io_schema_ref.endswith("qa_v2.json")
     assert "JSON summary" in qa.user_template


### PR DESCRIPTION
## Summary
- add bullet lists, examples, and strict JSON instructions to all domain agent prompts
- introduce v2 schemas with role/task/summary/findings/risks fields
- update agents and tests to use new v2 schemas

## Testing
- `pre-commit run --files core/agents/cto_agent.py core/agents/finance_agent.py core/agents/finance_specialist_agent.py core/agents/hrm_agent.py core/agents/ip_analyst_agent.py core/agents/marketing_agent.py core/agents/materials_engineer_agent.py core/agents/patent_agent.py core/agents/qa_agent.py core/agents/regulatory_agent.py core/agents/research_scientist_agent.py core/orchestrator.py dr_rd/agents/dynamic_agent.py dr_rd/prompting/prompt_registry.py tests/test_agents_migration_promptfactory.py tests/test_dynamic_agent_spec.py tests/test_llm_json_schema.py tests/test_prompt_templates_schema.py dr_rd/schemas/cto_v2.json dr_rd/schemas/finance_v2.json dr_rd/schemas/generic_v2.json dr_rd/schemas/hrm_v2.json dr_rd/schemas/ip_analyst_v2.json dr_rd/schemas/marketing_v2.json dr_rd/schemas/materials_engineer_v2.json dr_rd/schemas/qa_v2.json dr_rd/schemas/regulatory_v2.json dr_rd/schemas/research_v2.json`
- `pytest tests/test_prompt_templates_schema.py tests/test_dynamic_agent_spec.py tests/test_llm_json_schema.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb7ac31660832cbdd578d5715b1351