### PR TITLE
test(self_check): expand coverage for dynamic reminders and retry logging

### DIFF
--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -55,4 +55,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-09-07T03:41:36.288252Z from commit da66d16_
+_Last generated at 2025-09-07T03:54:59.647226Z from commit d8755c3_

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-09-07T03:41:36.288252Z'
-git_sha: da66d16f490668510980863d8f125129bc99abb2
+generated_at: '2025-09-07T03:54:59.647226Z'
+git_sha: d8755c35bcbdd45761ffc64348fab54108250f05
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -173,7 +173,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/spec_builder.py
+- path: orchestrators/executor.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -194,14 +194,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
+- path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/executor.py
+- path: orchestrators/app_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -215,7 +215,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
+- path: core/summarization/schemas.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -229,14 +236,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/schemas.py
-  role: Summarization
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: core/summarization/__init__.py
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_self_check_dynamic_reminders.py
+++ b/tests/test_self_check_dynamic_reminders.py
@@ -1,0 +1,166 @@
+import json
+from pathlib import Path
+import logging
+
+import pytest
+
+from core.evaluation.self_check import validate_and_retry
+
+# Load the real Finance schema to exercise type checks accurately
+FINANCE_SCHEMA = json.loads(Path("dr_rd/schemas/finance_v2.json").read_text())
+
+
+def _valid_finance_json():
+    """Return a minimal valid Finance JSON object."""
+    return {
+        "role": "Finance",
+        "task": "t",
+        "summary": "s",
+        "findings": "f",
+        "unit_economics": {
+            "total_revenue": 10,
+            "total_cost": 5,
+            "gross_margin": 5,
+            "contribution_margin": 2,
+        },
+        "npv": 1,
+        "simulations": {"mean": 1, "std_dev": 1, "p5": 0, "p95": 2},
+        "assumptions": [],
+        "risks": ["r"],
+        "next_steps": ["n"],
+        "sources": [],
+    }
+
+
+# Missing key detection with multiple missing fields
+
+def test_missing_keys_multiple(monkeypatch):
+    monkeypatch.setattr(
+        "core.evaluation.self_check._load_schema", lambda role: FINANCE_SCHEMA
+    )
+    bad = _valid_finance_json()
+    bad["unit_economics"].pop("total_cost")
+    bad["unit_economics"].pop("contribution_margin")
+    captured = {}
+
+    def retry_fn(reminder: str) -> str:
+        captured["reminder"] = reminder
+        fixed = _valid_finance_json()
+        return json.dumps(fixed)
+
+    _, meta = validate_and_retry(
+        "Finance", {"title": "t"}, json.dumps(bad), retry_fn
+    )
+    assert "missing 'total_cost'" in captured["reminder"]
+    assert "missing 'contribution_margin'" in captured["reminder"]
+    assert meta == {"retried": True, "valid_json": True, "missing_keys": []}
+
+
+# Type mismatch errors and corresponding hints
+
+def test_type_mismatch_numeric(monkeypatch):
+    monkeypatch.setattr(
+        "core.evaluation.self_check._load_schema", lambda role: FINANCE_SCHEMA
+    )
+    bad = _valid_finance_json()
+    bad["npv"] = "Not determined"
+    captured = {}
+
+    def retry_fn(reminder: str) -> str:
+        captured["reminder"] = reminder
+        return json.dumps(bad)
+
+    validate_and_retry("Finance", {"title": "t"}, json.dumps(bad), retry_fn)
+    assert "numeric field" in captured["reminder"]
+
+
+def test_type_mismatch_array(monkeypatch):
+    monkeypatch.setattr(
+        "core.evaluation.self_check._load_schema", lambda role: FINANCE_SCHEMA
+    )
+    bad = _valid_finance_json()
+    bad["risks"] = "All good"
+    captured = {}
+
+    def retry_fn(reminder: str) -> str:
+        captured["reminder"] = reminder
+        return json.dumps(bad)
+
+    validate_and_retry("Finance", {"title": "t"}, json.dumps(bad), retry_fn)
+    assert "array was required" in captured["reminder"]
+
+
+# Combined errors (missing key + type mismatch)
+
+def test_combined_errors(monkeypatch):
+    monkeypatch.setattr(
+        "core.evaluation.self_check._load_schema", lambda role: FINANCE_SCHEMA
+    )
+    bad = _valid_finance_json()
+    bad["unit_economics"].pop("total_cost")
+    bad["findings"] = ["list"]  # should be a single string
+    captured = {}
+
+    def retry_fn(reminder: str) -> str:
+        captured["reminder"] = reminder
+        fixed = _valid_finance_json()
+        return json.dumps(fixed)
+
+    _, meta = validate_and_retry(
+        "Finance", {"title": "t"}, json.dumps(bad), retry_fn
+    )
+    assert "missing 'total_cost'" in captured["reminder"]
+    assert "used a list where a single string was required" in captured["reminder"]
+    assert " and " in captured["reminder"]
+    assert meta == {"retried": True, "valid_json": True, "missing_keys": []}
+
+
+# Logging/trace output for retry attempts
+
+def test_retry_logging(monkeypatch, caplog):
+    from core.evaluation import self_check
+
+    events = []
+
+    def fake_append_step(run_id, payload):
+        events.append(payload)
+
+    monkeypatch.setattr(self_check, "_load_schema", lambda role: None)
+    monkeypatch.setattr(self_check.trace_writer, "append_step", fake_append_step)
+
+    caplog.set_level(logging.INFO)
+
+    def retry_fn(reminder: str) -> str:
+        return "still bad"
+
+    validate_and_retry(
+        "Finance", {"title": "t", "id": "task"}, "not json", retry_fn, run_id="run"
+    )
+
+    assert any(e["event"] == "retry_prompt" for e in events)
+    assert any(e["event"] == "validation_error" for e in events)
+    record = next(r for r in caplog.records if r.message == "retry_prompt")
+    assert record.role == "Finance"
+    assert "Reminder:" in record.prompt
+
+
+# Successful retries using a second corrected JSON
+
+def test_retry_success_after_type_fix(monkeypatch):
+    monkeypatch.setattr(
+        "core.evaluation.self_check._load_schema", lambda role: FINANCE_SCHEMA
+    )
+    bad = _valid_finance_json()
+    bad["npv"] = "Not determined"
+    captured = {}
+
+    def retry_fn(reminder: str) -> str:
+        captured["reminder"] = reminder
+        fixed = _valid_finance_json()
+        return json.dumps(fixed)
+
+    _, meta = validate_and_retry(
+        "Finance", {"title": "t"}, json.dumps(bad), retry_fn
+    )
+    assert meta == {"retried": True, "valid_json": True, "missing_keys": []}
+    assert "numeric field" in captured["reminder"]


### PR DESCRIPTION
## Summary
- add comprehensive self-check tests covering missing keys, type mismatches, combined errors, logging events, and successful retries
- regenerate repo_map after adding tests

## Testing
- `pytest tests/test_self_check_dynamic_reminders.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pptx'; ModuleNotFoundError: No module named 'fastapi'; ImportError: cannot import name 'load_redaction_policy' from 'planning.segmenter')*


------
https://chatgpt.com/codex/tasks/task_e_68bd017005dc832c8281e2ed2cc98b98