### PR TITLE
feat: reinforce prompts and artifact pipeline

### DIFF
--- a/docs/PROMPT_STANDARDS.md
+++ b/docs/PROMPT_STANDARDS.md
@@ -25,6 +25,9 @@ All prompts include safety instructions:
 
 When retrieval is enabled, prompts also require inline numbered citations and a final `sources` list.
 
+## JSON Key Conventions
+System prompts enumerate a **Required JSON keys** section. All listed keys must appear in the model output; use empty strings or arrays or the string "Not determined" when data is unavailable. Agents may not add additional keys. Roles with frequent schema errors embed an example JSON object in the user prompt, and user templates clarify that list fields (e.g. `properties`, `tradeoffs`) must be arrays and that fields like `risks` and `next_steps` cannot be blank. The Synthesizer includes a "## Key Results" section after the Executive Summary to highlight the most important findings.
+
 ## Using the PromptFactory
 Agents request prompts through `PromptFactory.build_prompt` providing:
 `{"role", "task", "inputs", "io_schema_ref", "retrieval_policy", ...}`.

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-09-05T04:50:46.382103Z from commit 22d68a9_
+_Last generated at 2025-09-06T13:05:25.506399Z from commit bb08475_

--- a/dr_rd/prompting/prompt_registry.py
+++ b/dr_rd/prompting/prompt_registry.py
@@ -80,7 +80,7 @@ registry = PromptRegistry()
 registry.register(
     PromptTemplate(
         id="planner",
-        version="v1",
+        version="v2",
         role="Planner",
         task_key=None,
         system=(
@@ -94,14 +94,17 @@ registry.register(
             "should default to 'Dynamic Specialist'. Prefer ids "
             '"T01","T02",... If the user supplies ids, convert to that '
             "format. Produce at least six tasks spanning design/architecture, "
-            "materials, regulatory/IP, finance, marketing, and QA/testing. "
-            'If required information is missing, return {"error":"MISSING_INFO",'
-            '"needs":[...]} instead of empty fields.'
+            "materials, regulatory/IP, finance, marketing, and QA/testing.\n"
+            "Required JSON keys:\n"
+            "- tasks\n"
+            "All listed keys must appear (use empty strings/arrays or 'Not determined' when no data is available) and no other keys may be added.\n"
+            "Example:\n"
+            '{"tasks": [{"id": "T01", "title": "Define architecture", "summary": "...", "description": "...", "role": "CTO"}]}\n'
+            'If required information is missing, return {"error":"MISSING_INFO","needs":[...]} instead of empty fields.'
         ),
         user_template=(
             "Project idea: {idea}{constraints_section}{risk_section}\n\n"
-            "Follow the planner schema exactly and return only the JSON object. "
-            "No extra text."
+            "Follow the planner schema exactly and return only the JSON object. No extra text."
         ),
         io_schema_ref="dr_rd/schemas/planner_v1.json",
         retrieval_policy=RetrievalPolicy.LIGHT,
@@ -111,7 +114,7 @@ registry.register(
 registry.register(
     PromptTemplate(
         id="synthesizer",
-        version="v1",
+        version="v2",
         role="Synthesizer",
         task_key=None,
         system="You are a multi-disciplinary R&D lead.",
@@ -124,6 +127,7 @@ registry.register(
             "project concept, researched data, and a build guide. Use clear "
             "Markdown with these sections:\n\n"
             "- ## Executive Summary\n"
+            "- ## Key Results\n"
             "- ## Problem & Value\n"
             "- ## Research Findings\n"
             "- ## Risks & Unknowns\n"
@@ -133,7 +137,8 @@ registry.register(
             "- ## Market & GTM\n"
             "- ## Cost Overview\n"
             "- ## Gaps and Unresolved Issues\n"
-            "- ## Next Steps"
+            "- ## Next Steps\n\n"
+            "Summarize the most important findings in 'Key Results'."
         ),
         io_schema_ref="dr_rd/schemas/synthesizer_agent.json",
         retrieval_policy=RetrievalPolicy.NONE,
@@ -157,6 +162,7 @@ registry.register(
             "- sources\n"
             "- role\n"
             "- task\n\n"
+            "All listed keys must appear (use empty strings/arrays or 'Not determined' when no data is available) and no other keys may be added.\n"
             "Example:\n"
             '{"role": "CTO", "task": "Assess architecture", "summary": "...", '
             '"findings": "...", "risks": ["..."], "next_steps": ["..."], "sources": ["..."]}\n'
@@ -189,6 +195,7 @@ registry.register(
             "- sources\n"
             "- role\n"
             "- task\n\n"
+            "All listed keys must appear (use empty strings/arrays or 'Not determined' when no data is available) and no other keys may be added.\n"
             "Example:\n"
             '{"role": "Regulatory", "task": "Check standards", "summary": "...", '
             '"findings": "...", "risks": ["..."], "next_steps": ["..."], "sources": ["..."]}\n'
@@ -226,6 +233,7 @@ registry.register(
             "- npv\n"
             "- simulations\n"
             "- assumptions\n\n"
+            "All listed keys must appear (use empty strings/arrays or 'Not determined' when no data is available) and no other keys may be added.\n"
             "Example:\n"
             '{"role": "Finance", "task": "Estimate costs", "summary": "...", '
             '"findings": "...", "risks": ["..."], "next_steps": ["..."], "sources": ["..."], '
@@ -260,6 +268,7 @@ registry.register(
             "- sources\n"
             "- role\n"
             "- task\n\n"
+            "All listed keys must appear (use empty strings/arrays or 'Not determined' when no data is available) and no other keys may be added.\n"
             "Example:\n"
             '{"role": "Marketing Analyst", "task": "Assess market", "summary": "...", '
             '"findings": "...", "risks": ["..."], "next_steps": ["..."], "sources": ["..."]}\n'
@@ -291,6 +300,7 @@ registry.register(
             "- sources\n"
             "- role\n"
             "- task\n\n"
+            "All listed keys must appear (use empty strings/arrays or 'Not determined' when no data is available) and no other keys may be added.\n"
             "Example:\n"
             '{"role": "IP Analyst", "task": "Review patents", "summary": "...", '
             '"findings": "...", "risks": ["..."], "next_steps": ["..."], "sources": ["..."]}\n'
@@ -322,6 +332,7 @@ registry.register(
             "- sources\n"
             "- role\n"
             "- task\n\n"
+            "All listed keys must appear (use empty strings/arrays or 'Not determined' when no data is available) and no other keys may be added.\n"
             "Example:\n"
             '{"role": "Patent", "task": "Assess claims", "summary": "...", '
             '"findings": "...", "risks": ["..."], "next_steps": ["..."], "sources": ["..."]}\n'
@@ -354,6 +365,7 @@ registry.register(
             "- sources\n"
             "- role\n"
             "- task\n\n"
+            "All listed keys must appear (use empty strings/arrays or 'Not determined' when no data is available) and no other keys may be added.\n"
             "Example:\n"
             '{"role": "Research Scientist", "task": "Study phenomenon", "summary": "...", '
             '"findings": [{"claim": "...", "evidence": "..."}], "gaps": "...", '
@@ -362,7 +374,9 @@ registry.register(
         ),
         user_template=(
             "Idea: {idea}\nTask: {task}\nProvide detailed scientific analysis "
-            "with findings, risks, next_steps, and sources in JSON."
+            "with findings, gaps, risks, next_steps, and sources in JSON. Lists such as findings must be arrays and fields like risks and next_steps cannot be blank.\n"
+            "Example:\n"
+            '{"role": "Research Scientist", "task": "Study phenomenon", "summary": "...", "findings": [{"claim": "...", "evidence": "..."}], "gaps": "...", "risks": ["..."], "next_steps": ["..."], "sources": [{"id": "1", "title": "..."}]}'
         ),
         io_schema_ref="dr_rd/schemas/research_v2.json",
         retrieval_policy=RetrievalPolicy.AGGRESSIVE,
@@ -386,6 +400,7 @@ registry.register(
             "- sources\n"
             "- role\n"
             "- task\n\n"
+            "All listed keys must appear (use empty strings/arrays or 'Not determined' when no data is available) and no other keys may be added.\n"
             "Example:\n"
             '{"role": "HRM", "task": "Plan team", "summary": "...", "findings": "...", '
             '"risks": ["..."], "next_steps": ["..."], "sources": ["..."]}\n'
@@ -419,6 +434,7 @@ registry.register(
             "- sources\n"
             "- role\n"
             "- task\n\n"
+            "All listed keys must appear (use empty strings/arrays or 'Not determined' when no data is available) and no other keys may be added.\n"
             "Example:\n"
             '{"role": "Materials Engineer", "task": "Select materials", "summary": "...", '
             '"findings": "...", "properties": [], "tradeoffs": ["..."], '
@@ -428,7 +444,9 @@ registry.register(
         user_template=(
             "Idea: {idea}\nTask: {task}\nProvide material selection and "
             "feasibility analysis, including summary, properties, tradeoffs, "
-            "risks, next_steps, and sources in JSON."
+            "risks, next_steps, and sources in JSON. Lists such as properties and tradeoffs must be arrays and fields like risks and next_steps cannot be blank.\n"
+            "Example:\n"
+            '{"role": "Materials Engineer", "task": "Select materials", "summary": "...", "findings": "...", "properties": [], "tradeoffs": [], "risks": ["..."], "next_steps": ["..."], "sources": ["..."]}'
         ),
         io_schema_ref="dr_rd/schemas/materials_engineer_v2.json",
         retrieval_policy=RetrievalPolicy.LIGHT,
@@ -452,13 +470,16 @@ registry.register(
             "- sources\n"
             "- role\n"
             "- task\n\n"
+            "All listed keys must appear (use empty strings/arrays or 'Not determined' when no data is available) and no other keys may be added.\n"
             "Example:\n"
             '{"role": "Dynamic Specialist", "task": "General analysis", "summary": "...", '
             '"findings": "...", "risks": ["..."], "next_steps": ["..."], "sources": ["..."]}\n'
             "Only output JSON, no extra explanation or prose outside JSON."
         ),
         user_template=(
-            "Idea: {idea}\nTask: {task}\nProvide a concise analysis and " "recommendations."
+            "Idea: {idea}\nTask: {task}\nProvide a concise analysis and recommendations. Lists must be arrays where appropriate and fields like risks and next_steps cannot be blank.\n"
+            "Example:\n"
+            '{"role": "Dynamic Specialist", "task": "General analysis", "summary": "...", "findings": "...", "risks": ["..."], "next_steps": ["..."], "sources": ["..."]}'
         ),
         io_schema_ref="dr_rd/schemas/generic_v2.json",
         retrieval_policy=RetrievalPolicy.LIGHT,
@@ -485,6 +506,7 @@ registry.register(
             "- sources\n"
             "- role\n"
             "- task\n\n"
+            "All listed keys must appear (use empty strings/arrays or 'Not determined' when no data is available) and no other keys may be added.\n"
             "Example:\n"
             '{"role": "QA", "task": "Test review", "summary": "...", "findings": "...", '
             '"defects": ["..."], "coverage": "...", "risks": ["..."], "next_steps": ["..."], "sources": ["..."]}\n'

--- a/orchestrators/executor.py
+++ b/orchestrators/executor.py
@@ -16,26 +16,102 @@ def _render(template: str, context: Dict[str, Any]) -> str:
         return template.format(**context)
 
 
-DEFAULT_BUILD_SPEC = "# Build Spec\n\nGenerated for: {idea}\n"
-DEFAULT_WORK_PLAN = "# Work Plan\n\nTasks:\n{tasks}\n"
-
-
 def execute(plan: List[Dict[str, Any]], ctx: Dict[str, Any]) -> Dict[str, Path]:
     """Write ``build_spec.md`` and ``work_plan.md`` artifacts for a run."""
     run_id = ctx.get("run_id", "latest")
     idea = ctx.get("idea", "")
+    findings = ctx.get("role_to_findings", {})
     if not plan:
-        # Planner already reported an error; emit minimal placeholder so downstream
-        # consumers do not fail when reading the artifact.
         placeholder = "# Work Plan\n\nNo plan could be generated.\n"
         path_plan = write_text(run_id, "work_plan", "md", placeholder)
         return {"work_plan": path_plan}
 
-    tasks_md = "\n".join(f"- {t.get('title','')}" for t in plan)
-    context = {"idea": idea, "tasks": tasks_md}
+    def _arch_details() -> str:
+        parts: list[str] = []
+        for r in ("CTO", "Dynamic Specialist"):
+            f = findings.get(r, {}).get("findings")
+            if f:
+                parts.append(str(f))
+        return "\n".join(parts)
 
-    build_spec = _render(DEFAULT_BUILD_SPEC, context)
-    work_plan = _render(DEFAULT_WORK_PLAN, context)
+    def _materials_details() -> str:
+        payload = findings.get("Materials Engineer", {})
+        props = payload.get("properties") or []
+        trade = payload.get("tradeoffs") or []
+        lines: list[str] = []
+        if props:
+            lines.append("Properties:\n" + "\n".join(f"- {p}" for p in props))
+        if trade:
+            lines.append("Tradeoffs:\n" + "\n".join(f"- {t}" for t in trade))
+        return "\n\n".join(lines)
+
+    def _technical_details() -> str:
+        parts: list[str] = []
+        for r in ("Research Scientist", "Simulation"):
+            f = findings.get(r, {}).get("findings")
+            if f:
+                parts.append(str(f))
+        return "\n".join(parts)
+
+    def _risks_summary() -> str:
+        risks: list[str] = []
+        for payload in findings.values():
+            r = payload.get("risks")
+            if isinstance(r, list):
+                risks.extend(r)
+            n = payload.get("next_steps")
+            if isinstance(n, list):
+                risks.extend(n)
+        return "\n".join(f"- {r}" for r in risks)
+
+    build_tpl = Path("templates/build_spec.jinja").read_text(encoding="utf-8")
+    build_spec = _render(
+        build_tpl,
+        {
+            "architecture_details": _arch_details(),
+            "materials_details": _materials_details(),
+            "technical_details": _technical_details(),
+            "risks_summary": _risks_summary(),
+        },
+    )
+
+    phase_roles = {
+        "Design & Research": [
+            "CTO",
+            "Research Scientist",
+            "Materials Engineer",
+            "Simulation",
+            "Dynamic Specialist",
+        ],
+        "Business & Compliance": [
+            "Finance",
+            "Marketing Analyst",
+            "IP Analyst",
+            "Regulatory",
+            "HRM",
+        ],
+        "Integration & Testing": ["QA"],
+    }
+    phases: Dict[str, list[dict]] = {k: [] for k in phase_roles}
+    phases.setdefault("Other", [])
+    for t in plan:
+        entry = {
+            "id": t.get("id"),
+            "role": t.get("role"),
+            "title": t.get("title"),
+            "summary": t.get("summary") or t.get("description", ""),
+        }
+        placed = False
+        for phase, roles in phase_roles.items():
+            if t.get("role") in roles:
+                phases[phase].append(entry)
+                placed = True
+                break
+        if not placed:
+            phases["Other"].append(entry)
+
+    work_tpl = Path("templates/work_plan.jinja").read_text(encoding="utf-8")
+    work_plan = _render(work_tpl, {"phases": {k: v for k, v in phases.items() if v}})
 
     path_spec = write_text(run_id, "build_spec", "md", build_spec)
     path_plan = write_text(run_id, "work_plan", "md", work_plan)

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-09-05T04:50:46.382103Z'
-git_sha: 22d68a989a00aa72aa9bc2364a3cbd83c1262bed
+generated_at: '2025-09-06T13:05:25.506399Z'
+git_sha: bb084751413e229b01edd2c1fce50cf3919ac65b
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -180,13 +180,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/qa_router.py
   role: Orchestrator
   responsibilities: []
@@ -201,7 +194,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/spec_builder.py
+- path: orchestrators/plan_utils.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/app_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -215,15 +215,8 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/plan_utils.py
+- path: orchestrators/spec_builder.py
   role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: core/summarization/schemas.py
-  role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
@@ -236,7 +229,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/__init__.py
+- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -244,6 +237,13 @@ modules:
   invoked_by: []
   invokes: []
 - path: core/summarization/integrator.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/templates/build_spec.jinja
+++ b/templates/build_spec.jinja
@@ -1,0 +1,13 @@
+# Build Spec
+
+## Architecture & Design
+{{ architecture_details }}
+
+## Materials & Components
+{{ materials_details }}
+
+## Technical Findings
+{{ technical_details }}
+
+## Risks & Mitigations
+{{ risks_summary }}

--- a/templates/work_plan.jinja
+++ b/templates/work_plan.jinja
@@ -1,0 +1,8 @@
+# Work Plan
+
+{% for phase, tasks in phases.items() %}
+**{{ phase }}**
+{% for t in tasks %}
+- *{{ t.id }} ({{ t.role }})* – **{{ t.title }}:** {{ t.summary }}
+{% endfor %}
+{% endfor %}

--- a/tests/test_self_check_escalate.py
+++ b/tests/test_self_check_escalate.py
@@ -1,11 +1,8 @@
 from core.evaluation.self_check import validate_and_retry
 
 
-def test_self_check_escalates_and_places_placeholder():
+def test_self_check_places_placeholder_after_retry():
     def retry(_rem):
-        return "{}"  # still invalid
-
-    def escalate(_rem):
         return "{}"  # still invalid
 
     result, meta = validate_and_retry(
@@ -13,7 +10,6 @@ def test_self_check_escalates_and_places_placeholder():
         {"id": "T1", "title": "t"},
         "{}",
         retry,
-        escalate_fn=escalate,
     )
-    assert meta.get("escalated") and not meta.get("valid_json")
+    assert not meta.get("valid_json")
     assert result["findings"] == "Not determined"


### PR DESCRIPTION
## Summary
- tighten agent prompts with explicit required JSON keys and embedded examples for error-prone roles
- add Key Results section to Synthesizer and template-driven build_spec/work_plan generation
- introduce per-role redaction codenames and single-pass JSON validation with fallback placeholders

## Testing
- `python scripts/generate_repo_map.py`
- `pytest -q` *(fails: tests/gtm/test_generate_deck.py, tests/integrations/test_jira_bridge.py, tests/integrations/test_slack_bridge.py, tests/integrations/test_teams_bridge.py, tests/utils/test_redaction.py)*


------
https://chatgpt.com/codex/tasks/task_e_68bc2fb284ec832c94d0eb8351f73d5e