### PR TITLE
Enforce strict agent JSON schema and output handling

### DIFF
--- a/dr_rd/schemas/chief_scientist_v1.json
+++ b/dr_rd/schemas/chief_scientist_v1.json
@@ -2,22 +2,57 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "summary": {"type": "string"},
-    "findings": {"type": "string"},
+    "summary": {
+      "type": "string"
+    },
+    "findings": {
+      "type": "string"
+    },
     "sources": {
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "title": {"type": "string"},
-          "url": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
         },
-        "required": ["id", "title"]
+        "required": [
+          "id",
+          "title"
+        ]
       }
     },
-    "next_steps": {"type": "string"}
+    "next_steps": {
+      "type": "string"
+    },
+    "role": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
   },
-  "required": ["summary", "findings", "sources"],
+  "required": [
+    "summary",
+    "findings",
+    "sources",
+    "role",
+    "task",
+    "risks",
+    "next_steps"
+  ],
   "additionalProperties": false
 }

--- a/dr_rd/schemas/compliance_matrix_v1.json
+++ b/dr_rd/schemas/compliance_matrix_v1.json
@@ -7,19 +7,72 @@
       "items": {
         "type": "object",
         "properties": {
-          "ref": {"type": "string"},
-          "text": {"type": "string"},
-          "applicable": {"type": "boolean"},
-          "rationale": {"type": ["string", "null"]}
+          "ref": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          },
+          "applicable": {
+            "type": "boolean"
+          },
+          "rationale": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
         },
-        "required": ["ref", "text", "applicable"],
+        "required": [
+          "ref",
+          "text",
+          "applicable"
+        ],
         "additionalProperties": false
       }
     },
-    "gaps": {"type": "array", "items": {"type": "string"}},
-    "risks": {"type": "array", "items": {"type": "string"}},
-    "next_steps": {"type": "array", "items": {"type": "string"}}
+    "gaps": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "next_steps": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "role": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
+    },
+    "findings": {
+      "type": "string"
+    },
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
   },
-  "required": ["requirements"],
+  "required": [
+    "requirements",
+    "role",
+    "task",
+    "findings",
+    "risks",
+    "next_steps",
+    "sources"
+  ],
   "additionalProperties": false
 }

--- a/dr_rd/schemas/cto_v1.json
+++ b/dr_rd/schemas/cto_v1.json
@@ -2,22 +2,57 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "summary": {"type": "string"},
-    "findings": {"type": "string"},
+    "summary": {
+      "type": "string"
+    },
+    "findings": {
+      "type": "string"
+    },
     "sources": {
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "title": {"type": "string"},
-          "url": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
         },
-        "required": ["id", "title"]
+        "required": [
+          "id",
+          "title"
+        ]
       }
     },
-    "next_steps": {"type": "string"}
+    "next_steps": {
+      "type": "string"
+    },
+    "role": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
   },
-  "required": ["summary", "findings", "sources"],
+  "required": [
+    "summary",
+    "findings",
+    "sources",
+    "role",
+    "task",
+    "risks",
+    "next_steps"
+  ],
   "additionalProperties": false
 }

--- a/dr_rd/schemas/cto_v2.json
+++ b/dr_rd/schemas/cto_v2.json
@@ -2,25 +2,57 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "role": {"type": "string"},
-    "task": {"type": "string"},
-    "summary": {"type": "string"},
-    "findings": {"type": "string"},
-    "risks": {"type": "array", "items": {"type": "string"}},
-    "next_steps": {"type": "string"},
+    "role": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
+    },
+    "summary": {
+      "type": "string"
+    },
+    "findings": {
+      "type": "string"
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "next_steps": {
+      "type": "string"
+    },
     "sources": {
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "title": {"type": "string"},
-          "url": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
         },
-        "required": ["id", "title"]
+        "required": [
+          "id",
+          "title"
+        ]
       }
     }
   },
-  "required": ["role", "task", "summary", "findings", "risks", "next_steps", "sources"],
+  "required": [
+    "role",
+    "task",
+    "summary",
+    "findings",
+    "risks",
+    "next_steps",
+    "sources"
+  ],
   "additionalProperties": false
 }

--- a/dr_rd/schemas/dynamic_agent_v1.json
+++ b/dr_rd/schemas/dynamic_agent_v1.json
@@ -2,13 +2,41 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "role": {"type": "string"},
-    "task": {"type": "string"},
-    "findings": {"type": "string"},
-    "risks": {"type": "array", "items": {"type": "string"}},
-    "next_steps": {"type": "array", "items": {"type": "string"}},
-    "sources": {"type": "array", "items": {"type": "string"}}
+    "role": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
+    },
+    "findings": {
+      "type": "string"
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "next_steps": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
   },
-  "required": ["role", "task", "findings", "risks", "next_steps", "sources"],
+  "required": [
+    "role",
+    "task",
+    "findings",
+    "risks",
+    "next_steps",
+    "sources"
+  ],
   "additionalProperties": false
 }

--- a/dr_rd/schemas/finance_v1.json
+++ b/dr_rd/schemas/finance_v1.json
@@ -1,34 +1,100 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "required": ["role", "task", "unit_economics", "npv", "simulations", "assumptions", "risks", "next_steps", "sources"],
+  "required": [
+    "role",
+    "task",
+    "unit_economics",
+    "npv",
+    "simulations",
+    "assumptions",
+    "risks",
+    "next_steps",
+    "sources",
+    "findings"
+  ],
   "properties": {
-    "role": {"type": "string"},
-    "task": {"type": "string"},
+    "role": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
+    },
     "unit_economics": {
       "type": "object",
-      "required": ["total_revenue", "total_cost", "gross_margin", "contribution_margin"],
+      "required": [
+        "total_revenue",
+        "total_cost",
+        "gross_margin",
+        "contribution_margin"
+      ],
       "properties": {
-        "total_revenue": {"type": "number"},
-        "total_cost": {"type": "number"},
-        "gross_margin": {"type": "number"},
-        "contribution_margin": {"type": "number"}
+        "total_revenue": {
+          "type": "number"
+        },
+        "total_cost": {
+          "type": "number"
+        },
+        "gross_margin": {
+          "type": "number"
+        },
+        "contribution_margin": {
+          "type": "number"
+        }
       }
     },
-    "npv": {"type": "number"},
+    "npv": {
+      "type": "number"
+    },
     "simulations": {
       "type": "object",
-      "required": ["mean", "std_dev", "p5", "p95"],
+      "required": [
+        "mean",
+        "std_dev",
+        "p5",
+        "p95"
+      ],
       "properties": {
-        "mean": {"type": "number"},
-        "std_dev": {"type": "number"},
-        "p5": {"type": "number"},
-        "p95": {"type": "number"}
+        "mean": {
+          "type": "number"
+        },
+        "std_dev": {
+          "type": "number"
+        },
+        "p5": {
+          "type": "number"
+        },
+        "p95": {
+          "type": "number"
+        }
       }
     },
-    "assumptions": {"type": "array", "items": {"type": "string"}},
-    "risks": {"type": "array", "items": {"type": "string"}},
-    "next_steps": {"type": "array", "items": {"type": "string"}},
-    "sources": {"type": "array", "items": {"type": "string"}}
+    "assumptions": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "next_steps": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "findings": {
+      "type": "string"
+    }
   }
 }

--- a/dr_rd/schemas/finance_v2.json
+++ b/dr_rd/schemas/finance_v2.json
@@ -1,36 +1,104 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "required": ["role", "task", "summary", "findings", "unit_economics", "npv", "simulations", "assumptions", "risks", "next_steps", "sources"],
+  "required": [
+    "role",
+    "task",
+    "summary",
+    "findings",
+    "unit_economics",
+    "npv",
+    "simulations",
+    "assumptions",
+    "risks",
+    "next_steps",
+    "sources"
+  ],
   "properties": {
-    "role": {"type": "string"},
-    "task": {"type": "string"},
-    "summary": {"type": "string"},
-    "findings": {"type": "string"},
+    "role": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
+    },
+    "summary": {
+      "type": "string"
+    },
+    "findings": {
+      "type": "string"
+    },
     "unit_economics": {
       "type": "object",
-      "required": ["total_revenue", "total_cost", "gross_margin", "contribution_margin"],
+      "required": [
+        "total_revenue",
+        "total_cost",
+        "gross_margin",
+        "contribution_margin"
+      ],
       "properties": {
-        "total_revenue": {"type": "number"},
-        "total_cost": {"type": "number"},
-        "gross_margin": {"type": "number"},
-        "contribution_margin": {"type": "number"}
+        "total_revenue": {
+          "type": "number"
+        },
+        "total_cost": {
+          "type": "number"
+        },
+        "gross_margin": {
+          "type": "number"
+        },
+        "contribution_margin": {
+          "type": "number"
+        }
       }
     },
-    "npv": {"type": "number"},
+    "npv": {
+      "type": "number"
+    },
     "simulations": {
       "type": "object",
-      "required": ["mean", "std_dev", "p5", "p95"],
+      "required": [
+        "mean",
+        "std_dev",
+        "p5",
+        "p95"
+      ],
       "properties": {
-        "mean": {"type": "number"},
-        "std_dev": {"type": "number"},
-        "p5": {"type": "number"},
-        "p95": {"type": "number"}
+        "mean": {
+          "type": "number"
+        },
+        "std_dev": {
+          "type": "number"
+        },
+        "p5": {
+          "type": "number"
+        },
+        "p95": {
+          "type": "number"
+        }
       }
     },
-    "assumptions": {"type": "array", "items": {"type": "string"}},
-    "risks": {"type": "array", "items": {"type": "string"}},
-    "next_steps": {"type": "array", "items": {"type": "string"}},
-    "sources": {"type": "array", "items": {"type": "string"}}
+    "assumptions": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "next_steps": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
   }
 }

--- a/dr_rd/schemas/generic_v1.json
+++ b/dr_rd/schemas/generic_v1.json
@@ -2,13 +2,41 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "role": {"type": "string"},
-    "task": {"type": "string"},
-    "findings": {"type": "string"},
-    "risks": {"type": "array", "items": {"type": "string"}},
-    "next_steps": {"type": "array", "items": {"type": "string"}},
-    "sources": {"type": "array", "items": {"type": "string"}}
+    "role": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
+    },
+    "findings": {
+      "type": "string"
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "next_steps": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
   },
-  "required": ["role", "task", "findings", "risks", "next_steps", "sources"],
+  "required": [
+    "role",
+    "task",
+    "findings",
+    "risks",
+    "next_steps",
+    "sources"
+  ],
   "additionalProperties": false
 }

--- a/dr_rd/schemas/generic_v2.json
+++ b/dr_rd/schemas/generic_v2.json
@@ -2,14 +2,45 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "role": {"type": "string"},
-    "task": {"type": "string"},
-    "summary": {"type": "string"},
-    "findings": {"type": "string"},
-    "risks": {"type": "array", "items": {"type": "string"}},
-    "next_steps": {"type": "array", "items": {"type": "string"}},
-    "sources": {"type": "array", "items": {"type": "string"}}
+    "role": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
+    },
+    "summary": {
+      "type": "string"
+    },
+    "findings": {
+      "type": "string"
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "next_steps": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
   },
-  "required": ["role", "task", "summary", "findings", "risks", "next_steps", "sources"],
+  "required": [
+    "role",
+    "task",
+    "summary",
+    "findings",
+    "risks",
+    "next_steps",
+    "sources"
+  ],
   "additionalProperties": false
 }

--- a/dr_rd/schemas/hrm_v1.json
+++ b/dr_rd/schemas/hrm_v1.json
@@ -2,22 +2,57 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "summary": {"type": "string"},
-    "findings": {"type": "string"},
+    "summary": {
+      "type": "string"
+    },
+    "findings": {
+      "type": "string"
+    },
     "sources": {
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "title": {"type": "string"},
-          "url": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
         },
-        "required": ["id", "title"]
+        "required": [
+          "id",
+          "title"
+        ]
       }
     },
-    "next_steps": {"type": "string"}
+    "next_steps": {
+      "type": "string"
+    },
+    "role": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
   },
-  "required": ["summary", "findings", "sources"],
+  "required": [
+    "summary",
+    "findings",
+    "sources",
+    "role",
+    "task",
+    "risks",
+    "next_steps"
+  ],
   "additionalProperties": false
 }

--- a/dr_rd/schemas/hrm_v2.json
+++ b/dr_rd/schemas/hrm_v2.json
@@ -2,25 +2,57 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "role": {"type": "string"},
-    "task": {"type": "string"},
-    "summary": {"type": "string"},
-    "findings": {"type": "string"},
-    "risks": {"type": "array", "items": {"type": "string"}},
-    "next_steps": {"type": "string"},
+    "role": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
+    },
+    "summary": {
+      "type": "string"
+    },
+    "findings": {
+      "type": "string"
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "next_steps": {
+      "type": "string"
+    },
     "sources": {
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "title": {"type": "string"},
-          "url": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
         },
-        "required": ["id", "title"]
+        "required": [
+          "id",
+          "title"
+        ]
       }
     }
   },
-  "required": ["role", "task", "summary", "findings", "risks", "next_steps", "sources"],
+  "required": [
+    "role",
+    "task",
+    "summary",
+    "findings",
+    "risks",
+    "next_steps",
+    "sources"
+  ],
   "additionalProperties": false
 }

--- a/dr_rd/schemas/ip_analyst_v1.json
+++ b/dr_rd/schemas/ip_analyst_v1.json
@@ -2,22 +2,57 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "summary": {"type": "string"},
-    "findings": {"type": "string"},
+    "summary": {
+      "type": "string"
+    },
+    "findings": {
+      "type": "string"
+    },
     "sources": {
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "title": {"type": "string"},
-          "url": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
         },
-        "required": ["id", "title"]
+        "required": [
+          "id",
+          "title"
+        ]
       }
     },
-    "next_steps": {"type": "string"}
+    "next_steps": {
+      "type": "string"
+    },
+    "role": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
   },
-  "required": ["summary", "findings", "sources"],
+  "required": [
+    "summary",
+    "findings",
+    "sources",
+    "role",
+    "task",
+    "risks",
+    "next_steps"
+  ],
   "additionalProperties": false
 }

--- a/dr_rd/schemas/ip_analyst_v2.json
+++ b/dr_rd/schemas/ip_analyst_v2.json
@@ -2,25 +2,57 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "role": {"type": "string"},
-    "task": {"type": "string"},
-    "summary": {"type": "string"},
-    "findings": {"type": "string"},
-    "risks": {"type": "array", "items": {"type": "string"}},
-    "next_steps": {"type": "string"},
+    "role": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
+    },
+    "summary": {
+      "type": "string"
+    },
+    "findings": {
+      "type": "string"
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "next_steps": {
+      "type": "string"
+    },
     "sources": {
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "title": {"type": "string"},
-          "url": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
         },
-        "required": ["id", "title"]
+        "required": [
+          "id",
+          "title"
+        ]
       }
     }
   },
-  "required": ["role", "task", "summary", "findings", "risks", "next_steps", "sources"],
+  "required": [
+    "role",
+    "task",
+    "summary",
+    "findings",
+    "risks",
+    "next_steps",
+    "sources"
+  ],
   "additionalProperties": false
 }

--- a/dr_rd/schemas/marketing_v1.json
+++ b/dr_rd/schemas/marketing_v1.json
@@ -2,22 +2,57 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "summary": {"type": "string"},
-    "findings": {"type": "string"},
+    "summary": {
+      "type": "string"
+    },
+    "findings": {
+      "type": "string"
+    },
     "sources": {
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "title": {"type": "string"},
-          "url": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
         },
-        "required": ["id", "title"]
+        "required": [
+          "id",
+          "title"
+        ]
       }
     },
-    "next_steps": {"type": "string"}
+    "next_steps": {
+      "type": "string"
+    },
+    "role": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
   },
-  "required": ["summary", "findings", "sources"],
+  "required": [
+    "summary",
+    "findings",
+    "sources",
+    "role",
+    "task",
+    "risks",
+    "next_steps"
+  ],
   "additionalProperties": false
 }

--- a/dr_rd/schemas/marketing_v2.json
+++ b/dr_rd/schemas/marketing_v2.json
@@ -2,25 +2,57 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "role": {"type": "string"},
-    "task": {"type": "string"},
-    "summary": {"type": "string"},
-    "findings": {"type": "string"},
-    "risks": {"type": "array", "items": {"type": "string"}},
-    "next_steps": {"type": "string"},
+    "role": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
+    },
+    "summary": {
+      "type": "string"
+    },
+    "findings": {
+      "type": "string"
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "next_steps": {
+      "type": "string"
+    },
     "sources": {
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "title": {"type": "string"},
-          "url": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
         },
-        "required": ["id", "title"]
+        "required": [
+          "id",
+          "title"
+        ]
       }
     }
   },
-  "required": ["role", "task", "summary", "findings", "risks", "next_steps", "sources"],
+  "required": [
+    "role",
+    "task",
+    "summary",
+    "findings",
+    "risks",
+    "next_steps",
+    "sources"
+  ],
   "additionalProperties": false
 }

--- a/dr_rd/schemas/materials_engineer_v1.json
+++ b/dr_rd/schemas/materials_engineer_v1.json
@@ -2,22 +2,57 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "summary": {"type": "string"},
-    "findings": {"type": "string"},
+    "summary": {
+      "type": "string"
+    },
+    "findings": {
+      "type": "string"
+    },
     "sources": {
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "title": {"type": "string"},
-          "url": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
         },
-        "required": ["id", "title"]
+        "required": [
+          "id",
+          "title"
+        ]
       }
     },
-    "next_steps": {"type": "string"}
+    "next_steps": {
+      "type": "string"
+    },
+    "role": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
   },
-  "required": ["summary", "findings", "sources"],
+  "required": [
+    "summary",
+    "findings",
+    "sources",
+    "role",
+    "task",
+    "risks",
+    "next_steps"
+  ],
   "additionalProperties": false
 }

--- a/dr_rd/schemas/materials_engineer_v2.json
+++ b/dr_rd/schemas/materials_engineer_v2.json
@@ -1,29 +1,81 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "required": ["role", "task", "summary", "findings", "properties", "tradeoffs", "risks", "next_steps", "sources"],
+  "required": [
+    "role",
+    "task",
+    "summary",
+    "findings",
+    "properties",
+    "tradeoffs",
+    "risks",
+    "next_steps",
+    "sources"
+  ],
   "properties": {
-    "role": {"type": "string"},
-    "task": {"type": "string"},
-    "summary": {"type": "string"},
-    "findings": {"type": "string"},
+    "role": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
+    },
+    "summary": {
+      "type": "string"
+    },
+    "findings": {
+      "type": "string"
+    },
     "properties": {
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["name", "property", "value", "units", "source"],
+        "required": [
+          "name",
+          "property",
+          "value",
+          "units",
+          "source"
+        ],
         "properties": {
-          "name": {"type": "string"},
-          "property": {"type": "string"},
+          "name": {
+            "type": "string"
+          },
+          "property": {
+            "type": "string"
+          },
           "value": {},
-          "units": {"type": "string"},
-          "source": {"type": "string"}
+          "units": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          }
         }
       }
     },
-    "tradeoffs": {"type": "array", "items": {"type": "string"}},
-    "risks": {"type": "array", "items": {"type": "string"}},
-    "next_steps": {"type": "array", "items": {"type": "string"}},
-    "sources": {"type": "array", "items": {"type": "string"}}
+    "tradeoffs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "next_steps": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
   }
 }

--- a/dr_rd/schemas/materials_v1.json
+++ b/dr_rd/schemas/materials_v1.json
@@ -1,28 +1,81 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "required": ["role", "task", "summary", "properties", "tradeoffs", "risks", "next_steps", "sources"],
+  "required": [
+    "role",
+    "task",
+    "summary",
+    "properties",
+    "tradeoffs",
+    "risks",
+    "next_steps",
+    "sources",
+    "findings"
+  ],
   "properties": {
-    "role": {"type": "string"},
-    "task": {"type": "string"},
-    "summary": {"type": "string"},
+    "role": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
+    },
+    "summary": {
+      "type": "string"
+    },
     "properties": {
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["name", "property", "value", "units", "source"],
+        "required": [
+          "name",
+          "property",
+          "value",
+          "units",
+          "source"
+        ],
         "properties": {
-          "name": {"type": "string"},
-          "property": {"type": "string"},
+          "name": {
+            "type": "string"
+          },
+          "property": {
+            "type": "string"
+          },
           "value": {},
-          "units": {"type": "string"},
-          "source": {"type": "string"}
+          "units": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          }
         }
       }
     },
-    "tradeoffs": {"type": "array", "items": {"type": "string"}},
-    "risks": {"type": "array", "items": {"type": "string"}},
-    "next_steps": {"type": "array", "items": {"type": "string"}},
-    "sources": {"type": "array", "items": {"type": "string"}}
+    "tradeoffs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "next_steps": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "findings": {
+      "type": "string"
+    }
   }
 }

--- a/dr_rd/schemas/mechanical_systems_lead_v1.json
+++ b/dr_rd/schemas/mechanical_systems_lead_v1.json
@@ -2,22 +2,57 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "summary": {"type": "string"},
-    "findings": {"type": "string"},
+    "summary": {
+      "type": "string"
+    },
+    "findings": {
+      "type": "string"
+    },
     "sources": {
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "title": {"type": "string"},
-          "url": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
         },
-        "required": ["id", "title"]
+        "required": [
+          "id",
+          "title"
+        ]
       }
     },
-    "next_steps": {"type": "string"}
+    "next_steps": {
+      "type": "string"
+    },
+    "role": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
   },
-  "required": ["summary", "findings", "sources"],
+  "required": [
+    "summary",
+    "findings",
+    "sources",
+    "role",
+    "task",
+    "risks",
+    "next_steps"
+  ],
   "additionalProperties": false
 }

--- a/dr_rd/schemas/patent_evidence_v1.json
+++ b/dr_rd/schemas/patent_evidence_v1.json
@@ -4,40 +4,150 @@
   "properties": {
     "records": {
       "type": "array",
-      "items": {"$ref": "#/definitions/patent"}
+      "items": {
+        "$ref": "#/definitions/patent"
+      }
+    },
+    "role": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
+    },
+    "findings": {
+      "type": "string"
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "next_steps": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   },
-  "required": ["records"],
+  "required": [
+    "records",
+    "role",
+    "task",
+    "findings",
+    "risks",
+    "next_steps",
+    "sources"
+  ],
   "additionalProperties": false,
   "definitions": {
     "source": {
       "type": "object",
       "properties": {
-        "id": {"type": "string"},
-        "url": {"type": "string"}
+        "id": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
       },
-      "required": ["id", "url"],
+      "required": [
+        "id",
+        "url"
+      ],
       "additionalProperties": false
     },
     "patent": {
       "type": "object",
       "properties": {
-        "pub_number": {"type": "string"},
-        "app_number": {"type": ["string", "null"]},
-        "title": {"type": "string"},
-        "abstract": {"type": ["string", "null"]},
-        "assignees": {"type": "array", "items": {"type": "string"}},
-        "inventors": {"type": "array", "items": {"type": "string"}},
-        "cpc_codes": {"type": "array", "items": {"type": "string"}},
-        "ipc_codes": {"type": "array", "items": {"type": "string"}},
-        "pub_date": {"type": "string"},
-        "priority_date": {"type": ["string", "null"]},
-        "cited_by_count": {"type": ["number", "null"]},
-        "citations": {"type": "array", "items": {"type": "string"}},
-        "url": {"type": "string"},
-        "source": {"$ref": "#/definitions/source"}
+        "pub_number": {
+          "type": "string"
+        },
+        "app_number": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "title": {
+          "type": "string"
+        },
+        "abstract": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "assignees": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "inventors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "cpc_codes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ipc_codes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "pub_date": {
+          "type": "string"
+        },
+        "priority_date": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "cited_by_count": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "citations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "url": {
+          "type": "string"
+        },
+        "source": {
+          "$ref": "#/definitions/source"
+        }
       },
-      "required": ["pub_number", "title", "assignees", "inventors", "cpc_codes", "ipc_codes", "pub_date", "citations", "url", "source"],
+      "required": [
+        "pub_number",
+        "title",
+        "assignees",
+        "inventors",
+        "cpc_codes",
+        "ipc_codes",
+        "pub_date",
+        "citations",
+        "url",
+        "source"
+      ],
       "additionalProperties": false
     }
   }

--- a/dr_rd/schemas/planner_v1.json
+++ b/dr_rd/schemas/planner_v1.json
@@ -3,25 +3,75 @@
   "title": "Planner V1",
   "type": "object",
   "properties": {
-    "plan_id": {"type": "string"},
+    "plan_id": {
+      "type": "string"
+    },
     "tasks": {
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "title": {"type": "string"},
-          "summary": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          }
         },
-        "required": ["id", "title", "summary"],
+        "required": [
+          "id",
+          "title",
+          "summary"
+        ],
         "additionalProperties": false
       }
     },
-    "constraints": {"type": "string"},
-    "assumptions": {"type": "string"},
-    "metrics": {"type": "string"},
-    "next_steps": {"type": "string"}
+    "constraints": {
+      "type": "string"
+    },
+    "assumptions": {
+      "type": "string"
+    },
+    "metrics": {
+      "type": "string"
+    },
+    "next_steps": {
+      "type": "string"
+    },
+    "role": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
+    },
+    "findings": {
+      "type": "string"
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
   },
-  "required": ["plan_id", "tasks"],
+  "required": [
+    "plan_id",
+    "tasks",
+    "role",
+    "task",
+    "findings",
+    "risks",
+    "next_steps",
+    "sources"
+  ],
   "additionalProperties": false
 }

--- a/dr_rd/schemas/qa_v1.json
+++ b/dr_rd/schemas/qa_v1.json
@@ -2,15 +2,50 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "role": {"type": "string"},
-    "task": {"type": "string"},
-    "findings": {"type": "string"},
-    "risks": {"type": "array", "items": {"type": "string"}},
-    "next_steps": {"type": "array", "items": {"type": "string"}},
-    "sources": {"type": "array", "items": {"type": "string"}},
-    "defects": {"type": "array", "items": {"type": "string"}},
-    "coverage": {"type": "string"}
+    "role": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
+    },
+    "findings": {
+      "type": "string"
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "next_steps": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "defects": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "coverage": {
+      "type": "string"
+    }
   },
-  "required": ["role", "task", "findings", "risks", "next_steps", "sources"],
+  "required": [
+    "role",
+    "task",
+    "findings",
+    "risks",
+    "next_steps",
+    "sources"
+  ],
   "additionalProperties": false
 }

--- a/dr_rd/schemas/qa_v2.json
+++ b/dr_rd/schemas/qa_v2.json
@@ -2,16 +2,56 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "role": {"type": "string"},
-    "task": {"type": "string"},
-    "summary": {"type": "string"},
-    "findings": {"type": "string"},
-    "risks": {"type": "array", "items": {"type": "string"}},
-    "next_steps": {"type": "array", "items": {"type": "string"}},
-    "sources": {"type": "array", "items": {"type": "string"}},
-    "defects": {"type": "array", "items": {"type": "string"}},
-    "coverage": {"type": "string"}
+    "role": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
+    },
+    "summary": {
+      "type": "string"
+    },
+    "findings": {
+      "type": "string"
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "next_steps": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "defects": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "coverage": {
+      "type": "string"
+    }
   },
-  "required": ["role", "task", "summary", "findings", "risks", "next_steps", "sources", "defects", "coverage"],
+  "required": [
+    "role",
+    "task",
+    "summary",
+    "findings",
+    "risks",
+    "next_steps",
+    "sources",
+    "defects",
+    "coverage"
+  ],
   "additionalProperties": false
 }

--- a/dr_rd/schemas/reflection_v1.json
+++ b/dr_rd/schemas/reflection_v1.json
@@ -2,22 +2,57 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "summary": {"type": "string"},
-    "findings": {"type": "string"},
+    "summary": {
+      "type": "string"
+    },
+    "findings": {
+      "type": "string"
+    },
     "sources": {
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "title": {"type": "string"},
-          "url": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
         },
-        "required": ["id", "title"]
+        "required": [
+          "id",
+          "title"
+        ]
       }
     },
-    "next_steps": {"type": "string"}
+    "next_steps": {
+      "type": "string"
+    },
+    "role": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
   },
-  "required": ["summary", "findings", "sources"],
+  "required": [
+    "summary",
+    "findings",
+    "sources",
+    "role",
+    "task",
+    "risks",
+    "next_steps"
+  ],
   "additionalProperties": false
 }

--- a/dr_rd/schemas/regulatory_evidence_v1.json
+++ b/dr_rd/schemas/regulatory_evidence_v1.json
@@ -4,36 +4,122 @@
   "properties": {
     "records": {
       "type": "array",
-      "items": {"$ref": "#/definitions/reg"}
+      "items": {
+        "$ref": "#/definitions/reg"
+      }
+    },
+    "role": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
+    },
+    "findings": {
+      "type": "string"
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "next_steps": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   },
-  "required": ["records"],
+  "required": [
+    "records",
+    "role",
+    "task",
+    "findings",
+    "risks",
+    "next_steps",
+    "sources"
+  ],
   "additionalProperties": false,
   "definitions": {
     "source": {
       "type": "object",
       "properties": {
-        "id": {"type": "string"},
-        "url": {"type": "string"}
+        "id": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
       },
-      "required": ["id", "url"],
+      "required": [
+        "id",
+        "url"
+      ],
       "additionalProperties": false
     },
     "reg": {
       "type": "object",
       "properties": {
-        "authority": {"type": "string"},
-        "agency": {"type": "string"},
-        "docket_id": {"type": ["string", "null"]},
-        "cfr_refs": {"type": "array", "items": {"type": "string"}},
-        "rule_stage": {"type": ["string", "null"]},
-        "effective_date": {"type": ["string", "null"]},
-        "summary": {"type": ["string", "null"]},
-        "url": {"type": "string"},
-        "applicable": {"type": "boolean"},
-        "source": {"$ref": "#/definitions/source"}
+        "authority": {
+          "type": "string"
+        },
+        "agency": {
+          "type": "string"
+        },
+        "docket_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "cfr_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "rule_stage": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "effective_date": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "summary": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url": {
+          "type": "string"
+        },
+        "applicable": {
+          "type": "boolean"
+        },
+        "source": {
+          "$ref": "#/definitions/source"
+        }
       },
-      "required": ["authority", "agency", "summary", "url", "applicable", "source"],
+      "required": [
+        "authority",
+        "agency",
+        "summary",
+        "url",
+        "applicable",
+        "source"
+      ],
       "additionalProperties": false
     }
   }

--- a/dr_rd/schemas/regulatory_specialist_v1.json
+++ b/dr_rd/schemas/regulatory_specialist_v1.json
@@ -2,22 +2,57 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "summary": {"type": "string"},
-    "findings": {"type": "string"},
+    "summary": {
+      "type": "string"
+    },
+    "findings": {
+      "type": "string"
+    },
     "sources": {
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "title": {"type": "string"},
-          "url": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
         },
-        "required": ["id", "title"]
+        "required": [
+          "id",
+          "title"
+        ]
       }
     },
-    "next_steps": {"type": "string"}
+    "next_steps": {
+      "type": "string"
+    },
+    "role": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
   },
-  "required": ["summary", "findings", "sources"],
+  "required": [
+    "summary",
+    "findings",
+    "sources",
+    "role",
+    "task",
+    "risks",
+    "next_steps"
+  ],
   "additionalProperties": false
 }

--- a/dr_rd/schemas/regulatory_v1.json
+++ b/dr_rd/schemas/regulatory_v1.json
@@ -2,22 +2,57 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "summary": {"type": "string"},
-    "findings": {"type": "string"},
+    "summary": {
+      "type": "string"
+    },
+    "findings": {
+      "type": "string"
+    },
     "sources": {
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "title": {"type": "string"},
-          "url": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
         },
-        "required": ["id", "title"]
+        "required": [
+          "id",
+          "title"
+        ]
       }
     },
-    "next_steps": {"type": "string"}
+    "next_steps": {
+      "type": "string"
+    },
+    "role": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
   },
-  "required": ["summary", "findings", "sources"],
+  "required": [
+    "summary",
+    "findings",
+    "sources",
+    "role",
+    "task",
+    "risks",
+    "next_steps"
+  ],
   "additionalProperties": false
 }

--- a/dr_rd/schemas/regulatory_v2.json
+++ b/dr_rd/schemas/regulatory_v2.json
@@ -2,25 +2,57 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "role": {"type": "string"},
-    "task": {"type": "string"},
-    "summary": {"type": "string"},
-    "findings": {"type": "string"},
-    "risks": {"type": "array", "items": {"type": "string"}},
-    "next_steps": {"type": "string"},
+    "role": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
+    },
+    "summary": {
+      "type": "string"
+    },
+    "findings": {
+      "type": "string"
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "next_steps": {
+      "type": "string"
+    },
     "sources": {
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "title": {"type": "string"},
-          "url": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
         },
-        "required": ["id", "title"]
+        "required": [
+          "id",
+          "title"
+        ]
       }
     }
   },
-  "required": ["role", "task", "summary", "findings", "risks", "next_steps", "sources"],
+  "required": [
+    "role",
+    "task",
+    "summary",
+    "findings",
+    "risks",
+    "next_steps",
+    "sources"
+  ],
   "additionalProperties": false
 }

--- a/dr_rd/schemas/research_v1.json
+++ b/dr_rd/schemas/research_v1.json
@@ -8,31 +8,71 @@
       "items": {
         "type": "object",
         "properties": {
-          "claim": {"type": "string"},
-          "evidence": {"type": "string"},
-          "citations": {"type": "array", "items": {"type": "string"}}
+          "claim": {
+            "type": "string"
+          },
+          "evidence": {
+            "type": "string"
+          },
+          "citations": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
         },
-        "required": ["claim", "evidence"],
+        "required": [
+          "claim",
+          "evidence"
+        ],
         "additionalProperties": false
       }
     },
-    "gaps": {"type": "string"},
-    "risks": {"type": "string"},
-    "next_steps": {"type": "string"},
+    "gaps": {
+      "type": "string"
+    },
+    "risks": {
+      "type": "string"
+    },
+    "next_steps": {
+      "type": "string"
+    },
     "sources": {
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "title": {"type": "string"},
-          "url": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
         },
-        "required": ["id", "title"],
+        "required": [
+          "id",
+          "title"
+        ],
         "additionalProperties": false
       }
+    },
+    "role": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
     }
   },
-  "required": ["findings", "sources"],
+  "required": [
+    "findings",
+    "sources",
+    "role",
+    "task",
+    "risks",
+    "next_steps"
+  ],
   "additionalProperties": false
 }

--- a/dr_rd/schemas/research_v2.json
+++ b/dr_rd/schemas/research_v2.json
@@ -3,39 +3,80 @@
   "title": "Research V2",
   "type": "object",
   "properties": {
-    "role": {"type": "string"},
-    "task": {"type": "string"},
-    "summary": {"type": "string"},
+    "role": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
+    },
+    "summary": {
+      "type": "string"
+    },
     "findings": {
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
-          "claim": {"type": "string"},
-          "evidence": {"type": "string"},
-          "citations": {"type": "array", "items": {"type": "string"}}
+          "claim": {
+            "type": "string"
+          },
+          "evidence": {
+            "type": "string"
+          },
+          "citations": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
         },
-        "required": ["claim", "evidence"],
+        "required": [
+          "claim",
+          "evidence"
+        ],
         "additionalProperties": false
       }
     },
-    "gaps": {"type": "string"},
-    "risks": {"type": "string"},
-    "next_steps": {"type": "string"},
+    "gaps": {
+      "type": "string"
+    },
+    "risks": {
+      "type": "string"
+    },
+    "next_steps": {
+      "type": "string"
+    },
     "sources": {
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "title": {"type": "string"},
-          "url": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
         },
-        "required": ["id", "title"],
+        "required": [
+          "id",
+          "title"
+        ],
         "additionalProperties": false
       }
     }
   },
-  "required": ["role", "task", "summary", "findings", "risks", "next_steps", "sources"],
+  "required": [
+    "role",
+    "task",
+    "summary",
+    "findings",
+    "risks",
+    "next_steps",
+    "sources"
+  ],
   "additionalProperties": false
 }

--- a/dr_rd/schemas/simulation_v1.json
+++ b/dr_rd/schemas/simulation_v1.json
@@ -2,23 +2,84 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "role": {"type": "string"},
-    "task": {"type": "string"},
-    "domain": {"type": "string"},
-    "inputs": {"type": "object"},
-    "findings": {"type": "array", "items": {"type": "string"}},
-    "metrics": {"type": "object"},
-    "artifacts": {"type": "array", "items": {"type": "string"}},
-    "sources": {"type": "array", "items": {"type": "string"}},
+    "role": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
+    },
+    "domain": {
+      "type": "string"
+    },
+    "inputs": {
+      "type": "object"
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "metrics": {
+      "type": "object"
+    },
+    "artifacts": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "cost_summary": {
       "type": "object",
       "properties": {
-        "token_est": {"type": "number"},
-        "tool_runtime_ms": {"type": "number"}
+        "token_est": {
+          "type": "number"
+        },
+        "tool_runtime_ms": {
+          "type": "number"
+        }
       },
-      "required": ["token_est", "tool_runtime_ms"]
+      "required": [
+        "token_est",
+        "tool_runtime_ms"
+      ]
     },
-    "spans": {"type": "array", "items": {"type": "object"}}
+    "spans": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "next_steps": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
   },
-  "required": ["role", "task", "domain", "inputs", "findings", "metrics", "sources", "cost_summary", "spans"]
+  "required": [
+    "role",
+    "task",
+    "domain",
+    "inputs",
+    "findings",
+    "metrics",
+    "sources",
+    "cost_summary",
+    "spans",
+    "risks",
+    "next_steps"
+  ]
 }

--- a/dr_rd/schemas/synthesizer_agent.json
+++ b/dr_rd/schemas/synthesizer_agent.json
@@ -3,13 +3,65 @@
   "title": "Synthesizer Agent",
   "type": "object",
   "properties": {
-    "summary": {"type": "string"},
-    "key_points": {"type": "array", "items": {"type": "string"}},
-    "contradictions": {"type": "array", "items": {"type": "string"}},
-    "confidence": {"type": "number"},
-    "sources": {"type": "array", "items": {"type": "string"}},
-    "citations_json": {"type": "string"}
+    "summary": {
+      "type": "string"
+    },
+    "key_points": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "contradictions": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "confidence": {
+      "type": "number"
+    },
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "citations_json": {
+      "type": "string"
+    },
+    "role": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
+    },
+    "findings": {
+      "type": "string"
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "next_steps": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
   },
-  "required": ["summary", "key_points", "citations_json"],
+  "required": [
+    "summary",
+    "key_points",
+    "citations_json",
+    "role",
+    "task",
+    "findings",
+    "risks",
+    "next_steps",
+    "sources"
+  ],
   "additionalProperties": false
 }

--- a/dr_rd/schemas/synthesizer_v1.json
+++ b/dr_rd/schemas/synthesizer_v1.json
@@ -3,12 +3,61 @@
   "title": "Synthesizer V1",
   "type": "object",
   "properties": {
-    "summary": {"type": "string"},
-    "key_points": {"type": "array", "items": {"type": "string"}},
-    "contradictions": {"type": "array", "items": {"type": "string"}},
-    "confidence": {"type": "number"},
-    "sources": {"type": "array", "items": {"type": "string"}}
+    "summary": {
+      "type": "string"
+    },
+    "key_points": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "contradictions": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "confidence": {
+      "type": "number"
+    },
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "role": {
+      "type": "string"
+    },
+    "task": {
+      "type": "string"
+    },
+    "findings": {
+      "type": "string"
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "next_steps": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
   },
-  "required": ["summary", "key_points"],
+  "required": [
+    "summary",
+    "key_points",
+    "role",
+    "task",
+    "findings",
+    "risks",
+    "next_steps",
+    "sources"
+  ],
   "additionalProperties": false
 }

--- a/tests/test_open_issues_report.py
+++ b/tests/test_open_issues_report.py
@@ -1,13 +1,32 @@
 import json
+
 import streamlit as st
+
 from core.orchestrator import compose_final_proposal
+
 
 def test_open_issues_section_in_report():
     st.session_state.clear()
-    valid = {"role": "CTO", "task": "t", "findings": "x", "risks": [], "next_steps": [], "sources": []}
+    valid = {
+        "role": "CTO",
+        "task": "t",
+        "findings": "x",
+        "risks": [],
+        "next_steps": [],
+        "sources": [],
+    }
     st.session_state["answers_raw"] = {"CTO": [json.dumps(valid)]}
-    placeholder = {"role": "CTO", "task": "t", "findings": "TODO", "risks": "TODO", "next_steps": "TODO", "sources": []}
-    st.session_state["open_issues"] = [{"task_id": "T1", "role": "CTO", "result": placeholder, "title": "t"}]
+    placeholder = {
+        "role": "CTO",
+        "task": "t",
+        "findings": "Not determined",
+        "risks": "Not determined",
+        "next_steps": "Not determined",
+        "sources": [],
+    }
+    st.session_state["open_issues"] = [
+        {"task_id": "T1", "role": "CTO", "result": placeholder, "title": "t"}
+    ]
     report = compose_final_proposal("idea", {"CTO": json.dumps(valid)})
     assert "## Open Issues" in report
     assert "T1" in report

--- a/tests/test_output_artifacts.py
+++ b/tests/test_output_artifacts.py
@@ -1,0 +1,43 @@
+import json
+from collections import deque
+
+import config.feature_flags as ff
+from core import orchestrator
+
+
+def test_artifact_written_for_invalid_output(monkeypatch):
+    monkeypatch.setattr(ff, "PARALLEL_EXEC_ENABLED", False)
+
+    class DummyAgent:
+        def __init__(self, model):
+            self.model = model
+
+    monkeypatch.setattr(
+        orchestrator,
+        "route_task",
+        lambda t, ui_model=None: (t["role"], DummyAgent, "m", t),
+    )
+    monkeypatch.setattr(orchestrator, "pseudonymize_for_model", lambda x: (x, {}))
+    monkeypatch.setattr(orchestrator, "select_model", lambda purpose, agent_name=None: "m")
+    monkeypatch.setattr("core.evaluation.self_check._load_schema", lambda role: None)
+
+    outputs = deque(["not json", "not json"])  # force placeholder
+
+    def fake_invoke(agent, task, model=None, meta=None, run_id=None):
+        return outputs.popleft()
+
+    monkeypatch.setattr(orchestrator, "invoke_agent_safely", fake_invoke)
+
+    run_id = "artifact_test"
+    tasks = [{"role": "Research Scientist", "title": "T", "description": "d"}]
+    orchestrator.execute_plan("idea", tasks, agents={}, run_id=run_id)
+
+    from utils.paths import run_root
+
+    path = run_root(run_id) / "T01_output.json"
+    assert path.exists()
+    data = json.loads(path.read_text())
+    assert (
+        data.get("error") == "Agent failed to produce output"
+        or data.get("findings") == "Not determined"
+    )

--- a/tests/test_self_check_escalate.py
+++ b/tests/test_self_check_escalate.py
@@ -1,10 +1,13 @@
 from core.evaluation.self_check import validate_and_retry
 
+
 def test_self_check_escalates_and_places_placeholder():
     def retry(_rem):
         return "{}"  # still invalid
+
     def escalate(_rem):
         return "{}"  # still invalid
+
     result, meta = validate_and_retry(
         "Dynamic Specialist",
         {"id": "T1", "title": "t"},
@@ -13,4 +16,4 @@ def test_self_check_escalates_and_places_placeholder():
         escalate_fn=escalate,
     )
     assert meta.get("escalated") and not meta.get("valid_json")
-    assert result["findings"] == "TODO"
+    assert result["findings"] == "Not determined"

--- a/utils/json_safety.py
+++ b/utils/json_safety.py
@@ -1,26 +1,48 @@
-import json, re, logging
+import json
+import logging
+import re
+
 log = logging.getLogger(__name__)
 
-CODE_FENCE_RE = re.compile(r"^```(?:json)?\s*|\s*```$", re.IGNORECASE|re.MULTILINE)
+CODE_FENCE_RE = re.compile(r"^```(?:json)?\s*|\s*```$", re.IGNORECASE | re.MULTILINE)
+UNQUOTED_KEY_RE = re.compile(r"([,{]\s*)([A-Za-z0-9_]+)\s*:")
+MISSING_VALUE_RE = re.compile(r":\s*(?=[,}])")
+TRAILING_COMMA_RE = re.compile(r",(\s*[}\]])")
+
 
 def strip_fences(txt: str) -> str:
     return re.sub(CODE_FENCE_RE, "", txt or "").strip()
 
+
 def extract_braced(txt: str) -> str:
     # Take largest {...} block to avoid pre/post chatter
-    s = txt.find("{"); e = txt.rfind("}")
-    return txt[s:e+1] if s != -1 and e != -1 and e > s else txt
+    s = txt.find("{")
+    e = txt.rfind("}")
+    return txt[s : e + 1] if s != -1 and e != -1 and e > s else txt
+
 
 def light_sanitize(txt: str) -> str:
     # Remove trailing commas before } or ]
     txt = re.sub(r",\s*([}\]])", r"\1", txt)
     # Replace smart quotes
-    txt = txt.replace("“","\"").replace("”","\"").replace("’","'")
+    txt = txt.replace("“", '"').replace("”", '"').replace("’", "'")
     return txt
+
+
+def auto_repair_json(txt: str) -> str:
+    """Attempt lightweight structural fixes for common JSON issues."""
+    if not isinstance(txt, str):
+        return txt
+    txt = TRAILING_COMMA_RE.sub(r"\1", txt)
+    txt = UNQUOTED_KEY_RE.sub(lambda m: f'{m.group(1)}"{m.group(2)}":', txt)
+    txt = MISSING_VALUE_RE.sub(": null", txt)
+    return txt
+
 
 def parse_json_loose(raw: str):
     """Attempt multiple strategies to coerce LLM text into JSON."""
-    if raw is None: raise ValueError("No planner text to parse")
+    if raw is None:
+        raise ValueError("No planner text to parse")
     candidates = []
     candidates.append(strip_fences(raw))
     candidates.append(extract_braced(candidates[0]))
@@ -31,6 +53,12 @@ def parse_json_loose(raw: str):
             return json.loads(c)
         except Exception as e:
             last_err = e
+            # Try auto-repair on the candidate before moving on
+            try:
+                return json.loads(auto_repair_json(c))
+            except Exception as e2:  # pragma: no cover - best effort
+                last_err = e2
+                continue
     log.warning("Planner JSON repair engaged. head=%r", (raw or "")[:120])
     # Final recovery: find first '{'..matching '}' chunk-by-chunk
     candidate = extract_braced(raw)


### PR DESCRIPTION
## Summary
- require full JSON contract across agent schemas and validate missing keys
- repair and retry malformed agent JSON while replacing `TODO` placeholders
- persist per-task outputs for traceability and surface placeholder issues

## Testing
- `pre-commit run --files core/evaluation/self_check.py core/orchestrator.py utils/json_safety.py tests/test_open_issues_report.py tests/test_orchestrator.py tests/test_retry_ladder.py tests/test_self_check.py tests/test_self_check_escalate.py tests/test_output_artifacts.py dr_rd/schemas/chief_scientist_v1.json dr_rd/schemas/compliance_matrix_v1.json dr_rd/schemas/cto_v1.json dr_rd/schemas/cto_v2.json dr_rd/schemas/dynamic_agent_v1.json dr_rd/schemas/finance_v1.json dr_rd/schemas/finance_v2.json dr_rd/schemas/generic_v1.json dr_rd/schemas/generic_v2.json dr_rd/schemas/hrm_v1.json dr_rd/schemas/hrm_v2.json dr_rd/schemas/ip_analyst_v1.json dr_rd/schemas/ip_analyst_v2.json dr_rd/schemas/marketing_v1.json dr_rd/schemas/marketing_v2.json dr_rd/schemas/materials_engineer_v1.json dr_rd/schemas/materials_engineer_v2.json dr_rd/schemas/materials_v1.json dr_rd/schemas/mechanical_systems_lead_v1.json dr_rd/schemas/patent_evidence_v1.json dr_rd/schemas/planner_v1.json dr_rd/schemas/qa_v1.json dr_rd/schemas/qa_v2.json dr_rd/schemas/reflection_v1.json dr_rd/schemas/regulatory_evidence_v1.json dr_rd/schemas/regulatory_specialist_v1.json dr_rd/schemas/regulatory_v1.json dr_rd/schemas/regulatory_v2.json dr_rd/schemas/research_v1.json dr_rd/schemas/research_v2.json dr_rd/schemas/simulation_v1.json dr_rd/schemas/synthesizer_agent.json dr_rd/schemas/synthesizer_v1.json`
- `pytest tests/test_self_check.py tests/test_self_check_escalate.py tests/test_open_issues_report.py tests/test_orchestrator.py tests/test_retry_ladder.py tests/test_output_artifacts.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb7f2122c0832c9da3a1898fc6ea84