### PR TITLE
feat(self_check): targeted "Reminder:" retry prompts + audit logging

### DIFF
--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -55,4 +55,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-09-07T03:18:28.072915Z from commit 5812c54_
+_Last generated at 2025-09-07T03:33:09.306784Z from commit 9f2922d_

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-09-07T03:18:28.072915Z'
-git_sha: 5812c54febd4008fe05a0e6d5629a813e966cdbe
+generated_at: '2025-09-07T03:33:09.306784Z'
+git_sha: 9f2922d812c4978f51475abd6cac78f2a17b4856
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -173,7 +173,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/executor.py
+- path: orchestrators/__init__.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/qa_router.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -181,6 +188,13 @@ modules:
   invoked_by: []
   invokes: []
 - path: orchestrators/plan_utils.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/executor.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -201,21 +215,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/qa_router.py
-  role: Orchestrator
+- path: core/summarization/integrator.py
+  role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/__init__.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: core/summarization/role_summarizer.py
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -229,14 +236,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
-  role: Summarization
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: core/summarization/__init__.py
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_self_check.py
+++ b/tests/test_self_check.py
@@ -35,7 +35,7 @@ def test_self_check_retry_failure(monkeypatch):
 
     bad_output = "No JSON here"
     fixed, meta = validate_and_retry("Research Scientist", {"title": "t"}, bad_output, retry_fn)
-    assert fixed["valid_json"] is False
+    assert fixed["findings"] == "Not determined"
     assert meta == {"retried": True, "valid_json": False, "missing_keys": []}
 
 
@@ -80,10 +80,92 @@ def test_missing_keys_reminder(monkeypatch):
 
     bad_output = json.dumps({"role": "Research Scientist", "task": "t"})
     validate_and_retry("Research Scientist", {"title": "t"}, bad_output, retry_fn)
-    assert (
-        captured["reminder"]
-        == "Include the keys 'findings', 'risks', 'next_steps', and 'sources' in your JSON."
+    assert captured["reminder"].startswith("Reminder:")
+    for key in ["findings", "risks", "next_steps", "sources"]:
+        assert f"missing '{key}'" in captured["reminder"]
+
+
+def test_schema_missing_multiple_keys(monkeypatch):
+    schema = {
+        "type": "object",
+        "properties": {
+            "total_cost": {"type": "number"},
+            "contribution_margin": {"type": "number"},
+        },
+        "required": ["total_cost", "contribution_margin"],
+    }
+    monkeypatch.setattr("core.evaluation.self_check._load_schema", lambda role: schema)
+    captured = {}
+
+    def retry_fn(reminder: str) -> str:
+        captured["reminder"] = reminder
+        return json.dumps(
+            {
+                "role": "Finance",
+                "task": "t",
+                "findings": ["f"],
+                "risks": ["r"],
+                "next_steps": ["n"],
+                "sources": [],
+                "total_cost": 1,
+                "contribution_margin": 2,
+            }
+        )
+
+    bad_output = json.dumps(
+        {
+            "role": "Finance",
+            "task": "t",
+            "findings": ["f"],
+            "risks": ["r"],
+            "next_steps": ["n"],
+            "sources": [],
+        }
     )
+    validate_and_retry("Finance", {"title": "t"}, bad_output, retry_fn)
+    assert captured["reminder"].startswith("Reminder:")
+    assert "missing 'total_cost'" in captured["reminder"]
+    assert "missing 'contribution_margin'" in captured["reminder"]
+
+
+def test_schema_type_mismatch(monkeypatch):
+    schema = {
+        "type": "object",
+        "properties": {"npv": {"type": "number"}, "risks": {"type": "array"}},
+        "required": ["npv", "risks"],
+    }
+    monkeypatch.setattr("core.evaluation.self_check._load_schema", lambda role: schema)
+    captured = {}
+
+    def retry_fn(reminder: str) -> str:
+        captured["reminder"] = reminder
+        return json.dumps(
+            {
+                "role": "Finance",
+                "task": "t",
+                "findings": ["f"],
+                "risks": ["r"],
+                "next_steps": ["n"],
+                "sources": [],
+                "npv": 1,
+            }
+        )
+
+    bad_output = json.dumps(
+        {
+            "role": "Finance",
+            "task": "t",
+            "findings": ["f"],
+            "risks": "bad",
+            "next_steps": ["n"],
+            "sources": [],
+            "npv": "Not determined",
+        }
+    )
+    validate_and_retry("Finance", {"title": "t"}, bad_output, retry_fn)
+    assert captured["reminder"].startswith("Reminder:")
+    assert "used 'Not determined' for a numeric field" in captured["reminder"]
+    assert "used a string where an array was required" in captured["reminder"]
 
 
 def test_has_required_rejects_empty_strings():

--- a/tests/test_self_check_tolerant.py
+++ b/tests/test_self_check_tolerant.py
@@ -18,5 +18,4 @@ def test_self_check_returns_structured_failure():
     bad = "not json"
     result, meta = validate_and_retry("r", {"id": 1, "title": "t"}, bad, lambda _: bad)
     assert meta["valid_json"] is False
-    assert result["valid_json"] is False
-    assert "raw_head" in result
+    assert result["findings"] == "Not determined"


### PR DESCRIPTION
## Summary
- build dynamic "Reminder:" prompts in `validate_and_retry` from missing keys and JSON schema errors
- log retry prompts with trace events for auditability
- expand self-check tests for missing keys and type mismatches

## Testing
- `pytest tests/test_self_check.py tests/test_self_check_escalate.py tests/test_self_check_tolerant.py -q`
- `python scripts/generate_repo_map.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcfc1f52a4832ca1377860723b4fca