### PR TITLE
Add runtime JSON payload sanitizer for agents

### DIFF
--- a/core/agents/cto_agent.py
+++ b/core/agents/cto_agent.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from typing import Any
 
 from core.agents.prompt_agent import PromptFactoryAgent
@@ -11,13 +10,11 @@ from dr_rd.prompting.prompt_registry import RetrievalPolicy
 class CTOAgent(PromptFactoryAgent):
     def act(self, idea: str, task: Any = None, **kwargs) -> str:
         tool_req = should_use_tool(task) if isinstance(task, dict) else None
-        tool_result = None
         if tool_req:
             try:
-                out = self.run_tool(tool_req["tool"], tool_req.get("params", {}))
-                tool_result = {"output": out}
-            except Exception as e:  # pragma: no cover - best effort
-                tool_result = {"error": str(e)}
+                self.run_tool(tool_req["tool"], tool_req.get("params", {}))
+            except Exception:  # pragma: no cover - best effort
+                pass
         spec = {
             "role": "CTO",
             "task": task.get("description", "") if isinstance(task, dict) else str(task or ""),
@@ -31,11 +28,4 @@ class CTOAgent(PromptFactoryAgent):
             "evaluation_hooks": ["self_check_minimal"],
         }
         result = super().run_with_spec(spec, **kwargs)
-        if tool_result:
-            try:
-                data = json.loads(result)
-                data["tool_result"] = tool_result
-                result = json.dumps(data)
-            except Exception:  # pragma: no cover
-                pass
         return result

--- a/core/agents/prompt_agent.py
+++ b/core/agents/prompt_agent.py
@@ -13,7 +13,7 @@ from dr_rd.prompting.prompt_factory import PromptFactory
 from dr_rd.prompting.prompt_registry import RetrievalPolicy
 from utils.logging import logger
 from utils.json_fixers import attempt_auto_fix
-from utils.agent_json import sanitize_sources
+from utils.agent_json import clean_json_payload
 
 
 class AgentRunResult(str):
@@ -117,8 +117,7 @@ class PromptFactoryAgent(LLMRoleAgent):
         try:
             data = json.loads(raw)
             if schema is not None:
-                if (schema.get("properties") or {}).get("sources") is not None:
-                    data = sanitize_sources(data, schema)
+                data = clean_json_payload(data, schema)
                 data = coerce_types(data, schema)
                 data = strip_additional_properties(data, schema)
                 jsonschema.validate(data, schema)
@@ -133,8 +132,7 @@ class PromptFactoryAgent(LLMRoleAgent):
                         placeholder = make_empty_payload(schema)
                         placeholder.update(data)
                         data = placeholder
-                    if (schema.get("properties") or {}).get("sources") is not None:
-                        data = sanitize_sources(data, schema)
+                    data = clean_json_payload(data, schema)
                     data = coerce_types(data, schema)
                     data = strip_additional_properties(data, schema)
                     jsonschema.validate(data, schema)
@@ -194,8 +192,7 @@ class PromptFactoryAgent(LLMRoleAgent):
         try:
             data = json.loads(raw)
             if fallback_schema is not None:
-                if (fallback_schema.get("properties") or {}).get("sources") is not None:
-                    data = sanitize_sources(data, fallback_schema)
+                data = clean_json_payload(data, fallback_schema)
                 data = coerce_types(data, fallback_schema)
                 data = strip_additional_properties(data, fallback_schema)
                 jsonschema.validate(data, fallback_schema)

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -16,6 +16,14 @@ Critical fixes are backported to active LTS branches only.
 - Maintain corresponding `*_fallback.json` schemas with relaxed validation used
   for retry flows.
 
+## JSON Output Sanitization
+
+Use `utils.agent_json.clean_json_payload` before validating agent responses.
+This helper strips unknown keys, normalizes `sources`, removes markdown bullets
+and joins multi-line strings, coerces strings/lists, and fills any missing
+required fields with defaults. Running it keeps schema validation strict while
+reducing manual repair work.
+
 ## On‑Call
 
 See [ONCALL_RUNBOOK.md](ONCALL_RUNBOOK.md) for rotation details.

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -55,4 +55,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-09-08T21:04:02.613870Z from commit e2c9d7b_
+_Last generated at 2025-09-08T21:28:15.287770Z from commit 69697fa_

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-09-08T21:04:02.613870Z'
-git_sha: e2c9d7bf0b49fa80cbeb52a5f12efbd947a4cdb9
+generated_at: '2025-09-08T21:28:15.287770Z'
+git_sha: 69697fafc3f9affe58353cec1822742af81d110d
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -173,21 +173,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/spec_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/qa_router.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/__init__.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -215,6 +201,20 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
+- path: orchestrators/__init__.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/spec_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
 - path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
@@ -222,14 +222,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/__init__.py
+- path: core/summarization/integrator.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_agent_sanitization.py
+++ b/tests/test_agent_sanitization.py
@@ -1,6 +1,9 @@
+import json
 import jsonschema
 
 from core.agents.prompt_agent import coerce_types, strip_additional_properties
+from core.agents.cto_agent import CTOAgent
+from utils.agent_json import clean_json_payload
 
 
 def test_sanitization_coerces_and_strips():
@@ -18,3 +21,112 @@ def test_sanitization_coerces_and_strips():
     cleaned = strip_additional_properties(coerced, schema)
     jsonschema.validate(cleaned, schema)
     assert cleaned == {"summary": "a; b", "findings": "x; y"}
+
+
+def test_clean_payload_sources_string_mode():
+    schema = {
+        "type": "object",
+        "properties": {
+            "sources": {"type": "array", "items": {"type": "string"}},
+        },
+        "required": ["sources"],
+        "additionalProperties": False,
+    }
+    payload = {
+        "sources": [
+            "plain source",
+            {"url": "http://b.com", "extra": 1},
+            {"title": "Only Title"},
+            {},
+            "[Link](http://c.com)",
+            5,
+        ]
+    }
+    cleaned = clean_json_payload(payload, schema)
+    cleaned = coerce_types(cleaned, schema)
+    cleaned = strip_additional_properties(cleaned, schema)
+    jsonschema.validate(cleaned, schema)
+    assert cleaned == {
+        "sources": [
+            "plain source",
+            "http://b.com",
+            "Only Title",
+            "Link: http://c.com",
+        ]
+    }
+
+
+def test_clean_payload_sources_object_mode_and_types():
+    schema = {
+        "type": "object",
+        "properties": {
+            "summary": {"type": "string"},
+            "tags": {"type": "array", "items": {"type": "string"}},
+            "next_steps": {"type": "string"},
+            "sources": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "string"},
+                        "title": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                    "required": ["id", "title"],
+                    "additionalProperties": False,
+                },
+            },
+        },
+        "required": ["summary", "tags", "next_steps", "sources"],
+        "additionalProperties": False,
+    }
+    payload = {
+        "summary": "- first\n- second",
+        "tags": "alpha; beta\n* gamma",
+        "sources": [
+            "[Paper](http://a.com)",
+            "http://b.com",
+            {"id": "1", "title": "T1", "url": "http://c.com", "x": 1},
+        ],
+    }
+    cleaned = clean_json_payload(payload, schema)
+    cleaned = coerce_types(cleaned, schema)
+    cleaned = strip_additional_properties(cleaned, schema)
+    jsonschema.validate(cleaned, schema)
+    assert cleaned == {
+        "summary": "first; second",
+        "tags": ["alpha", "beta", "gamma"],
+        "next_steps": "Not determined",
+        "sources": [
+            {"id": "paper", "title": "Paper", "url": "http://a.com"},
+            {"id": "http://b.com", "title": "http://b.com", "url": "http://b.com"},
+            {"id": "1", "title": "T1", "url": "http://c.com"},
+        ],
+    }
+
+
+def test_cto_agent_no_tool_result():
+    class DummyCTO(CTOAgent):
+        def __init__(self):
+            super().__init__("dummy")
+
+        def run_with_spec(self, spec, **kwargs):  # type: ignore[override]
+            return json.dumps(
+                {
+                    "role": "",
+                    "task": "",
+                    "summary": "",
+                    "findings": "",
+                    "risks": [],
+                    "next_steps": "",
+                    "sources": [],
+                }
+            )
+
+        def run_tool(self, tool_name, params):  # type: ignore[override]
+            return "ok"
+
+    agent = DummyCTO()
+    out = agent.act("idea", {"tool_request": {"tool": "t", "params": {}}})
+    data = json.loads(out)
+    assert "tool_result" not in data


### PR DESCRIPTION
## Summary
- add `clean_json_payload` helper to normalize agent responses and sanitize `sources`
- apply cleaning in `PromptFactoryAgent` and remove `tool_result` from CTO agent outputs
- document JSON output sanitization practices and expand tests

## Testing
- `pytest` *(fails: tests/integrations/test_jira_bridge.py, tests/integrations/test_slack_bridge.py, tests/integrations/test_teams_bridge.py, tests/utils/test_redaction.py, tests/gtm/test_generate_deck.py)*
- `pytest tests/test_agent_sanitization.py`

------
https://chatgpt.com/codex/tasks/task_e_68bf49466bb4832cac016d8387f91620