### PR TITLE
Fix planner prompt meta shadowing and deterministic error serialization

### DIFF
--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -56,4 +56,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-09-06T17:06:34.968247Z from commit 0fcaa0f_
+_Last generated at 2025-09-06T20:52:49.611117Z from commit 8a134a1_

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-09-06T17:06:34.968247Z'
-git_sha: 0fcaa0f1f88f41befb1cac02e0e5055758285045
+generated_at: '2025-09-06T20:52:49.611117Z'
+git_sha: 8a134a1e74d1929826ed5a3d7373044a1de6a2d3
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -180,27 +180,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/plan_utils.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/app_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/executor.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
@@ -215,7 +194,28 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
+- path: orchestrators/app_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
 - path: orchestrators/qa_router.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/plan_utils.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/executor.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -229,14 +229,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/__init__.py
+- path: core/summarization/integrator.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_errors_json_serialization.py
+++ b/tests/test_errors_json_serialization.py
@@ -1,0 +1,26 @@
+import json
+
+from utils.errors import SafeError, as_json
+
+
+def test_as_json_serializes_sets_deterministically():
+    err = SafeError(
+        kind="test",
+        user_message="u",
+        tech_message="t",
+        traceback=None,
+        support_id="id",
+        context={
+            "simple": {3, 1, 2},
+            "nested": {"inner": {5, 4}},
+            "list": [{2, 1}],
+            "tuple": ({3, 1}, {4, 2}),
+        },
+    )
+    data = json.loads(as_json(err))
+    ctx = data["context"]
+    assert ctx["simple"] == [1, 2, 3]
+    assert ctx["nested"]["inner"] == [4, 5]
+    assert ctx["list"][0] == [1, 2]
+    assert ctx["tuple"][0] == [1, 3]
+    assert ctx["tuple"][1] == [2, 4]

--- a/tests/test_planner_smoke.py
+++ b/tests/test_planner_smoke.py
@@ -1,0 +1,28 @@
+import os
+from unittest.mock import Mock, patch
+
+from core.agents.planner_agent import PlannerAgent
+from core.roles import canonical_roles
+from orchestrators.plan_utils import normalize_plan_to_tasks
+
+
+def make_openai_response(text: str):
+    mock_choice = Mock()
+    mock_choice.message = Mock(content=text)
+    return Mock(choices=[mock_choice])
+
+
+ALLOWED_ROLES = canonical_roles()
+
+
+@patch.dict(os.environ, {"OPENAI_API_KEY": "x"})
+@patch("core.agents.planner_agent.llm_call")
+def test_planner_smoke(mock_llm):
+    mock_llm.return_value = make_openai_response(
+        '{"tasks": [{"id": "T01", "title": "Do X", "description": "desc", "role": "CTO"}]}'
+    )
+    agent = PlannerAgent("gpt-5")
+    raw = agent.run("idea", "plan")
+    tasks = normalize_plan_to_tasks(raw)
+    assert len(tasks) >= 6
+    assert {t["role"] for t in tasks}.issubset(ALLOWED_ROLES)

--- a/tests/test_prompt_factory_placeholders.py
+++ b/tests/test_prompt_factory_placeholders.py
@@ -1,0 +1,46 @@
+import pytest
+
+from config import feature_flags
+from dr_rd.prompting.prompt_factory import PromptFactory
+from dr_rd.prompting.prompt_registry import PromptRegistry, PromptTemplate, RetrievalPolicy
+
+
+def make_factory():
+    registry = PromptRegistry()
+    registry.register(
+        PromptTemplate(
+            id="test",
+            version="v1",
+            role="Greeter",
+            task_key=None,
+            system="You are a friendly assistant.",
+            user_template="Hello {{ name }}!",
+            io_schema_ref="dr_rd/schemas/void.json",
+            retrieval_policy=RetrievalPolicy.NONE,
+        )
+    )
+    return PromptFactory(registry)
+
+
+def test_missing_placeholder_raises(monkeypatch):
+    monkeypatch.setattr(feature_flags, "SAFETY_ENABLED", False)
+    monkeypatch.setattr(feature_flags, "RAG_ENABLED", False)
+    monkeypatch.setattr(feature_flags, "ENABLE_LIVE_SEARCH", False)
+    monkeypatch.setattr(feature_flags, "EXAMPLES_ENABLED", False)
+    factory = make_factory()
+    spec = {"role": "Greeter", "task": "", "inputs": {}}
+    with pytest.raises(ValueError) as exc:
+        factory.build_prompt(spec)
+    assert ["name"] == str(exc.value).split(": ")[-1].split(", ")
+
+
+def test_prompt_builds_when_all_placeholders_provided(monkeypatch):
+    monkeypatch.setattr(feature_flags, "SAFETY_ENABLED", False)
+    monkeypatch.setattr(feature_flags, "RAG_ENABLED", False)
+    monkeypatch.setattr(feature_flags, "ENABLE_LIVE_SEARCH", False)
+    monkeypatch.setattr(feature_flags, "EXAMPLES_ENABLED", False)
+    factory = make_factory()
+    spec = {"role": "Greeter", "task": "", "inputs": {"name": "Ada"}}
+    prompt = factory.build_prompt(spec)
+    assert prompt["user"] == "Hello Ada!"
+    assert "system" in prompt

--- a/utils/errors.py
+++ b/utils/errors.py
@@ -106,11 +106,15 @@ def redact(text: str) -> str:
 
 
 def _coerce_sets(obj: Any) -> Any:
+    """Recursively convert sets to sorted lists for JSON serialization."""
+
     if isinstance(obj, set):
-        return list(obj)
+        # Sort deterministically using string representation to avoid type
+        # comparison issues between heterogeneous elements.
+        return sorted((_coerce_sets(v) for v in obj), key=lambda x: str(x))
     if isinstance(obj, dict):
         return {k: _coerce_sets(v) for k, v in obj.items()}
-    if isinstance(obj, list):
+    if isinstance(obj, (list, tuple)):
         return [_coerce_sets(v) for v in obj]
     return obj
 


### PR DESCRIPTION
## Summary
- avoid shadowing jinja2 `meta` by using a `policy_meta` variable when preparing retrieval plans
- serialize `SafeError` contexts deterministically by turning sets (even nested) into sorted lists
- add tests for prompt placeholders, SafeError JSON, and planner task coverage; regenerate repo map

## Testing
- `pre-commit run --files dr_rd/prompting/prompt_factory.py utils/errors.py tests/test_prompt_factory_placeholders.py tests/test_errors_json_serialization.py tests/test_planner_smoke.py repo_map.yaml docs/REPO_MAP.md`
- `pytest -q` *(fails: ImportError: cannot import name 'load_redaction_policy' from 'planning.segmenter')*


------
https://chatgpt.com/codex/tasks/task_e_68bc9e618080832cad7fe7956f5d4a2f