### PR TITLE
feat(prompts): strengthen agent prompts for schema compliance (Finance/Regulatory/Materials)

### DIFF
--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -55,4 +55,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-09-07T01:18:20.729610Z from commit 68792e9_
+_Last generated at 2025-09-07T03:18:28.072915Z from commit 5812c54_

--- a/dr_rd/prompting/prompt_registry.py
+++ b/dr_rd/prompting/prompt_registry.py
@@ -196,11 +196,12 @@ registry.register(
             "- sources\n"
             "- role\n"
             "- task\n\n"
+            "**LIST EACH RISK AS A SEPARATE ITEM IN `risks`. DO NOT COMBINE MULTIPLE RISKS INTO ONE PARAGRAPH.**\n"
             "All listed keys must appear (use empty strings/arrays or 'Not determined' when no data is available) and no other keys may be added.\n"
             "Example:\n"
-            '{"role": "Regulatory", "task": "Check standards", "summary": "...", '
-            '"findings": "...", "risks": ["..."], "next_steps": ["..."], "sources": ["..."]}\n'
-            "Return only the JSON keys defined in the schema. If you would otherwise emit a list where the schema expects a string, compress it into a single string (e.g., join with semicolons). Do not include any other keys.\n"
+            '{"role": "Regulatory", "task": "<TASK_TITLE>", "summary": "...", '
+            '"findings": "...", "risks": ["risk 1", "risk 2"], "next_steps": ["..."], "sources": ["..."]}\n'
+            "Return only the JSON keys defined in the schema. **If you would otherwise emit a list where the schema expects a string, compress it into a single string (e.g., join with semicolons).** Do not include any other keys.\n"
             "Only output JSON, no extra explanation or prose outside JSON."
         ),
         user_template=(
@@ -235,12 +236,14 @@ registry.register(
             "- **npv** (number)\n"
             "- **simulations** (object)\n"
             "- **assumptions** (array)\n\n"
+            "**DO NOT OMIT `total_cost` or `contribution_margin` in `unit_economics`. ENSURE `npv` IS A NUMBER (not a placeholder string).**\n"
             "All listed keys must appear and no other keys are allowed. Use empty strings/arrays or 'Not determined' when data is unavailable.\n"
             "**If the schema expects a string but you have a list, join items with semicolons into a single string.**\n"
             "Example:\n"
             '{"role": "Finance", "task": "<TASK_TITLE>", "summary": "...", '
             '"findings": "...", "risks": ["..."], "next_steps": ["..."], "sources": ["..."], '
-            '"unit_economics": {"total_revenue": 0}, "npv": 0, "simulations": {"mean": 0}, "assumptions": ["..."]}\n'
+            '"unit_economics": {"total_revenue": 0, "total_cost": 0, "gross_margin": 0, "contribution_margin": 0}, "npv": 0, '
+            '"simulations": {"mean": 0, "std_dev": 0, "p5": 0, "p95": 0}, "assumptions": ["..."]}\n'
             "Only output JSON, no extra explanation or prose outside JSON."
         ),
         user_template=(
@@ -442,10 +445,11 @@ registry.register(
             "- sources\n"
             "- role\n"
             "- task\n\n"
+            "**`properties` MUST BE A LIST OF OBJECTS (each with `name`, `property`, `value`, `units`, `source`) — NOT AN ARRAY OF PLAIN STRINGS.**\n"
             "All listed keys must appear (use empty strings/arrays or 'Not determined' when no data is available) and no other keys may be added.\n"
             "Example:\n"
-            '{"role": "Materials Engineer", "task": "Select materials", "summary": "...", '
-            '"findings": "...", "properties": [], "tradeoffs": ["..."], '
+            '{"role": "Materials Engineer", "task": "<TASK_TITLE>", "summary": "...", '
+            '"findings": "...", "properties": [{"name": "X", "property": "Y", "value": 0, "units": "", "source": ""}], "tradeoffs": ["..."], '
             '"risks": ["..."], "next_steps": ["..."], "sources": ["..."]}\n'
             "Only output JSON, no extra explanation or prose outside JSON."
         ),
@@ -454,7 +458,7 @@ registry.register(
             "Task: {{ task | default('unknown') }}\n"
             "Provide material selection and feasibility analysis, including summary, properties, tradeoffs, risks, next_steps, and sources in JSON. Lists such as properties and tradeoffs must be arrays and fields like risks and next_steps cannot be blank.\n"
             "Example:\n"
-            '{"role": "Materials Engineer", "task": "Select materials", "summary": "...", "findings": "...", "properties": [], "tradeoffs": [], "risks": ["..."], "next_steps": ["..."], "sources": ["..."]}'
+            '{"role": "Materials Engineer", "task": "<TASK_TITLE>", "summary": "...", "findings": "...", "properties": [{"name": "X", "property": "Y", "value": 0, "units": "", "source": ""}], "tradeoffs": ["..."], "risks": ["..."], "next_steps": ["..."], "sources": ["..."]}'
         ),
         io_schema_ref="dr_rd/schemas/materials_engineer_v2.json",
         retrieval_policy=RetrievalPolicy.LIGHT,

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-09-07T01:18:20.729610Z'
-git_sha: 68792e9ef3239f1f3e93b1cff569227d66ceced5
+generated_at: '2025-09-07T03:18:28.072915Z'
+git_sha: 5812c54febd4008fe05a0e6d5629a813e966cdbe
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -173,14 +173,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/plan_utils.py
+- path: orchestrators/executor.py
   role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/executor.py
+- path: orchestrators/plan_utils.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -201,6 +201,13 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
+- path: orchestrators/qa_router.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
 - path: orchestrators/__init__.py
   role: Orchestrator
   responsibilities: []
@@ -208,8 +215,8 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/qa_router.py
-  role: Orchestrator
+- path: core/summarization/role_summarizer.py
+  role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
@@ -230,13 +237,6 @@ modules:
   invoked_by: []
   invokes: []
 - path: core/summarization/__init__.py
-  role: Summarization
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []


### PR DESCRIPTION
## Summary
- add bold schema warnings and corrected examples for Finance, Regulatory, and Materials prompts
- refresh repo map documentation

## Testing
- `python -m pytest` *(fails: tests/gtm/test_generate_deck.py, tests/integrations/test_jira_bridge.py, tests/integrations/test_slack_bridge.py, tests/integrations/test_teams_bridge.py, tests/utils/test_redaction.py)*
- `python -m pytest tests/test_llm_json_schema.py tests/test_self_check.py` *(fails: tests/test_self_check.py::test_self_check_retry_failure)*
- `python scripts/generate_repo_map.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcf8f04e78832c9be091bc2171903b