### PR TITLE
Sanitize sources field for finance and marketing agents

### DIFF
--- a/core/agents/prompt_agent.py
+++ b/core/agents/prompt_agent.py
@@ -117,7 +117,8 @@ class PromptFactoryAgent(LLMRoleAgent):
         try:
             data = json.loads(raw)
             if schema is not None:
-                data = sanitize_sources(data, schema)
+                if (schema.get("properties") or {}).get("sources") is not None:
+                    data = sanitize_sources(data, schema)
                 data = coerce_types(data, schema)
                 data = strip_additional_properties(data, schema)
                 jsonschema.validate(data, schema)
@@ -132,7 +133,8 @@ class PromptFactoryAgent(LLMRoleAgent):
                         placeholder = make_empty_payload(schema)
                         placeholder.update(data)
                         data = placeholder
-                    data = sanitize_sources(data, schema)
+                    if (schema.get("properties") or {}).get("sources") is not None:
+                        data = sanitize_sources(data, schema)
                     data = coerce_types(data, schema)
                     data = strip_additional_properties(data, schema)
                     jsonschema.validate(data, schema)
@@ -192,7 +194,8 @@ class PromptFactoryAgent(LLMRoleAgent):
         try:
             data = json.loads(raw)
             if fallback_schema is not None:
-                data = sanitize_sources(data, fallback_schema)
+                if (fallback_schema.get("properties") or {}).get("sources") is not None:
+                    data = sanitize_sources(data, fallback_schema)
                 data = coerce_types(data, fallback_schema)
                 data = strip_additional_properties(data, fallback_schema)
                 jsonschema.validate(data, fallback_schema)

--- a/docs/PROMPTS.md
+++ b/docs/PROMPTS.md
@@ -23,3 +23,9 @@ validation still fails, the agent retries with a simplified prompt and a
 relaxed fallback schema. The fallback may leave non-essential fields blank or
 marked as "Not determined," but a valid JSON object is always returned so
 downstream orchestrators do not crash.
+
+Before validation, responses pass through a `sanitize_sources` step that coerces
+the `sources` field to match each role's schema. Finance and Marketing agents
+must return `sources` as a list of citation strings or URLs; any objects or empty
+entries are dropped. Regulatory still expects `sources` to be objects with
+`id`, `title`, and optional `url` fields.

--- a/docs/PROMPT_STANDARDS.md
+++ b/docs/PROMPT_STANDARDS.md
@@ -66,9 +66,11 @@ are logged for debugging but not exposed to end users.
 Retrieval behaviour follows `RAG_ENABLED` / `ENABLE_LIVE_SEARCH` flags. If both
 are false, prompts avoid retrieval language and sources are optional. When
 enabled and the template `retrieval_policy` is not `NONE`, prompts demand inline
-evidence markers and a non empty `sources` array of `{id,title,url}` objects.
-Agents returning empty sources in this mode trigger the evaluator retry.
-Sources must not be plain strings or markdown links; each entry must be a JSON object.
+evidence markers and a non empty `sources` array. Finance and Marketing agents
+emit `sources` as a list of strings, while Regulatory and other roles expect
+`{id,title,url}` objects. A sanitization step converts markdown links or bare
+URLs into the appropriate format and drops malformed items. Agents returning
+empty sources in this mode trigger the evaluator retry.
 
 ## Migration Notes
 Roles now powered by `PromptFactory`: CTO, Research Scientist, Regulatory,

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -55,4 +55,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-09-08T18:31:17.350009Z from commit fab88d5_
+_Last generated at 2025-09-08T18:55:16.610698Z from commit 641809f_

--- a/dr_rd/prompting/prompt_registry.py
+++ b/dr_rd/prompting/prompt_registry.py
@@ -249,6 +249,9 @@ registry.register(
             "- **npv** (number)\n"
             "- **simulations** (object)\n"
             "- **assumptions** (array)\n\n"
+            "`sources` must be a list of strings representing citations or URLs. Example: \"sources\": [\"https://example.com/funding-analysis\"]\n"
+            "Do not include objects or empty dictionaries in `sources`; invalid entries will be ignored.\n"
+            "Incorrect Example: {\"sources\": [\"https://example.com\", {}]} — `{}` breaks the schema.\n"
             "**DO NOT OMIT `total_cost` or `contribution_margin` in `unit_economics`. ENSURE `npv` IS A NUMBER (not a placeholder string).**\n"
             "All listed keys must appear and no other keys are allowed. Use empty strings/arrays or 'Not determined' when data is unavailable.\n"
             "**If the schema expects a string but you have a list, join items with semicolons into a single string.**\n"
@@ -262,7 +265,7 @@ registry.register(
         user_template=(
             "Idea: {{ idea | default('') }}\n"
             "Task: {{ task | default('unknown') }}\n"
-            "Provide budget estimates and financial risk analysis. Include unit_economics, npv, simulations, assumptions, risks, next_steps, and sources in the JSON summary."
+            "Provide budget estimates and financial risk analysis. Include unit_economics, npv, simulations, assumptions, risks, next_steps, and sources in the JSON summary. Return `sources` as a list of citation URLs (strings)."
         ),
         io_schema_ref="dr_rd/schemas/finance_v2.json",
         retrieval_policy=RetrievalPolicy.LIGHT,
@@ -288,6 +291,9 @@ registry.register(
             "- role\n"
             "- task\n\n"
             "All listed keys must appear (use empty strings/arrays or 'Not determined' when no data is available) and no other keys may be added.\n"
+            "`sources` must be a list of strings representing citations or URLs. Example: \"sources\": [\"https://example.com/market-report\"]\n"
+            "Do not include objects or empty dictionaries in `sources`; invalid entries will be ignored.\n"
+            "Incorrect Example: {\"sources\": [{}, \"https://example.com/market\"]} — `{}` breaks the schema.\n"
             "Be concise and factual—avoid repetition or marketing buzzwords. Include a short list of 5–7 key market points covering Total Addressable Market (TAM), Ideal Customer Profile (ICP), channels, pricing strategy, and key assumptions.\n"
             "Format these points as separate sentences within a single semicolon-separated string or as individual items in the `risks` or `next_steps` arrays; never use markdown bullets or newline-separated lists. No '-' or '*' bullet characters should appear in any JSON field.\n"
             "Example:\n"
@@ -303,7 +309,7 @@ registry.register(
         user_template=(
             "Idea: {{ idea | default('') }}\n"
             "Task: {{ task | default('unknown') }}\n"
-            "Provide marketing analysis and conclude with summary, findings, next_steps, and sources in JSON."
+            "Provide marketing analysis and conclude with summary, findings, next_steps, and sources in JSON. Return `sources` as a list of citation URLs (strings)."
         ),
         io_schema_ref="dr_rd/schemas/marketing_v2.json",
         retrieval_policy=RetrievalPolicy.LIGHT,

--- a/dr_rd/schemas/marketing_v2.json
+++ b/dr_rd/schemas/marketing_v2.json
@@ -26,22 +26,7 @@
     "sources": {
       "type": "array",
       "items": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "id",
-          "title"
-        ]
+        "type": "string"
       }
     }
   },

--- a/dr_rd/schemas/marketing_v2_fallback.json
+++ b/dr_rd/schemas/marketing_v2_fallback.json
@@ -13,15 +13,7 @@
     "next_steps": { "type": ["string", "null"] },
     "sources": {
       "type": ["array", "null"],
-      "items": {
-        "type": "object",
-        "properties": {
-          "id": { "type": ["string", "null"] },
-          "title": { "type": ["string", "null"] },
-          "url": { "type": ["string", "null"] }
-        },
-        "required": ["id", "title"]
-      }
+      "items": { "type": "string" }
     }
   },
   "required": ["role", "task", "summary"],

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-09-08T18:31:17.350009Z'
-git_sha: fab88d58bc45391a1f5027f004136e02befb0baa
+generated_at: '2025-09-08T18:55:16.610698Z'
+git_sha: 641809f6bb55453575f30a164ff6e5f513cf7e87
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -180,14 +180,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/qa_router.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/plan_utils.py
+- path: orchestrators/app_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -201,7 +194,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
+- path: orchestrators/qa_router.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -215,6 +208,13 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
+- path: orchestrators/plan_utils.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
 - path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
@@ -222,7 +222,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
+- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -236,7 +236,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/schemas.py
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_sanitized_sources.py
+++ b/tests/test_sanitized_sources.py
@@ -1,0 +1,66 @@
+import json
+import jsonschema
+from config import feature_flags
+from core.agents.base_agent import LLMRoleAgent
+from core.agents.prompt_agent import PromptFactoryAgent
+
+
+def _run(role: str, schema_path: str, raw: str, monkeypatch) -> str:
+    monkeypatch.setattr(feature_flags, "EVALUATORS_ENABLED", False)
+
+    def fake_act(self, system, user, response_format=None, **kwargs):  # type: ignore[override]
+        return raw
+
+    monkeypatch.setattr(LLMRoleAgent, "act", fake_act)
+    agent = PromptFactoryAgent("gpt-4o-mini")
+    spec = {"role": role, "inputs": {"idea": "", "task": ""}, "io_schema_ref": schema_path}
+    return agent.run_with_spec(spec)
+
+
+def test_finance_drops_invalid_sources(monkeypatch):
+    raw = json.dumps(
+        {
+            "role": "Finance",
+            "task": "T1",
+            "summary": "",
+            "findings": "",
+            "unit_economics": {
+                "total_revenue": 0,
+                "total_cost": 0,
+                "gross_margin": 0,
+                "contribution_margin": 0,
+            },
+            "npv": 0,
+            "simulations": {"mean": 0, "std_dev": 0, "p5": 0, "p95": 0},
+            "assumptions": [],
+            "risks": [],
+            "next_steps": [],
+            "sources": ["valid_source", {}],
+        }
+    )
+    result = _run("Finance", "dr_rd/schemas/finance_v2.json", raw, monkeypatch)
+    data = json.loads(result)
+    schema = json.load(open("dr_rd/schemas/finance_v2.json", encoding="utf-8"))
+    jsonschema.validate(data, schema)
+    assert data["sources"] == ["valid_source"]
+
+
+def test_marketing_converts_dict_sources(monkeypatch):
+    raw = json.dumps(
+        {
+            "role": "Marketing Analyst",
+            "task": "T1",
+            "summary": "",
+            "findings": "",
+            "risks": [],
+            "next_steps": "",
+            "sources": [{"url": "https://abc.com"}],
+        }
+    )
+    result = _run(
+        "Marketing Analyst", "dr_rd/schemas/marketing_v2.json", raw, monkeypatch
+    )
+    data = json.loads(result)
+    schema = json.load(open("dr_rd/schemas/marketing_v2.json", encoding="utf-8"))
+    jsonschema.validate(data, schema)
+    assert data["sources"] == ["https://abc.com"]


### PR DESCRIPTION
## Summary
- Clarify Finance and Marketing prompts so `sources` is a list of citation strings and warn against object entries
- Sanitize malformed `sources` before validation, converting to strings or objects per schema
- Add tests and docs for new `sources` handling and regenerate repo map

## Testing
- `pytest tests/test_sanitized_sources.py tests/test_regulatory_sources.py`
- `python scripts/generate_repo_map.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf259bdcf8832cba22e29857f4e5c6