### PR TITLE
Add resilient JSON fallback for agents

### DIFF
--- a/core/agents/prompt_agent.py
+++ b/core/agents/prompt_agent.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from typing import Any
 
 import jsonschema
@@ -9,7 +10,19 @@ from config import feature_flags
 from core.agents.base_agent import LLMRoleAgent
 from core.llm_client import responses_json_schema_from_file
 from dr_rd.prompting.prompt_factory import PromptFactory
+from dr_rd.prompting.prompt_registry import RetrievalPolicy
 from utils.logging import logger
+
+
+class AgentRunResult(str):
+    """String result carrying a fallback flag."""
+
+    fallback_used: bool
+
+    def __new__(cls, value: str, fallback_used: bool = False):
+        obj = str.__new__(cls, value)
+        obj.fallback_used = fallback_used
+        return obj
 
 
 def coerce_types(data: Any, schema: dict) -> Any:
@@ -46,13 +59,42 @@ def strip_additional_properties(data: Any, schema: dict) -> Any:
     return data
 
 
+def _fallback_schema_path(path: str) -> str:
+    root, ext = os.path.splitext(path)
+    return f"{root}_fallback{ext}"
+
+
+def make_empty_payload(schema: dict) -> dict[str, Any]:
+    props = schema.get("properties", {}) or {}
+    payload: dict[str, Any] = {}
+    for key, prop in props.items():
+        t = prop.get("type")
+        if isinstance(t, list):
+            if "array" in t:
+                payload[key] = []
+            elif "object" in t:
+                payload[key] = {}
+            else:
+                payload[key] = ""
+        elif t == "array":
+            payload[key] = []
+        elif t == "object":
+            payload[key] = {}
+        else:
+            payload[key] = ""
+    for key in schema.get("required", []):
+        if payload.get(key) in ("", None, {}):
+            payload[key] = "Not determined"
+    return payload
+
+
 class PromptFactoryAgent(LLMRoleAgent):
     """Mixin providing PromptFactory-based execution with schema validation
     and optional evaluator hooks."""
 
     _factory = PromptFactory()
 
-    def run_with_spec(self, spec: dict[str, Any], **kwargs) -> str:
+    def run_with_spec(self, spec: dict[str, Any], **kwargs) -> AgentRunResult:
         prompt = self._factory.build_prompt(spec)
         schema_path = prompt.get("io_schema_ref")
         response_format = None
@@ -62,35 +104,81 @@ class PromptFactoryAgent(LLMRoleAgent):
                 schema = json.load(fh)
             response_format = responses_json_schema_from_file(schema_path)
         user = prompt["user"]
-        for attempt in range(2):
-            raw = super().act(
-                prompt["system"],
-                user,
-                response_format=response_format,
-                **(prompt.get("llm_hints") or {}),
-                **kwargs,
-            )
+
+        raw = super().act(
+            prompt["system"],
+            user,
+            response_format=response_format,
+            **(prompt.get("llm_hints") or {}),
+            **kwargs,
+        )
+        try:
+            data = json.loads(raw)
+            if schema is not None:
+                data = coerce_types(data, schema)
+                data = strip_additional_properties(data, schema)
+                jsonschema.validate(data, schema)
+            valid = True
+        except Exception as e:
+            logger.debug("schema_validation_failed: %s", e)
+            valid = False
+        evaluator_fail = False
+        if valid and feature_flags.EVALUATORS_ENABLED:
+            if (
+                prompt.get("retrieval", {}).get("enabled")
+                and prompt.get("retrieval", {}).get("policy") != "NONE"
+                and not data.get("sources")
+            ):
+                evaluator_fail = True
+                logger.debug("evaluator_missing_sources")
+        if valid and not evaluator_fail:
+            return AgentRunResult(json.dumps(data))
+
+        # Fallback attempt
+        fallback_path = _fallback_schema_path(schema_path) if schema_path else None
+        fallback_schema = schema
+        if fallback_path:
             try:
-                data = json.loads(raw)
-                if schema is not None:
-                    data = coerce_types(data, schema)
-                    data = strip_additional_properties(data, schema)
-                    jsonschema.validate(data, schema)
-                valid = True
-            except Exception as e:
-                logger.debug("schema_validation_failed: %s", e)
-                valid = False
-            evaluator_fail = False
-            if valid and feature_flags.EVALUATORS_ENABLED:
-                if (
-                    prompt.get("retrieval", {}).get("enabled")
-                    and prompt.get("retrieval", {}).get("policy") != "NONE"
-                    and not data.get("sources")
-                ):
-                    evaluator_fail = True
-                    logger.debug("evaluator_missing_sources")
-            if valid and not evaluator_fail:
-                return json.dumps(data)
-            if attempt == 0:
-                user = user + "\nThe previous output was invalid or missing citations. Return valid JSON only."
-        return raw
+                with open(fallback_path, encoding="utf-8") as fh:
+                    fallback_schema = json.load(fh)
+            except Exception:
+                fallback_schema = schema
+            response_format = responses_json_schema_from_file(fallback_path)
+
+        fallback_spec = dict(spec)
+        if fallback_path:
+            fallback_spec["io_schema_ref"] = fallback_path
+        fallback_spec["retrieval_policy"] = RetrievalPolicy.NONE
+        fb_prompt = self._factory.build_prompt(fallback_spec)
+        fb_system = (
+            f"You are {spec.get('role', 'an AI assistant')}. "
+            "The previous output did not meet the JSON schema. "
+            "Now provide a concise result focusing on key fields in valid JSON. "
+            "You may leave unknown fields empty or as 'Not determined' but must return a JSON object with the expected keys. "
+            "Do not include citations or sources."
+        )
+        fb_user = fb_prompt.get("user", "")
+
+        raw = super().act(
+            fb_system,
+            fb_user,
+            response_format=response_format,
+            **(fb_prompt.get("llm_hints") or {}),
+            **kwargs,
+        )
+        try:
+            data = json.loads(raw)
+            if fallback_schema is not None:
+                data = coerce_types(data, fallback_schema)
+                data = strip_additional_properties(data, fallback_schema)
+                jsonschema.validate(data, fallback_schema)
+            valid = True
+        except Exception as e:
+            logger.debug("schema_validation_failed: %s", e)
+            valid = False
+
+        if valid:
+            return AgentRunResult(json.dumps(data), fallback_used=True)
+
+        empty = make_empty_payload(fallback_schema or {})
+        return AgentRunResult(json.dumps(empty), fallback_used=True)

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -13,6 +13,8 @@ Critical fixes are backported to active LTS branches only.
 - Bump schema version and template id (`<role>.v{n}`).
 - Document migration notes in `MIGRATION_GUIDE_v1_to_v2.md`.
 - Update `PromptRegistry` entries accordingly.
+- Maintain corresponding `*_fallback.json` schemas with relaxed validation used
+  for retry flows.
 
 ## On‑Call
 

--- a/docs/PROMPTS.md
+++ b/docs/PROMPTS.md
@@ -13,3 +13,11 @@ print(planner.system)
 The previous YAML-based prompt files and editing utilities have been removed.
 The registry is the single source of truth and prompts cannot be modified at
 runtime.
+
+## JSON Validation Fallback
+
+Agents invoked through `PromptFactoryAgent` automatically retry with a
+simplified prompt and a relaxed fallback schema when the initial response fails
+JSON validation.  The fallback may leave non-essential fields blank or marked as
+"Not determined," but a valid JSON object is always returned so downstream
+orchestrators do not crash.

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -55,4 +55,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-09-08T15:46:44.987173Z from commit 42bb128_
+_Last generated at 2025-09-08T16:21:51.845081Z from commit d55da8f_

--- a/dr_rd/schemas/cto_v2_fallback.json
+++ b/dr_rd/schemas/cto_v2_fallback.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "role": {
+      "type": ["string", "null"]
+    },
+    "task": {
+      "type": ["string", "null"]
+    },
+    "summary": {
+      "type": ["string", "null"]
+    },
+    "findings": {
+      "type": ["string", "null"]
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "next_steps": {
+      "type": ["string", "null"]
+    },
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": { "type": ["string", "null"] },
+          "title": { "type": ["string", "null"] },
+          "url": { "type": ["string", "null"] }
+        },
+        "required": ["id", "title"]
+      }
+    }
+  },
+  "required": ["role", "task", "summary"],
+  "additionalProperties": false
+}

--- a/dr_rd/schemas/marketing_v2_fallback.json
+++ b/dr_rd/schemas/marketing_v2_fallback.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "role": { "type": ["string", "null"] },
+    "task": { "type": ["string", "null"] },
+    "summary": { "type": ["string", "null"] },
+    "findings": { "type": ["string", "null"] },
+    "risks": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "next_steps": { "type": ["string", "null"] },
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": { "type": ["string", "null"] },
+          "title": { "type": ["string", "null"] },
+          "url": { "type": ["string", "null"] }
+        },
+        "required": ["id", "title"]
+      }
+    }
+  },
+  "required": ["role", "task", "summary"],
+  "additionalProperties": false
+}

--- a/dr_rd/schemas/regulatory_v2_fallback.json
+++ b/dr_rd/schemas/regulatory_v2_fallback.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "role": { "type": ["string", "null"] },
+    "task": { "type": ["string", "null"] },
+    "summary": { "type": ["string", "null"] },
+    "findings": { "type": ["string", "null"] },
+    "risks": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "next_steps": { "type": ["string", "null"] },
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": { "type": ["string", "null"] },
+          "title": { "type": ["string", "null"] },
+          "url": { "type": ["string", "null"] }
+        },
+        "required": ["id", "title"]
+      }
+    }
+  },
+  "required": ["role", "task", "summary"],
+  "additionalProperties": false
+}

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-09-08T15:46:44.987173Z'
-git_sha: 42bb128ba57d4d417eaabba4197a1c68aa6c43fd
+generated_at: '2025-09-08T16:21:51.845081Z'
+git_sha: d55da8f7ddbb96dd5e47aa813a9940776dd5f4c6
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -173,7 +173,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
+- path: orchestrators/qa_router.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -194,7 +194,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/qa_router.py
+- path: orchestrators/executor.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -208,7 +208,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/executor.py
+- path: orchestrators/app_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -222,14 +222,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/__init__.py
+- path: core/summarization/integrator.py
   role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_prompt_agent_fallback.py
+++ b/tests/test_prompt_agent_fallback.py
@@ -1,0 +1,51 @@
+import json
+
+from core.agents.prompt_agent import PromptFactoryAgent
+from core.agents.base_agent import LLMRoleAgent
+
+
+class DummyAgent(PromptFactoryAgent):
+    """Minimal agent for testing."""
+    pass
+
+
+def _spec():
+    return {
+        "role": "Marketing Analyst",
+        "task": "t",
+        "inputs": {"idea": "i", "task": "t"},
+        "io_schema_ref": "dr_rd/schemas/marketing_v2.json",
+    }
+
+
+def test_fallback_produces_valid_json(monkeypatch):
+    agent = DummyAgent("gpt-4o-mini")
+    outputs = iter([
+        "not json",
+        json.dumps({"role": "Marketing Analyst", "task": "t", "summary": "ok"}),
+    ])
+
+    def fake_act(self, system, user, **kwargs):
+        return next(outputs)
+
+    monkeypatch.setattr(LLMRoleAgent, "act", fake_act)
+    result = agent.run_with_spec(_spec())
+    assert isinstance(result, str)
+    assert result.fallback_used is True
+    data = json.loads(result)
+    assert data["summary"] == "ok"
+
+
+def test_fallback_returns_placeholder_on_failure(monkeypatch):
+    agent = DummyAgent("gpt-4o-mini")
+    outputs = iter(["bad", "still bad"])
+
+    def fake_act(self, system, user, **kwargs):
+        return next(outputs)
+
+    monkeypatch.setattr(LLMRoleAgent, "act", fake_act)
+    result = agent.run_with_spec(_spec())
+    data = json.loads(result)
+    assert result.fallback_used is True
+    assert {"role", "task", "summary"}.issubset(data)
+    assert data["summary"] == "Not determined"


### PR DESCRIPTION
## Summary
- enhance `PromptFactoryAgent.run_with_spec` with fallback prompts, relaxed schemas, and empty-payload defaults
- add fallback JSON schemas for CTO, Regulatory, and Marketing agents
- document and test JSON fallback retry behaviour

## Testing
- `pytest` *(fails: tests/gtm/test_generate_deck.py, tests/integrations/test_jira_bridge.py, tests/integrations/test_slack_bridge.py, tests/integrations/test_teams_bridge.py, tests/utils/test_redaction.py)*
- `pytest tests/test_prompt_agent_fallback.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf01ae9694832cb443bcd14a1dcf01