### PR TITLE
Add full API call prompt/response logging artifact

### DIFF
--- a/docs/API_CALL_LOG.md
+++ b/docs/API_CALL_LOG.md
@@ -1,0 +1,11 @@
+# API Call Log Artifact
+
+Each run captures all external API calls and saves them under the run's artifact directory:
+
+- `api_calls.jsonl` – full records with complete request parameters, prompts, and responses.
+- `api_calls.csv` – same data as CSV for spreadsheets.
+- `api_calls.md` – human-readable table with truncated text for quick inspection. See the JSONL/CSV for full content.
+
+Logging is enabled by default. Set environment variable `DRRD_API_CALL_LOG` to `false` to disable it.
+
+These logs contain raw prompts and responses, which may include sensitive information. Handle and share them with care.

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -55,4 +55,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-09-06T23:57:59.463369Z from commit 6bb1b82_
+_Last generated at 2025-09-07T00:09:10.711737Z from commit dea9f84_

--- a/dr_rd/telemetry/api_call_log.py
+++ b/dr_rd/telemetry/api_call_log.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import csv
+import json
+import traceback
+from pathlib import Path
+from threading import Lock
+from typing import Any, Callable, List, Optional
+from time import time
+
+from pydantic import BaseModel
+
+
+class APICallRecord(BaseModel):
+    ts_start: float
+    ts_end: float
+    run_id: str
+    task_id: str
+    agent: str
+    api_name: str
+    endpoint: str
+    params: dict[str, Any] | None = None
+    prompt_text: str = ""
+    response_text: str = ""
+    status_code: int | None = None
+    error: bool = False
+    exception: str | None = None
+    traceback: str | None = None
+
+
+class APICallLogger:
+    """Collect and persist API call records for a run."""
+
+    def __init__(self, run_id: str, artifact_dir: Path, enabled: bool = True) -> None:
+        self.run_id = run_id
+        self.artifact_dir = artifact_dir
+        self.enabled = enabled
+        self._records: List[APICallRecord] = []
+        self._lock = Lock()
+
+    def log(self, record: APICallRecord) -> None:
+        if not self.enabled:
+            return
+        with self._lock:
+            self._records.append(record)
+
+    def flush(self) -> None:
+        if not self.enabled:
+            return
+        self.artifact_dir.mkdir(parents=True, exist_ok=True)
+        if not self._records:
+            return
+        jsonl_path = self.artifact_dir / "api_calls.jsonl"
+        with jsonl_path.open("w", encoding="utf-8") as fh:
+            for rec in self._records:
+                fh.write(rec.model_dump_json() + "\n")
+        csv_path = self.artifact_dir / "api_calls.csv"
+        fieldnames = list(APICallRecord.model_fields)
+        with csv_path.open("w", newline="", encoding="utf-8") as fh:
+            writer = csv.DictWriter(fh, fieldnames=fieldnames)
+            writer.writeheader()
+            for rec in self._records:
+                writer.writerow(rec.model_dump())
+        md_path = self.artifact_dir / "api_calls.md"
+        with md_path.open("w", encoding="utf-8") as fh:
+            fh.write("# API Call Log\n\n")
+            fh.write(
+                "This table shows truncated prompts and responses. "
+                "See api_calls.jsonl or api_calls.csv for full data.\n\n"
+            )
+            fh.write("| ts_start | api_name | prompt_text | response_text |\n")
+            fh.write("|---|---|---|---|\n")
+            for rec in self._records:
+                pr = (rec.prompt_text or "")[:80].replace("\n", " ")
+                rr = (rec.response_text or "")[:80].replace("\n", " ")
+                fh.write(f"| {rec.ts_start} | {rec.api_name} | {pr} | {rr} |\n")
+
+    def close(self) -> None:
+        self.flush()
+        with self._lock:
+            self._records.clear()
+
+
+def instrumented_api_call(
+    api_name: str,
+    endpoint: str,
+    params: dict[str, Any] | None,
+    prompt_text: str,
+    call: Callable[[], Any],
+    *,
+    task_id: str = "",
+    agent: str = "",
+) -> Any:
+    """Execute ``call`` and log request/response to the global APICallLogger."""
+    from . import loggers as _loggers
+
+    logger = _loggers.get_api_call_logger()
+    ts_start = time()
+    error = False
+    exc_txt: str | None = None
+    tb_txt: str | None = None
+    status_code: int | None = None
+    response_text = ""
+    try:
+        resp = call()
+        status_code = getattr(resp, "http_status", None)
+        if hasattr(resp, "model_dump_json"):
+            response_text = resp.model_dump_json()
+        elif hasattr(resp, "json"):
+            try:
+                response_text = json.dumps(resp.json())
+            except Exception:
+                response_text = str(resp)
+        else:
+            response_text = str(resp)
+        return resp
+    except Exception as e:
+        error = True
+        exc_txt = repr(e)
+        tb_txt = traceback.format_exc()
+        raise
+    finally:
+        ts_end = time()
+        if logger is not None:
+            record = APICallRecord(
+                ts_start=ts_start,
+                ts_end=ts_end,
+                run_id=logger.run_id,
+                task_id=task_id,
+                agent=agent,
+                api_name=api_name,
+                endpoint=endpoint,
+                params=params or {},
+                prompt_text=prompt_text,
+                response_text=response_text if not error else "",
+                status_code=status_code,
+                error=error,
+                exception=exc_txt,
+                traceback=tb_txt,
+            )
+            logger.log(record)

--- a/dr_rd/telemetry/loggers.py
+++ b/dr_rd/telemetry/loggers.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from .api_call_log import APICallLogger
+
+_api_call_logger: Optional[APICallLogger] = None
+
+
+def set_api_call_logger(logger: APICallLogger | None) -> None:
+    global _api_call_logger
+    _api_call_logger = logger
+
+
+def get_api_call_logger() -> APICallLogger | None:
+    return _api_call_logger

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-09-06T23:57:59.463369Z'
-git_sha: 6bb1b82dde1498d861701d463cf8241d0b4cfb27
+generated_at: '2025-09-07T00:09:10.711737Z'
+git_sha: dea9f84f8b27a69b79446629078cfb0036bb3198
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -173,28 +173,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/__init__.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/plan_utils.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/qa_router.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/app_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -208,6 +187,20 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
+- path: orchestrators/plan_utils.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/app_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
 - path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
@@ -215,15 +208,8 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
-  role: Summarization
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: core/summarization/__init__.py
-  role: Summarization
+- path: orchestrators/__init__.py
+  role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
@@ -237,6 +223,20 @@ modules:
   invoked_by: []
   invokes: []
 - path: core/summarization/role_summarizer.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/__init__.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/integrator.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_api_call_log.py
+++ b/tests/test_api_call_log.py
@@ -1,0 +1,67 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from core import llm_client
+from dr_rd.telemetry.api_call_log import APICallLogger
+from dr_rd.telemetry import loggers as api_loggers
+
+
+class DummyResp:
+    http_status = 200
+
+    def __init__(self, text="hi"):
+        self.output = []
+        self.output_text = text
+
+    def model_dump_json(self):
+        return json.dumps({"text": self.output_text})
+
+
+def test_logs_successful_call(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setattr(llm_client.client.responses, "create", lambda **_: DummyResp())
+    monkeypatch.setattr(llm_client, "extract_text", lambda resp: resp.output_text)
+    logger = APICallLogger("r1", tmp_path, enabled=True)
+    api_loggers.set_api_call_logger(logger)
+    try:
+        llm_client.call_openai(
+            model="m",
+            messages=[{"role": "user", "content": "hi"}],
+            meta={"task_id": "T1", "agent": "tester"},
+        )
+    finally:
+        logger.flush()
+        api_loggers.set_api_call_logger(None)
+    rec = json.loads((tmp_path / "api_calls.jsonl").read_text().splitlines()[0])
+    assert rec["prompt_text"]
+    assert rec["response_text"] == DummyResp().model_dump_json()
+    assert rec["error"] is False
+
+
+def test_logs_exception_and_files_created(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    def boom(**kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(llm_client.client.responses, "create", boom)
+
+    class BoomChat:
+        def create(self, *args, **kwargs):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(llm_client.client.chat, "completions", BoomChat())
+    logger = APICallLogger("r2", tmp_path, enabled=True)
+    api_loggers.set_api_call_logger(logger)
+    with pytest.raises(RuntimeError):
+        llm_client.call_openai(model="m", messages=[{"role": "user", "content": "hi"}])
+    logger.flush()
+    api_loggers.set_api_call_logger(None)
+    j = tmp_path / "api_calls.jsonl"
+    c = tmp_path / "api_calls.csv"
+    m = tmp_path / "api_calls.md"
+    assert j.exists() and c.exists() and m.exists()
+    rec = json.loads(j.read_text().splitlines()[0])
+    assert rec["error"] is True
+    assert rec["exception"]

--- a/tests/test_llm_client_logging.py
+++ b/tests/test_llm_client_logging.py
@@ -13,6 +13,7 @@ class DummyResp:
 
 
 def test_llm_logging_success(monkeypatch, caplog):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     monkeypatch.setattr(
         llm_client.client.responses,
         "create",
@@ -36,6 +37,7 @@ def test_llm_logging_exception(monkeypatch, caplog):
     def boom(**kwargs):
         raise RuntimeError("404 boom")
 
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     monkeypatch.setattr(llm_client.client.responses, "create", boom)
 
     class BoomChat:


### PR DESCRIPTION
## Summary
- add APICallLogger to capture full prompt/response for each external API call
- instrument OpenAI client and Streamlit app to record calls and persist artifacts
- document API call log artifact and add tests for success and error cases

## Testing
- `pytest tests/test_api_call_log.py tests/test_llm_client_logging.py -q`
- `python scripts/generate_repo_map.py`

------
https://chatgpt.com/codex/tasks/task_e_68bccbec325c832ca90195c55d260a03