### PR TITLE
Add fallback schemas and second attempt logic for key agents

### DIFF
--- a/docs/JSON_SCHEMAS_SUMMARY.md
+++ b/docs/JSON_SCHEMAS_SUMMARY.md
@@ -41,3 +41,6 @@ Generated on 2025-08-28T20:12:06.613328 UTC.
 - **Reflection**: dr_rd/schemas/reflection_agent.json (INFERRED)
 - **Prototyping Test Lab Manager**: dr_rd/schemas/prototyping_test_lab_manager_agent.json (INFERRED)
 - **Optical Systems Engineer**: dr_rd/schemas/optical_systems_engineer_agent.json (INFERRED)
+- **CTO (Fallback)**: dr_rd/schemas/cto_v2_fallback.json
+- **Regulatory (Fallback)**: dr_rd/schemas/regulatory_v2_fallback.json
+- **Marketing (Fallback)**: dr_rd/schemas/marketing_v2_fallback.json

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -55,4 +55,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-09-08T16:21:51.845081Z from commit d55da8f_
+_Last generated at 2025-09-08T16:38:26.136143Z from commit af7eefd_

--- a/dr_rd/schemas/cto_v2_fallback.json
+++ b/dr_rd/schemas/cto_v2_fallback.json
@@ -15,7 +15,7 @@
       "type": ["string", "null"]
     },
     "risks": {
-      "type": "array",
+      "type": ["array", "null"],
       "items": {
         "type": "string"
       }
@@ -24,7 +24,7 @@
       "type": ["string", "null"]
     },
     "sources": {
-      "type": "array",
+      "type": ["array", "null"],
       "items": {
         "type": "object",
         "properties": {

--- a/dr_rd/schemas/marketing_v2_fallback.json
+++ b/dr_rd/schemas/marketing_v2_fallback.json
@@ -7,12 +7,12 @@
     "summary": { "type": ["string", "null"] },
     "findings": { "type": ["string", "null"] },
     "risks": {
-      "type": "array",
+      "type": ["array", "null"],
       "items": { "type": "string" }
     },
     "next_steps": { "type": ["string", "null"] },
     "sources": {
-      "type": "array",
+      "type": ["array", "null"],
       "items": {
         "type": "object",
         "properties": {

--- a/dr_rd/schemas/regulatory_v2_fallback.json
+++ b/dr_rd/schemas/regulatory_v2_fallback.json
@@ -7,12 +7,12 @@
     "summary": { "type": ["string", "null"] },
     "findings": { "type": ["string", "null"] },
     "risks": {
-      "type": "array",
+      "type": ["array", "null"],
       "items": { "type": "string" }
     },
     "next_steps": { "type": ["string", "null"] },
     "sources": {
-      "type": "array",
+      "type": ["array", "null"],
       "items": {
         "type": "object",
         "properties": {

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-09-08T16:21:51.845081Z'
-git_sha: d55da8f7ddbb96dd5e47aa813a9940776dd5f4c6
+generated_at: '2025-09-08T16:38:26.136143Z'
+git_sha: af7eefd2a3ea38cce60e33629ee8fe08811452c2
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -173,27 +173,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/qa_router.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/plan_utils.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/spec_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/executor.py
   role: Orchestrator
   responsibilities: []
@@ -215,6 +194,27 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
+- path: orchestrators/spec_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/plan_utils.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/qa_router.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
 - path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
@@ -222,14 +222,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/__init__.py
+- path: core/summarization/integrator.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_fallback_schemas.py
+++ b/tests/test_fallback_schemas.py
@@ -1,0 +1,17 @@
+import json
+import jsonschema
+import pytest
+
+SCHEMAS = [
+    "dr_rd/schemas/cto_v2_fallback.json",
+    "dr_rd/schemas/regulatory_v2_fallback.json",
+    "dr_rd/schemas/marketing_v2_fallback.json",
+]
+
+
+@pytest.mark.parametrize("path", SCHEMAS)
+def test_minimal_payload_valid(path):
+    with open(path, encoding="utf-8") as fh:
+        schema = json.load(fh)
+    payload = {"role": "r", "task": "t", "summary": "s"}
+    jsonschema.validate(payload, schema)


### PR DESCRIPTION
## Summary
- add fallback JSON schemas for CTO, Regulatory, and Marketing agents that require only minimal fields
- enhance PromptFactoryAgent to switch to fallback schemas with simplified prompts on second attempt
- document new schemas and add tests for fallback validation

## Testing
- `python scripts/generate_repo_map.py`
- `pytest tests/test_fallback_schemas.py tests/test_prompt_agent_fallback.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf05bf1848832ca38a26d5772d192f