### PR TITLE
Add tests for JSON cleaning and fallback behaviors

### DIFF
--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -16,7 +16,8 @@ Critical fixes are backported to active LTS branches only.
 - Maintain corresponding `*_fallback.json` schemas with relaxed validation used
   for retry flows. Finance, Research Scientist, and Materials Engineer now ship
   fallback schemas alongside their primary contracts, joining the existing CTO,
-  Regulatory, and Marketing roles.
+  Regulatory, and Marketing roles. These fallback contracts require only
+  `role`, `task`, and `summary`, permitting minimal payloads on retry.
 
 When an agent's response fails schema validation, the system retries using the
 fallback schema and a prompt requesting a minimal JSON payload. If this second
@@ -26,10 +27,10 @@ returned so downstream consumers always receive compliant output.
 ## JSON Output Sanitization
 
 Use `utils.agent_json.clean_json_payload` before validating agent responses.
-This helper strips unknown keys, normalizes `sources`, removes markdown bullets
-and joins multi-line strings, coerces strings/lists, and fills any missing
-required fields with defaults. Running it keeps schema validation strict while
-reducing manual repair work.
+This helper strips unknown keys (e.g. `tool_result`), normalizes `sources`,
+removes markdown bullets and joins multi-line strings, coerces strings/lists,
+and fills any missing required fields with defaults. Running it keeps schema
+validation strict while reducing manual repair work.
 
 ## On‑Call
 

--- a/docs/PROMPT_STANDARDS.md
+++ b/docs/PROMPT_STANDARDS.md
@@ -69,8 +69,10 @@ enabled and the template `retrieval_policy` is not `NONE`, prompts demand inline
 evidence markers and a non empty `sources` array. Finance and Marketing agents
 emit `sources` as a list of strings, while Regulatory and other roles expect
 `{id,title,url}` objects. A sanitization step converts markdown links or bare
-URLs into the appropriate format and drops malformed items. Agents returning
-empty sources in this mode trigger the evaluator retry.
+URLs into the appropriate format, drops malformed items, strips markdown bullets
+and multi-line formatting, coerces between lists and strings, fills missing
+required fields with defaults, and removes extra keys such as `tool_result`.
+Agents returning empty sources in this mode trigger the evaluator retry.
 
 ## Migration Notes
 Roles now powered by `PromptFactory`: CTO, Research Scientist, Regulatory,

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -55,4 +55,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-09-08T21:36:08.036456Z from commit e1524db_
+_Last generated at 2025-09-08T21:51:41.534546Z from commit 4041793_

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-09-08T21:36:08.036456Z'
-git_sha: e1524db8f2dd19581fd2bca704e84a77e91be72e
+generated_at: '2025-09-08T21:51:41.534546Z'
+git_sha: 404179312e99736694eb3638f06b7ddd75558281
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -180,6 +180,13 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
+- path: orchestrators/app_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
 - path: orchestrators/plan_utils.py
   role: Orchestrator
   responsibilities: []
@@ -208,8 +215,8 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
-  role: Orchestrator
+- path: core/summarization/integrator.py
+  role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
@@ -222,21 +229,14 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/__init__.py
-  role: Summarization
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: core/summarization/integrator.py
-  role: Summarization
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: core/summarization/role_summarizer.py
+  role: Summarization
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/__init__.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_agent_json.py
+++ b/tests/test_agent_json.py
@@ -1,6 +1,13 @@
+import json
+
+import jsonschema
 import pytest
 
-from utils.agent_json import AgentOutputFormatError, extract_json_strict
+from utils.agent_json import (
+    AgentOutputFormatError,
+    clean_json_payload,
+    extract_json_strict,
+)
 
 
 def test_repair_markdown_fences():
@@ -11,3 +18,155 @@ def test_repair_markdown_fences():
 def test_malformed_json_raises():
     with pytest.raises(AgentOutputFormatError):
         extract_json_strict("```json\n{bad}\n```")
+
+
+def test_sources_clean_string_array():
+    schema = {
+        "type": "object",
+        "properties": {
+            "sources": {"type": "array", "items": {"type": "string"}},
+        },
+        "required": ["sources"],
+        "additionalProperties": False,
+    }
+    payload = {
+        "sources": ["Some reference", {}, "[Title](http://example.com)"]
+    }
+    cleaned = clean_json_payload(payload, schema)
+    jsonschema.validate(cleaned, schema)
+    assert cleaned == {
+        "sources": ["Some reference", "Title: http://example.com"]
+    }
+
+
+def test_sources_clean_object_array():
+    schema = {
+        "type": "object",
+        "properties": {
+            "sources": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "string"},
+                        "title": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                    "required": ["id", "title", "url"],
+                    "additionalProperties": False,
+                },
+            }
+        },
+        "required": ["sources"],
+        "additionalProperties": False,
+    }
+    payload = {
+        "sources": ["http://example.com", "[Title](http://a.com)"]
+    }
+    cleaned = clean_json_payload(payload, schema)
+    jsonschema.validate(cleaned, schema)
+    assert cleaned == {
+        "sources": [
+            {
+                "id": "http://example.com",
+                "title": "http://example.com",
+                "url": "http://example.com",
+            },
+            {"id": "title", "title": "Title", "url": "http://a.com"},
+        ]
+    }
+
+
+def test_string_to_array_split():
+    schema = {
+        "type": "object",
+        "properties": {
+            "risks": {"type": "array", "items": {"type": "string"}},
+        },
+        "required": ["risks"],
+        "additionalProperties": False,
+    }
+    payload = {"risks": "Risk1; Risk2\n- Risk3"}
+    cleaned = clean_json_payload(payload, schema)
+    jsonschema.validate(cleaned, schema)
+    assert cleaned == {"risks": ["Risk1", "Risk2", "Risk3"]}
+
+
+def test_list_to_string_join():
+    schema = {
+        "type": "object",
+        "properties": {"summary": {"type": "string"}},
+        "required": ["summary"],
+        "additionalProperties": False,
+    }
+    payload = {"summary": ["Point A", "Point B"]}
+    cleaned = clean_json_payload(payload, schema)
+    jsonschema.validate(cleaned, schema)
+    assert cleaned == {"summary": "Point A; Point B"}
+
+
+def test_unknown_keys_removed():
+    schema = {
+        "type": "object",
+        "properties": {"summary": {"type": "string"}},
+        "required": ["summary"],
+        "additionalProperties": False,
+    }
+    payload = {"summary": "ok", "foo": "bar"}
+    cleaned = clean_json_payload(payload, schema)
+    jsonschema.validate(cleaned, schema)
+    assert cleaned == {"summary": "ok"}
+
+
+def test_tool_result_removed():
+    schema = {
+        "type": "object",
+        "properties": {
+            "role": {"type": "string"},
+            "task": {"type": "string"},
+            "summary": {"type": "string"},
+            "findings": {"type": "string"},
+            "risks": {"type": "array", "items": {"type": "string"}},
+            "next_steps": {"type": "string"},
+            "sources": {"type": "array", "items": {"type": "string"}},
+        },
+        "required": [
+            "role",
+            "task",
+            "summary",
+            "findings",
+            "risks",
+            "next_steps",
+            "sources",
+        ],
+        "additionalProperties": False,
+    }
+    payload = {
+        "role": "CTO",
+        "task": "t",
+        "summary": "s",
+        "findings": "f",
+        "risks": [],
+        "next_steps": "n",
+        "sources": [],
+        "tool_result": {"x": 1},
+    }
+    cleaned = clean_json_payload(payload, schema)
+    jsonschema.validate(cleaned, schema)
+    assert "tool_result" not in cleaned
+
+
+def test_missing_field_padding_marketing():
+    with open("dr_rd/schemas/marketing_v2.json", encoding="utf-8") as fh:
+        schema = json.load(fh)
+    payload = {
+        "role": "Marketing Analyst",
+        "task": "t",
+        "summary": "s",
+    }
+    cleaned = clean_json_payload(payload, schema)
+    jsonschema.validate(cleaned, schema)
+    assert cleaned["findings"] == "Not determined"
+    assert cleaned["next_steps"] == "Not determined"
+    assert cleaned["risks"] == []
+    assert cleaned["sources"] == []

--- a/tests/test_fallback_schemas.py
+++ b/tests/test_fallback_schemas.py
@@ -1,6 +1,10 @@
 import json
+
 import jsonschema
 import pytest
+
+from core.agents.prompt_agent import PromptFactoryAgent, make_empty_payload
+from core.agents.base_agent import LLMRoleAgent
 
 SCHEMAS = [
     "dr_rd/schemas/cto_v2_fallback.json",
@@ -18,3 +22,54 @@ def test_minimal_payload_valid(path):
         schema = json.load(fh)
     payload = {"role": "r", "task": "t", "summary": "s"}
     jsonschema.validate(payload, schema)
+
+
+class DummyAgent(PromptFactoryAgent):
+    """Minimal agent for fallback testing."""
+
+
+def _finance_spec():
+    return {
+        "role": "Finance",
+        "task": "t",
+        "inputs": {"idea": "i", "task": "t"},
+        "io_schema_ref": "dr_rd/schemas/finance_v2.json",
+    }
+
+
+def test_primary_failure_then_fallback_success(monkeypatch):
+    agent = DummyAgent("gpt-4o-mini")
+    outputs = iter(
+        [
+            "not json",
+            json.dumps({"role": "Finance", "task": "t", "summary": "ok"}),
+        ]
+    )
+
+    def fake_act(self, system, user, **kwargs):
+        return next(outputs)
+
+    monkeypatch.setattr(LLMRoleAgent, "act", fake_act)
+    result = agent.run_with_spec(_finance_spec())
+    data = json.loads(result)
+    assert result.fallback_used is True
+    with open("dr_rd/schemas/finance_v2_fallback.json", encoding="utf-8") as fh:
+        schema = json.load(fh)
+    jsonschema.validate(data, schema)
+
+
+def test_primary_and_fallback_failure(monkeypatch):
+    agent = DummyAgent("gpt-4o-mini")
+    outputs = iter(["bad", "still bad"])
+
+    def fake_act(self, system, user, **kwargs):
+        return next(outputs)
+
+    monkeypatch.setattr(LLMRoleAgent, "act", fake_act)
+    with open("dr_rd/schemas/finance_v2_fallback.json", encoding="utf-8") as fh:
+        schema = json.load(fh)
+    expected = make_empty_payload(schema)
+    result = agent.run_with_spec(_finance_spec())
+    data = json.loads(result)
+    assert result.fallback_used is True
+    assert data == expected


### PR DESCRIPTION
## Summary
- expand agent JSON tests for source sanitization, bullet splitting, extra-key stripping, and missing-field padding
- exercise Finance/Research/Materials fallback schemas with success and failure paths
- document sanitization and fallback contract behavior

## Testing
- `pytest tests/test_agent_json.py tests/test_fallback_schemas.py -q`
- `python scripts/generate_repo_map.py`

------
https://chatgpt.com/codex/tasks/task_e_68bf4f0cbdac832cb53aa6091a647dc5