### PR TITLE
Sanitize regulatory sources

### DIFF
--- a/core/agents/prompt_agent.py
+++ b/core/agents/prompt_agent.py
@@ -13,6 +13,7 @@ from dr_rd.prompting.prompt_factory import PromptFactory
 from dr_rd.prompting.prompt_registry import RetrievalPolicy
 from utils.logging import logger
 from utils.json_fixers import attempt_auto_fix
+from utils.agent_json import sanitize_sources
 
 
 class AgentRunResult(str):
@@ -116,6 +117,7 @@ class PromptFactoryAgent(LLMRoleAgent):
         try:
             data = json.loads(raw)
             if schema is not None:
+                data = sanitize_sources(data, schema)
                 data = coerce_types(data, schema)
                 data = strip_additional_properties(data, schema)
                 jsonschema.validate(data, schema)
@@ -130,6 +132,7 @@ class PromptFactoryAgent(LLMRoleAgent):
                         placeholder = make_empty_payload(schema)
                         placeholder.update(data)
                         data = placeholder
+                    data = sanitize_sources(data, schema)
                     data = coerce_types(data, schema)
                     data = strip_additional_properties(data, schema)
                     jsonschema.validate(data, schema)
@@ -189,6 +192,7 @@ class PromptFactoryAgent(LLMRoleAgent):
         try:
             data = json.loads(raw)
             if fallback_schema is not None:
+                data = sanitize_sources(data, fallback_schema)
                 data = coerce_types(data, fallback_schema)
                 data = strip_additional_properties(data, fallback_schema)
                 jsonschema.validate(data, fallback_schema)

--- a/docs/AGENT_PROMPT_AUDIT.md
+++ b/docs/AGENT_PROMPT_AUDIT.md
@@ -247,6 +247,7 @@ Generated on 2025-08-28T20:12:06.612544 UTC.
 - **Known Issues**: schema enforcement missing
 - **Recommended Fix**: Add schema enforcement
 - **Tests Coverage Found**: no
+- **Notes**: `sources` must be objects with `id`, `title`, and optional `url`; do not use markdown link strings.
 
 ## Generic Domain
 - **Prompt Location**: core/agents/generic_domain_agent.py

--- a/docs/PROMPT_STANDARDS.md
+++ b/docs/PROMPT_STANDARDS.md
@@ -68,6 +68,7 @@ are false, prompts avoid retrieval language and sources are optional. When
 enabled and the template `retrieval_policy` is not `NONE`, prompts demand inline
 evidence markers and a non empty `sources` array of `{id,title,url}` objects.
 Agents returning empty sources in this mode trigger the evaluator retry.
+Sources must not be plain strings or markdown links; each entry must be a JSON object.
 
 ## Migration Notes
 Roles now powered by `PromptFactory`: CTO, Research Scientist, Regulatory,

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -55,4 +55,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-09-08T17:17:36.377464Z from commit 20edf7a_
+_Last generated at 2025-09-08T18:31:17.350009Z from commit fab88d5_

--- a/dr_rd/prompting/prompt_registry.py
+++ b/dr_rd/prompting/prompt_registry.py
@@ -201,6 +201,9 @@ registry.register(
             "- sources\n"
             "- role\n"
             "- task\n\n"
+            "Each item in `sources` must be an object with `id`, `title`, and optional `url` fields. Do not use plain strings or markdown links in `sources`. For example, use {'id': 'Doe2024', 'title': 'Quantum Ethics Whitepaper', 'url': 'https://example.com/ethics.pdf'}. Avoid markdown syntax like [title](url).\n"
+            "Incorrect Example:\n"
+            '{"sources": ["[yjolt.org](https://yjolt.org/blog/establishing-legal-ethical-framework-quantum-technology?utm_source=openai)"]}\n'
             "**LIST EACH RISK AS A SEPARATE ITEM IN `risks`. DO NOT COMBINE MULTIPLE RISKS INTO ONE PARAGRAPH.**\n"
             "All listed keys must appear (use empty strings/arrays or 'Not determined' when no data is available) and no other keys may be added.\n"
             "Context: Relevant regulations may involve biomedical devices (FDA requirements), import/export controls (e.g., ITAR), and product safety (ISO/IEC standards). Include at least one applicable standard or regulation in your analysis. All required JSON fields must appear; use \"Not determined\" only if information is truly unavailable after multiple attempts.\n"

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-09-08T17:17:36.377464Z'
-git_sha: 20edf7a91e4d564982841b3d85058d3f3d68e276
+generated_at: '2025-09-08T18:31:17.350009Z'
+git_sha: fab88d58bc45391a1f5027f004136e02befb0baa
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -201,13 +201,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/executor.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/app_builder.py
   role: Orchestrator
   responsibilities: []
@@ -215,8 +208,8 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
-  role: Summarization
+- path: orchestrators/executor.py
+  role: Orchestrator
   responsibilities: []
   inputs: []
   outputs: []
@@ -229,7 +222,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/schemas.py
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -237,6 +230,13 @@ modules:
   invoked_by: []
   invokes: []
 - path: core/summarization/integrator.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_regulatory_sources.py
+++ b/tests/test_regulatory_sources.py
@@ -1,0 +1,86 @@
+import json
+
+import jsonschema
+
+from core.agents.prompt_agent import PromptFactoryAgent
+from core.agents.base_agent import LLMRoleAgent
+from config import feature_flags
+
+
+def _spec():
+    return {"role": "Regulatory", "inputs": {"idea": "", "task": ""}}
+
+
+def _schema():
+    with open("dr_rd/schemas/regulatory_v2.json", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _run(raw: str, monkeypatch) -> str:
+    monkeypatch.setattr(feature_flags, "EVALUATORS_ENABLED", False)
+
+    def fake_act(self, system, user, response_format=None, **kwargs):
+        return raw
+
+    monkeypatch.setattr(LLMRoleAgent, "act", fake_act)
+    agent = PromptFactoryAgent("gpt-4o-mini")
+    return agent.run_with_spec(_spec())
+
+
+def test_markdown_link_sanitized(monkeypatch):
+    raw = json.dumps(
+        {
+            "role": "Regulatory",
+            "task": "T1",
+            "summary": "",
+            "findings": "",
+            "risks": [],
+            "next_steps": [],
+            "sources": [
+                "([yjolt.org](https://yjolt.org/blog/establishing-legal-ethical-framework-quantum-technology?utm_source=openai))"
+            ],
+        }
+    )
+    result = _run(raw, monkeypatch)
+    data = json.loads(result)
+    jsonschema.validate(data, _schema())
+    assert data["sources"][0]["title"] == "yjolt.org"
+    assert data["sources"][0]["url"].startswith("https://yjolt.org")
+
+
+def test_missing_keys_filled(monkeypatch):
+    raw = json.dumps(
+        {
+            "role": "Regulatory",
+            "task": "T1",
+            "summary": "",
+            "findings": "",
+            "risks": [],
+            "next_steps": [],
+            "sources": [{"url": "https://example.com"}],
+        }
+    )
+    result = _run(raw, monkeypatch)
+    data = json.loads(result)
+    jsonschema.validate(data, _schema())
+    assert data["sources"][0]["id"] == "https://example.com"
+    assert data["sources"][0]["title"] == "https://example.com"
+
+
+def test_plain_string_source(monkeypatch):
+    raw = json.dumps(
+        {
+            "role": "Regulatory",
+            "task": "T1",
+            "summary": "",
+            "findings": "",
+            "risks": [],
+            "next_steps": [],
+            "sources": ["https://plain.example"],
+        }
+    )
+    result = _run(raw, monkeypatch)
+    data = json.loads(result)
+    jsonschema.validate(data, _schema())
+    assert data["sources"][0]["id"] == "https://plain.example"
+    assert data["sources"][0]["url"] == "https://plain.example"

--- a/utils/agent_json.py
+++ b/utils/agent_json.py
@@ -1,5 +1,6 @@
 import json
 import re
+from typing import Any
 
 from .json_safety import parse_json_loose
 
@@ -59,3 +60,50 @@ def extract_json_strict(text: str):
         return json.loads(candidate)
     except Exception as e:
         raise AgentOutputFormatError("Could not parse agent JSON") from e
+
+
+def _slugify(text: str) -> str:
+    s = text.strip().lower()
+    s = re.sub(r"[^a-z0-9\s-]", "", s)
+    s = re.sub(r"\s+", "-", s)
+    return s[:64] or "source"
+
+
+def sanitize_sources(data: dict[str, Any], schema: dict) -> dict[str, Any]:
+    if not isinstance(data, dict):
+        return data
+    props = schema.get("properties") or {}
+    if "sources" not in props:
+        return data
+    sources = data.get("sources")
+    if not isinstance(sources, list):
+        return data
+    sanitized: list[dict[str, Any]] = []
+    for item in sources:
+        if isinstance(item, dict):
+            sid = item.get("id") or item.get("url") or ""
+            title = item.get("title") or item.get("url") or ""
+            url = item.get("url")
+            entry: dict[str, Any] = {"id": sid, "title": title}
+            if url:
+                entry["url"] = url
+            sanitized.append(entry)
+        elif isinstance(item, str):
+            m = re.search(r"\[(.*?)\]\((.*?)\)", item)
+            if m:
+                title = m.group(1).strip()
+                url = m.group(2).strip()
+                entry = {"id": _slugify(title) or url, "title": title}
+                if url:
+                    entry["url"] = url
+                sanitized.append(entry)
+            else:
+                url = item.strip()
+                entry = {"id": url, "title": url}
+                if url:
+                    entry["url"] = url
+                sanitized.append(entry)
+        # silently drop unsupported types
+    new = dict(data)
+    new["sources"] = sanitized
+    return new


### PR DESCRIPTION
## Summary
- clarify Regulatory agent prompt that each source must be an object; show incorrect markdown example
- sanitize sources before schema validation and integrate into PromptFactoryAgent
- test source sanitization for markdown links, missing keys, and plain strings

## Testing
- `pytest tests/test_regulatory_sources.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf1ff2d840832c8b172b3b1a660e2a