### PR TITLE
Add fallback schemas and robust agent fallback handling

### DIFF
--- a/docs/JSON_SCHEMAS_SUMMARY.md
+++ b/docs/JSON_SCHEMAS_SUMMARY.md
@@ -44,3 +44,6 @@ Generated on 2025-08-28T20:12:06.613328 UTC.
 - **CTO (Fallback)**: dr_rd/schemas/cto_v2_fallback.json
 - **Regulatory (Fallback)**: dr_rd/schemas/regulatory_v2_fallback.json
 - **Marketing (Fallback)**: dr_rd/schemas/marketing_v2_fallback.json
+- **Finance (Fallback)**: dr_rd/schemas/finance_v2_fallback.json
+- **Research Scientist (Fallback)**: dr_rd/schemas/research_v2_fallback.json
+- **Materials Engineer (Fallback)**: dr_rd/schemas/materials_engineer_v2_fallback.json

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -14,7 +14,14 @@ Critical fixes are backported to active LTS branches only.
 - Document migration notes in `MIGRATION_GUIDE_v1_to_v2.md`.
 - Update `PromptRegistry` entries accordingly.
 - Maintain corresponding `*_fallback.json` schemas with relaxed validation used
-  for retry flows.
+  for retry flows. Finance, Research Scientist, and Materials Engineer now ship
+  fallback schemas alongside their primary contracts, joining the existing CTO,
+  Regulatory, and Marketing roles.
+
+When an agent's response fails schema validation, the system retries using the
+fallback schema and a prompt requesting a minimal JSON payload. If this second
+attempt still fails validation, a fully populated placeholder JSON object is
+returned so downstream consumers always receive compliant output.
 
 ## JSON Output Sanitization
 

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -55,4 +55,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-09-08T21:28:15.287770Z from commit 69697fa_
+_Last generated at 2025-09-08T21:36:08.036456Z from commit e1524db_

--- a/dr_rd/schemas/finance_v2_fallback.json
+++ b/dr_rd/schemas/finance_v2_fallback.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "role": { "type": ["string", "null"] },
+    "task": { "type": ["string", "null"] },
+    "summary": { "type": ["string", "null"] },
+    "findings": { "type": ["string", "null"] },
+    "unit_economics": {
+      "type": ["object", "null"],
+      "properties": {
+        "total_revenue": { "type": ["number", "null"] },
+        "total_cost": { "type": ["number", "null"] },
+        "gross_margin": { "type": ["number", "null"] },
+        "contribution_margin": { "type": ["number", "null"] }
+      },
+      "additionalProperties": false
+    },
+    "npv": { "type": ["number", "null"] },
+    "simulations": {
+      "type": ["object", "null"],
+      "properties": {
+        "mean": { "type": ["number", "null"] },
+        "std_dev": { "type": ["number", "null"] },
+        "p5": { "type": ["number", "null"] },
+        "p95": { "type": ["number", "null"] }
+      },
+      "additionalProperties": false
+    },
+    "assumptions": {
+      "type": ["array", "null"],
+      "items": { "type": "string" }
+    },
+    "risks": {
+      "type": ["array", "null"],
+      "items": { "type": "string" }
+    },
+    "next_steps": {
+      "type": ["array", "null"],
+      "items": { "type": "string" }
+    },
+    "sources": {
+      "type": ["array", "null"],
+      "items": { "type": "string" }
+    }
+  },
+  "required": ["role", "task", "summary"],
+  "additionalProperties": false
+}
+

--- a/dr_rd/schemas/materials_engineer_v2_fallback.json
+++ b/dr_rd/schemas/materials_engineer_v2_fallback.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "role": { "type": ["string", "null"] },
+    "task": { "type": ["string", "null"] },
+    "summary": { "type": ["string", "null"] },
+    "findings": { "type": ["string", "null"] },
+    "properties": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": { "type": ["string", "null"] },
+          "property": { "type": ["string", "null"] },
+          "value": {},
+          "units": { "type": ["string", "null"] },
+          "source": { "type": ["string", "null"] }
+        },
+        "additionalProperties": false
+      }
+    },
+    "tradeoffs": {
+      "type": ["array", "null"],
+      "items": { "type": "string" }
+    },
+    "risks": {
+      "type": ["array", "null"],
+      "items": { "type": "string" }
+    },
+    "next_steps": {
+      "type": ["array", "null"],
+      "items": { "type": "string" }
+    },
+    "sources": {
+      "type": ["array", "null"],
+      "items": { "type": "string" }
+    }
+  },
+  "required": ["role", "task", "summary"],
+  "additionalProperties": false
+}
+

--- a/dr_rd/schemas/research_v2_fallback.json
+++ b/dr_rd/schemas/research_v2_fallback.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Research V2 Fallback",
+  "type": "object",
+  "properties": {
+    "role": { "type": ["string", "null"] },
+    "task": { "type": ["string", "null"] },
+    "summary": { "type": ["string", "null"] },
+    "findings": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "object",
+        "properties": {
+          "claim": { "type": ["string", "null"] },
+          "evidence": { "type": ["string", "null"] },
+          "citations": {
+            "type": ["array", "null"],
+            "items": { "type": "string" }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "gaps": { "type": ["string", "null"] },
+    "risks": { "type": ["string", "null"] },
+    "next_steps": { "type": ["string", "null"] },
+    "sources": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": { "type": ["string", "null"] },
+          "title": { "type": ["string", "null"] },
+          "url": { "type": ["string", "null"] }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["role", "task", "summary"],
+  "additionalProperties": false
+}
+

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-09-08T21:28:15.287770Z'
-git_sha: 69697fafc3f9affe58353cec1822742af81d110d
+generated_at: '2025-09-08T21:36:08.036456Z'
+git_sha: e1524db8f2dd19581fd2bca704e84a77e91be72e
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -187,20 +187,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/executor.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/__init__.py
   role: Orchestrator
   responsibilities: []
@@ -215,7 +201,21 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
+- path: orchestrators/executor.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/app_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -236,7 +236,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/schemas.py
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_fallback_schemas.py
+++ b/tests/test_fallback_schemas.py
@@ -6,6 +6,9 @@ SCHEMAS = [
     "dr_rd/schemas/cto_v2_fallback.json",
     "dr_rd/schemas/regulatory_v2_fallback.json",
     "dr_rd/schemas/marketing_v2_fallback.json",
+    "dr_rd/schemas/finance_v2_fallback.json",
+    "dr_rd/schemas/research_v2_fallback.json",
+    "dr_rd/schemas/materials_engineer_v2_fallback.json",
 ]
 
 


### PR DESCRIPTION
## Summary
- add fallback JSON schemas for Finance, Research Scientist, and Materials Engineer
- enhance PromptFactoryAgent to locate fallback schemas and generate complete placeholder payloads when retries fail
- document new fallback behaviour and extend tests

## Testing
- `pytest tests/test_fallback_schemas.py tests/test_prompt_agent_fallback.py`
- `python scripts/generate_repo_map.py`

------
https://chatgpt.com/codex/tasks/task_e_68bf4bbb0fe4832cbaa2b8142d6e450a