### PR TITLE
feat(prompts): enhance CTO/Regulatory/Marketing prompts with modular design, standards context, and concise marketing bullets

### DIFF
--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -55,4 +55,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-09-07T03:54:59.647226Z from commit d8755c3_
+_Last generated at 2025-09-07T05:00:31.729958Z from commit c38196d_

--- a/dr_rd/prompting/prompt_registry.py
+++ b/dr_rd/prompting/prompt_registry.py
@@ -167,6 +167,7 @@ registry.register(
             "Example:\n"
             '{"role": "CTO", "task": "<TASK_TITLE>", "summary": "", '
             '"findings": "", "risks": [], "next_steps": [], "sources": []}\n'
+            "If the task is to design a system architecture, break your description into key components (e.g., optics, control loops, signal processing, data pipeline) and address each one in turn. This way, your **findings** can clearly call out each subsystem and its rationale. All required JSON fields must be filled; use \"Not determined\" only as a last resort after multiple attempts.\n"
             "Only output JSON, no extra explanation or prose outside JSON."
         ),
         user_template=(
@@ -198,6 +199,7 @@ registry.register(
             "- task\n\n"
             "**LIST EACH RISK AS A SEPARATE ITEM IN `risks`. DO NOT COMBINE MULTIPLE RISKS INTO ONE PARAGRAPH.**\n"
             "All listed keys must appear (use empty strings/arrays or 'Not determined' when no data is available) and no other keys may be added.\n"
+            "Context: Relevant regulations may involve biomedical devices (FDA requirements), import/export controls (e.g., ITAR), and product safety (ISO/IEC standards). Include at least one applicable standard or regulation in your analysis. All required JSON fields must appear; use \"Not determined\" only if information is truly unavailable after multiple attempts.\n"
             "Example:\n"
             '{"role": "Regulatory", "task": "<TASK_TITLE>", "summary": "", '
             '"findings": "", "risks": [], "next_steps": [], "sources": []}\n'
@@ -275,6 +277,7 @@ registry.register(
             "- role\n"
             "- task\n\n"
             "All listed keys must appear (use empty strings/arrays or 'Not determined' when no data is available) and no other keys may be added.\n"
+            "Be concise and factual—avoid repetition or marketing buzzwords. When appropriate, include a short bulleted list (5–7 bullets) covering: Total Addressable Market (TAM), Ideal Customer Profile (ICP), channels, pricing strategy, and key assumptions. All listed fields must appear and \"Not determined\" should only be used as a last-resort placeholder after retries.\n"
             "Example:\n"
             '{"role": "Marketing Analyst", "task": "<TASK_TITLE>", "summary": "", '
             '"findings": "", "risks": [], "next_steps": [], "sources": []}\n'

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-09-07T03:54:59.647226Z'
-git_sha: d8755c35bcbdd45761ffc64348fab54108250f05
+generated_at: '2025-09-07T05:00:31.729958Z'
+git_sha: c38196db75a763a3b35f01afb9e3eb915409319f
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -173,7 +173,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/executor.py
+- path: orchestrators/app_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -181,6 +181,13 @@ modules:
   invoked_by: []
   invokes: []
 - path: orchestrators/qa_router.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/plan_utils.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -201,28 +208,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
+- path: orchestrators/executor.py
   role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/plan_utils.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: core/summarization/schemas.py
-  role: Summarization
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: core/summarization/__init__.py
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -236,7 +229,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
+- path: core/summarization/__init__.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []


### PR DESCRIPTION
## Summary
- refine CTO prompt with guidance to break system architectures into components and fill all JSON fields
- expand Regulatory prompt with context on FDA, ITAR, and ISO/IEC standards and mandate citing applicable regulations
- clarify Marketing Analyst prompt to keep findings concise and include optional TAM/ICP bullet list
- refresh repo map

## Testing
- `python scripts/generate_repo_map.py`
- `pytest` *(fails: tests/gtm/test_generate_deck.py, tests/integrations/test_jira_bridge.py, tests/integrations/test_slack_bridge.py, tests/integrations/test_teams_bridge.py, tests/utils/test_redaction.py)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1123ee40832c98875e2215f138ea