### PR TITLE
Add tests for agent fallback and JSON repair

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,3 +17,12 @@ External queries follow a strict order: **redact → route → log → network**
 ## Intake Fields
 
 The intake UI accepts optional **Constraints** and a **Risk posture** selection (Low/Medium/High). These values are threaded into planning prompts and persisted with each project.
+
+## Retry and Fallback
+
+Agents built on `PromptFactoryAgent` first attempt to auto-correct malformed JSON
+responses.  Structural fixes (trailing commas, unquoted keys, etc.) are applied
+before validating against the role schema.  If the response still fails
+validation or required fields are missing, the agent issues a simplified
+fallback prompt with a relaxed schema.  The fallback always yields a minimal but
+valid JSON object so downstream stages never see `(Agent failed to return content)`.

--- a/docs/PROMPTS.md
+++ b/docs/PROMPTS.md
@@ -14,10 +14,12 @@ The previous YAML-based prompt files and editing utilities have been removed.
 The registry is the single source of truth and prompts cannot be modified at
 runtime.
 
-## JSON Validation Fallback
+## Auto-Correction and Fallback
 
-Agents invoked through `PromptFactoryAgent` automatically retry with a
-simplified prompt and a relaxed fallback schema when the initial response fails
-JSON validation.  The fallback may leave non-essential fields blank or marked as
-"Not determined," but a valid JSON object is always returned so downstream
-orchestrators do not crash.
+Agents invoked through `PromptFactoryAgent` attempt to repair malformed JSON
+before giving up.  Common issues like trailing commas, unquoted keys and fenced
+code blocks are auto-corrected and then revalidated against the role schema. If
+validation still fails, the agent retries with a simplified prompt and a
+relaxed fallback schema. The fallback may leave non-essential fields blank or
+marked as "Not determined," but a valid JSON object is always returned so
+downstream orchestrators do not crash.

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -55,4 +55,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-09-08T16:52:06.728926Z from commit 1471d45_
+_Last generated at 2025-09-08T17:17:36.377464Z from commit 20edf7a_

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-09-08T16:52:06.728926Z'
-git_sha: 1471d4507ddba5487cfe0c9cad97307012fa0865
+generated_at: '2025-09-08T17:17:36.377464Z'
+git_sha: 20edf7a91e4d564982841b3d85058d3f3d68e276
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -173,14 +173,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/executor.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/plan_utils.py
+- path: orchestrators/__init__.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -194,6 +187,13 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
+- path: orchestrators/plan_utils.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
 - path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
@@ -201,7 +201,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/__init__.py
+- path: orchestrators/executor.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -222,7 +222,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -236,7 +236,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/__init__.py
+- path: core/summarization/integrator.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_auto_correction.py
+++ b/tests/test_auto_correction.py
@@ -4,6 +4,7 @@ import pytest
 from core.agents.prompt_agent import PromptFactoryAgent
 from core.agents.base_agent import LLMRoleAgent
 from config import feature_flags
+from utils.json_fixers import attempt_auto_fix
 
 
 class DummyAgent(PromptFactoryAgent):
@@ -55,3 +56,17 @@ def test_auto_correction_no_fallback(tmp_path, monkeypatch, raw, expected):
     assert len(calls) == 1
     assert result.fallback_used is False
     assert json.loads(result) == expected
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("{\"a\": [\"b\",]}", {"a": ["b"]}),
+        ("{\"a\": }", {"a": None}),
+        ("```json\n{\"a\":1}\n```", {"a": 1}),
+    ],
+)
+def test_attempt_auto_fix_handles_edge_cases(raw, expected):
+    ok, fixed = attempt_auto_fix(raw)
+    assert ok
+    assert fixed == expected

--- a/tests/test_partial_output.py
+++ b/tests/test_partial_output.py
@@ -1,0 +1,34 @@
+import json
+
+from core.agents.prompt_agent import PromptFactoryAgent
+from core.agents.base_agent import LLMRoleAgent
+
+
+class DummyAgent(PromptFactoryAgent):
+    pass
+
+
+def _spec():
+    return {
+        "role": "CTO",
+        "task": "X",
+        "inputs": {"idea": "i", "task": "X"},
+        "io_schema_ref": "dr_rd/schemas/cto_v2.json",
+    }
+
+
+def test_missing_keys_autofilled(monkeypatch):
+    agent = DummyAgent("gpt-4o-mini")
+
+    def fake_act(self, system, user, **kwargs):  # type: ignore[override]
+        return '{"role":"CTO","task":"X","summary":"Feasibility looks okay."}'
+
+    monkeypatch.setattr(LLMRoleAgent, "act", fake_act)
+    result = agent.run_with_spec(_spec())
+    data = json.loads(result)
+    assert result.fallback_used is False
+    assert data["summary"] == "Feasibility looks okay."
+    assert data["findings"] == "Not determined"
+    assert data["risks"] == []
+    assert data["next_steps"] == "Not determined"
+    assert data["sources"] == []

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -1,0 +1,70 @@
+import json
+
+from orchestrators.executor import execute
+from core.agents.prompt_agent import PromptFactoryAgent
+from core.agents.base_agent import LLMRoleAgent
+from config import feature_flags
+
+
+class DummyAgent(PromptFactoryAgent):
+    pass
+
+
+SCHEMAS = {
+    "CTO": "dr_rd/schemas/marketing_v2.json",
+    "Marketing Analyst": "dr_rd/schemas/marketing_v2.json",
+    "Research Scientist": "dr_rd/schemas/marketing_v2.json",
+    "Regulatory": "dr_rd/schemas/marketing_v2.json",
+    "Finance": "dr_rd/schemas/marketing_v2.json",
+    "IP Analyst": "dr_rd/schemas/marketing_v2.json",
+}
+
+
+def test_pipeline_smoke(monkeypatch):
+    feature_flags.EVALUATORS_ENABLED = False
+    roles = list(SCHEMAS)
+    outputs = iter([
+        "not json",
+        '{"role":"CTO","task":"t","summary":"Feasibility ok.","findings":"","risks":[],"next_steps":"","sources":[]}',
+        '{"role":"Marketing Analyst","task":"t","summary":"Market analysis could not be fully completed due to limited data","findings":"","risks":[],"next_steps":"","sources":[],}',
+        '{"role":"Research Scientist","task":"t","summary":"rs","findings":"","risks":[],"next_steps":"","sources":[]}',
+        '{"role":"Regulatory","task":"t","summary":"reg","findings":"","risks":[],"next_steps":"","sources":[]}',
+        '{"role":"Finance","task":"t","summary":"fin","findings":"","risks":[],"next_steps":"","sources":[]}',
+        '{"role":"IP Analyst","task":"t","summary":"ip","findings":"","risks":[],"next_steps":"","sources":[]}',
+    ])
+
+    def fake_act(self, system, user, **kwargs):  # type: ignore[override]
+        return next(outputs)
+
+    monkeypatch.setattr(LLMRoleAgent, "act", fake_act)
+
+    def auto_fix(raw):
+        if raw == "not json":
+            return False, raw
+        from utils.json_fixers import attempt_auto_fix as real
+
+        return real(raw)
+
+    monkeypatch.setattr("core.agents.prompt_agent.attempt_auto_fix", auto_fix)
+
+    agent = DummyAgent("gpt-4o-mini")
+    findings = {}
+    plan = []
+    for idx, role in enumerate(roles):
+        spec = {
+            "role": role,
+            "task": "t",
+            "inputs": {"idea": "i", "task": "t"},
+            "io_schema_ref": SCHEMAS[role],
+        }
+        res = agent.run_with_spec(spec)
+        data = json.loads(res)
+        findings[role] = data
+        plan.append({"id": str(idx), "role": role, "title": role})
+        assert data["summary"] and data["summary"].lower() != "not determined"
+
+    paths = execute(plan, {"run_id": "smoke", "idea": "i", "role_to_findings": findings})
+    wp = paths["work_plan"]
+    text = wp.read_text()
+    assert "(Agent failed to return content)" not in text
+    assert "Not determined" not in text


### PR DESCRIPTION
## Summary
- test fallback when initial schema parsing fails and ensure flag is set
- expand JSON auto-correction coverage and add partial-output handling
- add pipeline smoke test and document new retry/fallback strategy

## Testing
- `pytest tests/test_prompt_agent_fallback.py tests/test_auto_correction.py tests/test_partial_output.py tests/test_pipeline_smoke.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf0b7a20d8832c82bc147e9d7e79b1