### PR TITLE
feat: handle gaps and unresolved issues in final report

### DIFF
--- a/core/final/composer.py
+++ b/core/final/composer.py
@@ -17,6 +17,7 @@ REQUIRED_SECTIONS = [
     "Market & GTM",
     "Cost Overview",
     "Next Steps",
+    "Gaps and Unresolved Issues",
 ]
 
 def _ensure_sections(text: str) -> str:

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -78,7 +78,7 @@ Every model call returns token usage and cost data from the provider. Per-step t
 Secrets are stored in Streamlit's encrypted settings or local `.env` files. Only the provided API keys are sent to external services. Trace exports redact sensitive fields based on repository policies.
 
 ## FAQ
-**What are Open Issues?** Tasks that failed or returned placeholders. They appear in the final report under an "Open Issues" section so gaps are explicit.
+**What are Gaps and Unresolved Issues?** Tasks that failed or returned placeholders. They appear in the final report under a "Gaps and Unresolved Issues" section so gaps are explicit.
 
 **Can I rerun a session?** Use the **Retry run** button shown on error banners or rerun with the same idea.
 

--- a/dr_rd/prompting/prompt_registry.py
+++ b/dr_rd/prompting/prompt_registry.py
@@ -132,6 +132,7 @@ registry.register(
             "- ## IP & Prior Art\n"
             "- ## Market & GTM\n"
             "- ## Cost Overview\n"
+            "- ## Gaps and Unresolved Issues\n"
             "- ## Next Steps"
         ),
         io_schema_ref="dr_rd/schemas/synthesizer_agent.json",

--- a/tests/test_open_issues_report.py
+++ b/tests/test_open_issues_report.py
@@ -28,5 +28,5 @@ def test_open_issues_section_in_report():
         {"task_id": "T1", "role": "CTO", "result": placeholder, "title": "t"}
     ]
     report = compose_final_proposal("idea", {"CTO": json.dumps(valid)})
-    assert "## Open Issues" in report
-    assert "T1" in report
+    assert "## Gaps and Unresolved Issues" in report
+    assert "CTO analysis could not be completed." in report

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -116,7 +116,9 @@ def test_open_issues_in_prompt(mock_complete, monkeypatch):
     monkeypatch.setattr(orchestrator, "pseudonymize_for_model", lambda x: (x, {}))
     compose_final_proposal("idea", {})
     _, prompt = mock_complete.call_args[0]
-    assert "Open Issues" in prompt
+    assert "### Research" in prompt
+    assert "[No data provided]" in prompt
+    assert "Open Issues" not in prompt
 
 
 @patch("core.orchestrator.complete")
@@ -140,4 +142,4 @@ def test_final_report_fallback(mock_complete):
     st.session_state["alias_maps"] = {}
     out = compose_final_proposal("idea", {})
     assert out.strip() != ""
-    assert "Open Issues" in out
+    assert "## Gaps and Unresolved Issues" in out


### PR DESCRIPTION
## Summary
- ensure synthesizer prompt includes 'Gaps and Unresolved Issues' section
- require new section in final composer bundler
- add placeholder handling and human-readable gaps summary in final report generation

## Testing
- `pytest -q` *(fails: No module named 'pptx', No module named 'fastapi')*
- `pytest tests/test_open_issues_report.py tests/test_orchestrator.py::test_open_issues_in_prompt tests/test_orchestrator.py::test_final_report_fallback -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb830e6400832c8d77e17850c7639d