### PR TITLE
feat(artifacts): dedupe Gaps heading, add missing-section placeholders, and enrich work_plan summaries

### DIFF
--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -1433,14 +1433,18 @@ def compose_final_proposal(
 
     gap_lines: list[str] = []
     if missing_roles or open_issues:
-        gap_lines.append("## Gaps and Unresolved Issues")
         for role in missing_roles:
             gap_lines.append(f"- {role} analysis is not available in this run.")
         for issue in open_issues:
             r = issue.get("role") or "Unknown role"
             gap_lines.append(f"- {r} analysis could not be completed.")
     if gap_lines:
-        final_markdown = final_markdown + "\n\n" + "\n".join(gap_lines)
+        header = "## Gaps and Unresolved Issues"
+        final_markdown = final_markdown.rstrip()
+        if header in final_markdown:
+            final_markdown = final_markdown + "\n" + "\n".join(gap_lines)
+        else:
+            final_markdown = final_markdown + f"\n\n{header}\n" + "\n".join(gap_lines)
     if alias_map:
         final_markdown = rehydrate_output(final_markdown, alias_map)
     run_id = st.session_state.get("run_id")

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -55,4 +55,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-09-07T05:13:08.654515Z from commit 794d604_
+_Last generated at 2025-09-07T05:32:08.021186Z from commit f17bb12_

--- a/orchestrators/executor.py
+++ b/orchestrators/executor.py
@@ -99,8 +99,13 @@ def execute(plan: List[Dict[str, Any]], ctx: Dict[str, Any]) -> Dict[str, Path]:
             "id": t.get("id"),
             "role": t.get("role"),
             "title": t.get("title"),
-            "summary": t.get("summary") or t.get("description", ""),
         }
+        payload = findings.get(t.get("role"), {})
+        agent_summary = (payload.get("summary") or "").strip()
+        if agent_summary and agent_summary.lower() != "not determined":
+            entry["summary"] = agent_summary
+        else:
+            entry["summary"] = "(Agent failed to return content)"
         placed = False
         for phase, roles in phase_roles.items():
             if t.get("role") in roles:

--- a/orchestrators/spec_builder.py
+++ b/orchestrators/spec_builder.py
@@ -5,7 +5,7 @@ from typing import Dict, Any
 from core.spec.models import *
 
 
-def _safe(x, default: str = ""):
+def _safe(x, default: str = "(This section was not completed in this research pass.)"):
     if not x or x == "Not determined":
         return default
     return x

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-09-07T05:13:08.654515Z'
-git_sha: 794d6047975efce75e37fc21688c97f1748314df
+generated_at: '2025-09-07T05:32:08.021186Z'
+git_sha: f17bb12ea394ab03aa598de6913ca9c99daf187b
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -173,14 +173,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/__init__.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/plan_utils.py
+- path: orchestrators/qa_router.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -201,13 +194,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/qa_router.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
@@ -215,7 +201,21 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/__init__.py
+- path: orchestrators/__init__.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/plan_utils.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -229,14 +229,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/schemas.py
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
+- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []


### PR DESCRIPTION
## Summary
- ensure final reports only include a single `Gaps and Unresolved Issues` heading
- clarify missing SDD sections with a default placeholder message
- reflect agent summaries (or failures) in the work plan entries and regenerate repo map

## Testing
- `pytest` *(fails: tests/gtm/test_generate_deck.py, tests/integrations/test_jira_bridge.py, tests/integrations/test_slack_bridge.py, tests/integrations/test_teams_bridge.py, tests/utils/test_redaction.py)*
- `python scripts/generate_repo_map.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd1895a5f8832ca928410ae255aace