### PR TITLE
Add pre-fallback JSON auto-correction

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,4 +29,8 @@ pytest -q e2e
 
 ## Agents
 
-Schema-constrained agents enforce OpenAI's `response_format={"type":"json_object"}` and fall back to a tolerant JSON parser when validating model output.
+Schema-constrained agents enforce OpenAI's `response_format={"type":"json_object"}`.
+If the initial `json.loads` fails, agent output undergoes an auto-correction
+pass that strips code fences, sanitizes quotes, repairs common JSON mistakes
+(`auto_repair_json`, `extract_json_block`, etc.), and reparses before the
+fallback prompt is triggered.

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -55,4 +55,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-09-08T16:38:26.136143Z from commit af7eefd_
+_Last generated at 2025-09-08T16:52:06.728926Z from commit 1471d45_

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-09-08T16:38:26.136143Z'
-git_sha: af7eefd2a3ea38cce60e33629ee8fe08811452c2
+generated_at: '2025-09-08T16:52:06.728926Z'
+git_sha: 1471d4507ddba5487cfe0c9cad97307012fa0865
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -180,27 +180,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/__init__.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/app_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/spec_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/plan_utils.py
   role: Orchestrator
   responsibilities: []
@@ -215,14 +194,28 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
-  role: Summarization
+- path: orchestrators/spec_builder.py
+  role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/__init__.py
+- path: orchestrators/__init__.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/app_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -237,6 +230,13 @@ modules:
   invoked_by: []
   invokes: []
 - path: core/summarization/schemas.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_auto_correction.py
+++ b/tests/test_auto_correction.py
@@ -1,0 +1,57 @@
+import json
+import pytest
+
+from core.agents.prompt_agent import PromptFactoryAgent
+from core.agents.base_agent import LLMRoleAgent
+from config import feature_flags
+
+
+class DummyAgent(PromptFactoryAgent):
+    """Minimal agent for testing auto-correction."""
+    pass
+
+
+class DummyFactory:
+    def __init__(self, schema_path: str):
+        self.schema_path = schema_path
+
+    def build_prompt(self, spec):
+        return {
+            "system": "sys",
+            "user": "user",
+            "io_schema_ref": self.schema_path,
+            "retrieval": {"enabled": False, "policy": "NONE"},
+            "llm_hints": {},
+        }
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("{\"a\": \"b\",}", {"a": "b"}),
+        ("{a: \"b\"}", {"a": "b"}),
+        ("```json\n{\"a\": \"b\"}\n```", {"a": "b"}),
+    ],
+)
+
+def test_auto_correction_no_fallback(tmp_path, monkeypatch, raw, expected):
+    monkeypatch.setattr(feature_flags, "EVALUATORS_ENABLED", False)
+    schema = {"type": "object", "properties": {"a": {"type": "string"}}, "required": ["a"]}
+    schema_path = tmp_path / "schema.json"
+    schema_path.write_text(json.dumps(schema))
+
+    calls: list[int] = []
+
+    def fake_act(self, system, user, **kwargs):  # type: ignore[override]
+        calls.append(1)
+        return raw
+
+    monkeypatch.setattr(LLMRoleAgent, "act", fake_act)
+
+    agent = DummyAgent("gpt-4o-mini")
+    agent._factory = DummyFactory(str(schema_path))
+
+    result = agent.run_with_spec({"role": "Tester"})
+    assert len(calls) == 1
+    assert result.fallback_used is False
+    assert json.loads(result) == expected

--- a/utils/json_fixers.py
+++ b/utils/json_fixers.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Tuple
+
+from .json_safety import strip_fences, auto_repair_json, light_sanitize, parse_json_loose
+from .agent_json import extract_json_block
+
+
+def attempt_auto_fix(raw: str) -> Tuple[bool, Any]:
+    """Attempt to repair malformed JSON strings.
+
+    Parameters
+    ----------
+    raw:
+        The raw string emitted by an LLM.
+
+    Returns
+    -------
+    tuple[bool, Any]
+        ``(True, obj)`` if JSON could be parsed into ``obj``; ``(False, cleaned)``
+        where ``cleaned`` is a sanitized string otherwise.
+    """
+
+    if not isinstance(raw, str):
+        return False, raw
+
+    cleaned = strip_fences(raw)
+    cleaned = light_sanitize(cleaned)
+    cleaned = auto_repair_json(cleaned)
+
+    try:
+        return True, json.loads(cleaned)
+    except Exception:
+        pass
+
+    obj = extract_json_block(cleaned)
+    if obj is not None:
+        return True, obj
+
+    try:
+        return True, parse_json_loose(cleaned)
+    except Exception:
+        return False, cleaned


### PR DESCRIPTION
## Summary
- repair malformed agent JSON using `attempt_auto_fix`
- try auto-correction before fallback in `PromptFactoryAgent`
- document JSON auto-correction behavior

## Testing
- `python scripts/generate_repo_map.py`
- `pytest tests/test_auto_correction.py tests/test_prompt_agent_fallback.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf09058b34832cb32d26a4e5712442