### PR TITLE
feat(quality): detect placeholder content; retry/reflect on fake data; improve Materials prompt

### DIFF
--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -55,4 +55,4 @@ Streamlit imports `app.main` from `app/__init__.py`.
 ## Change Rules & Conventions
 See [REPO_RULES.md](REPO_RULES.md).
 
-_Last generated at 2025-09-09T17:59:55.616577Z from commit 9c96c7d_
+_Last generated at 2025-09-09T18:10:30.766885Z from commit ce8e0af_

--- a/dr_rd/prompting/prompt_registry.py
+++ b/dr_rd/prompting/prompt_registry.py
@@ -492,6 +492,7 @@ registry.register(
             "`sources` must be a list of strings representing citations or URLs. Example: \"sources\": [\"https://example.com/material-data\"]\n"
             "Do not include objects or empty dictionaries in `sources`; invalid entries will be ignored.\n"
             "All listed keys must appear (use empty strings/arrays or 'Not determined' when no data is available) and no other keys may be added.\n"
+            "Do not use placeholder names like 'Material A' or fake sources like 'example.com'. Provide actual material names and credible sources. Each properties item must include real values with units and verifiable citations.\n"
             "Example:\n"
             '{"role": "Materials Engineer", "task": "<TASK_TITLE>", "summary": "", "findings": "", "properties": [{"name": "X", "property": "Y", "value": 0, "units": "", "source": ""}], "tradeoffs": [], "risks": [], "next_steps": [], "sources": []}\n'
             "Incorrect Example:\n"

--- a/repo_map.yaml
+++ b/repo_map.yaml
@@ -1,6 +1,6 @@
 version: 1
-generated_at: '2025-09-09T17:59:55.616577Z'
-git_sha: 9c96c7d060baf26c59b23d54827b29bad9b6e4ad
+generated_at: '2025-09-09T18:10:30.766885Z'
+git_sha: ce8e0af0430b1b18401030b6cd7f6dccabc30a48
 entry_points:
 - name: streamlit_app
   path: app.py
@@ -173,21 +173,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/app_builder.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/executor.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
-- path: orchestrators/spec_builder.py
   role: Orchestrator
   responsibilities: []
   inputs: []
@@ -201,13 +187,6 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: orchestrators/plan_utils.py
-  role: Orchestrator
-  responsibilities: []
-  inputs: []
-  outputs: []
-  invoked_by: []
-  invokes: []
 - path: orchestrators/qa_router.py
   role: Orchestrator
   responsibilities: []
@@ -215,14 +194,35 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/integrator.py
+- path: orchestrators/app_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/plan_utils.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: orchestrators/spec_builder.py
+  role: Orchestrator
+  responsibilities: []
+  inputs: []
+  outputs: []
+  invoked_by: []
+  invokes: []
+- path: core/summarization/role_summarizer.py
   role: Summarization
   responsibilities: []
   inputs: []
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/schemas.py
+- path: core/summarization/integrator.py
   role: Summarization
   responsibilities: []
   inputs: []
@@ -236,7 +236,7 @@ modules:
   outputs: []
   invoked_by: []
   invokes: []
-- path: core/summarization/role_summarizer.py
+- path: core/summarization/schemas.py
   role: Summarization
   responsibilities: []
   inputs: []

--- a/tests/test_execute_plan_placeholder.py
+++ b/tests/test_execute_plan_placeholder.py
@@ -25,10 +25,11 @@ def test_missing_fields_placeholder(monkeypatch):
         raise ValueError("Missing required fields in PromptAgent inputs: task")
 
     monkeypatch.setattr(orchestrator, "invoke_agent_safely", fake_invoke)
+    monkeypatch.delitem(orchestrator.AGENT_REGISTRY, "Reflection", raising=False)
     st.session_state.clear()
     agents = {"CTO": object()}
     tasks = [{"id": "T1", "title": "A", "description": "B", "role": "CTO"}]
     answers = execute_plan("idea", tasks, agents=agents, run_id="r1")
-    out = json.loads(answers["CTO"][0])
+    out = json.loads(answers["CTO"])
     assert out["summary"] == "Not determined"
     assert out["task"] == "A"

--- a/tests/test_placeholder_check.py
+++ b/tests/test_placeholder_check.py
@@ -1,0 +1,16 @@
+from dr_rd.evaluators.placeholder_check import evaluate
+
+
+def test_placeholder_patterns_fail():
+    assert evaluate("Material A")[0] is False
+    assert evaluate({"url": "https://example.com/foo"})[0] is False
+    assert evaluate("Research Journal X")[0] is False
+    assert evaluate("Study Y")[0] is False
+
+
+def test_realistic_strings_pass():
+    data = {
+        "name": "Aluminum",
+        "source": "https://doi.org/10.1000/xyz"
+    }
+    assert evaluate(data)[0] is True

--- a/tests/test_self_check.py
+++ b/tests/test_self_check.py
@@ -23,7 +23,10 @@ def test_self_check_retry_success(monkeypatch):
     bad_output = "No JSON here"
     fixed, meta = validate_and_retry("Research Scientist", {"title": "t"}, bad_output, retry_fn)
     assert json.loads(fixed)["role"] == "Research Scientist"
-    assert meta == {"retried": True, "valid_json": True, "missing_keys": []}
+    assert meta["retried"] is True
+    assert meta["valid_json"] is True
+    assert meta["missing_keys"] == []
+    assert meta["placeholder_failure"] is False
     assert calls["count"] == 1
 
 
@@ -36,7 +39,10 @@ def test_self_check_retry_failure(monkeypatch):
     bad_output = "No JSON here"
     fixed, meta = validate_and_retry("Research Scientist", {"title": "t"}, bad_output, retry_fn)
     assert fixed["findings"] == "Not determined"
-    assert meta == {"retried": True, "valid_json": False, "missing_keys": []}
+    assert meta["retried"] is True
+    assert meta["valid_json"] is False
+    assert meta["missing_keys"] == []
+    assert meta["placeholder_failure"] is False
 
 
 def test_self_check_retry_dict_output(monkeypatch):
@@ -57,7 +63,10 @@ def test_self_check_retry_dict_output(monkeypatch):
     bad_output = "No JSON here"
     fixed, meta = validate_and_retry("Research Scientist", {"title": "t"}, bad_output, retry_fn)
     assert json.loads(fixed)["role"] == "Research Scientist"
-    assert meta == {"retried": True, "valid_json": True, "missing_keys": []}
+    assert meta["retried"] is True
+    assert meta["valid_json"] is True
+    assert meta["missing_keys"] == []
+    assert meta["placeholder_failure"] is False
     assert calls["count"] == 1
 
 

--- a/tests/test_self_check_dynamic_reminders.py
+++ b/tests/test_self_check_dynamic_reminders.py
@@ -53,7 +53,10 @@ def test_missing_keys_multiple(monkeypatch):
     )
     assert "missing 'total_cost'" in captured["reminder"]
     assert "missing 'contribution_margin'" in captured["reminder"]
-    assert meta == {"retried": True, "valid_json": True, "missing_keys": []}
+    assert meta["retried"] is True
+    assert meta["valid_json"] is True
+    assert meta["missing_keys"] == []
+    assert meta["placeholder_failure"] is False
 
 
 # Type mismatch errors and corresponding hints
@@ -67,7 +70,7 @@ def test_type_mismatch_numeric(monkeypatch):
     captured = {}
 
     def retry_fn(reminder: str) -> str:
-        captured["reminder"] = reminder
+        captured.setdefault("reminder", reminder)
         return json.dumps(bad)
 
     validate_and_retry("Finance", {"title": "t"}, json.dumps(bad), retry_fn)
@@ -83,7 +86,7 @@ def test_type_mismatch_array(monkeypatch):
     captured = {}
 
     def retry_fn(reminder: str) -> str:
-        captured["reminder"] = reminder
+        captured.setdefault("reminder", reminder)
         return json.dumps(bad)
 
     validate_and_retry("Finance", {"title": "t"}, json.dumps(bad), retry_fn)
@@ -112,7 +115,10 @@ def test_combined_errors(monkeypatch):
     assert "missing 'total_cost'" in captured["reminder"]
     assert "used a list where a single string was required" in captured["reminder"]
     assert " and " in captured["reminder"]
-    assert meta == {"retried": True, "valid_json": True, "missing_keys": []}
+    assert meta["retried"] is True
+    assert meta["valid_json"] is True
+    assert meta["missing_keys"] == []
+    assert meta["placeholder_failure"] is False
 
 
 # Logging/trace output for retry attempts
@@ -162,5 +168,8 @@ def test_retry_success_after_type_fix(monkeypatch):
     _, meta = validate_and_retry(
         "Finance", {"title": "t"}, json.dumps(bad), retry_fn
     )
-    assert meta == {"retried": True, "valid_json": True, "missing_keys": []}
+    assert meta["retried"] is True
+    assert meta["valid_json"] is True
+    assert meta["missing_keys"] == []
+    assert meta["placeholder_failure"] is False
     assert "numeric field" in captured["reminder"]

--- a/tests/test_self_check_placeholder_retry.py
+++ b/tests/test_self_check_placeholder_retry.py
@@ -1,0 +1,39 @@
+import json
+from core.evaluation.self_check import validate_and_retry, PLACEHOLDER_RETRY_MSG
+
+
+def _build_payload(name, url):
+    return {
+        "role": "Materials Engineer",
+        "task": "t",
+        "summary": "s",
+        "findings": "f",
+        "properties": [
+            {
+                "name": name,
+                "property": "density",
+                "value": 1,
+                "units": "g/cm3",
+                "source": url,
+            }
+        ],
+        "tradeoffs": [],
+        "risks": ["r"],
+        "next_steps": ["n"],
+        "sources": [url],
+    }
+
+
+def test_placeholder_triggers_retry_and_escalates():
+    bad = json.dumps(_build_payload("Material A", "https://example.com/foo"))
+    calls = []
+
+    def retry_fn(reminder: str) -> str:
+        calls.append(reminder)
+        return bad
+
+    _, meta = validate_and_retry("Materials Engineer", {"title": "t"}, bad, retry_fn)
+    assert calls and calls[0] == PLACEHOLDER_RETRY_MSG
+    assert meta["retried"] is True
+    assert meta["valid_json"] is False
+    assert meta["placeholder_failure"] is True


### PR DESCRIPTION
## Summary
- extend placeholder evaluator to flag fake materials, journals, and example.com URLs
- integrate placeholder checks into self-check and orchestrator with retry/reflect logic
- discourage placeholders in Materials Engineer prompt and add unit tests

## Testing
- `pytest tests/test_placeholder_check.py tests/test_self_check_placeholder_retry.py tests/test_self_check.py tests/test_self_check_dynamic_reminders.py`
- `pytest tests/test_execute_plan_placeholder.py`
- `pytest` *(fails: Missing dependencies for some integration tests)*
- `python scripts/generate_repo_map.py`


------
https://chatgpt.com/codex/tasks/task_e_68c06bb88450832c8b962f74e8f752ef