### PR TITLE
[Planning] Add task group IDs

### DIFF
--- a/planning/codex_plan.yaml
+++ b/planning/codex_plan.yaml
@@ -1,5 +1,7 @@
 tasks:
-- description: "Integrate the Synthesizer agent fully into the final output generation pipeline instead of using a direct LLM call in `compose_final_proposal`."
+- id: T1
+  group: synthesizer-integration
+  description: "Integrate the Synthesizer agent fully into the final output generation pipeline instead of using a direct LLM call in `compose_final_proposal`."
   acceptance_criteria:
     - "The final report generation uses `SynthesizerAgent` to produce a JSON output per `synthesizer_v1.json`, which is then converted to markdown for display."
     - "All relevant sources and safety metadata are included in the Synthesizer’s JSON output and appear in the final report (citations, contradictions, confidence flags as applicable)."
@@ -7,7 +9,9 @@ tasks:
   test_coverage: "Add a unit test for the synthesis stage that forces a final compilation on sample agent outputs and asserts the result conforms to the Synthesizer schema (e.g., contains `summary`, `key_points`, `sources` fields). Verify that disabling/enabling schema enforcement toggles the behavior."
   labels: ["architecture", "output-format", "enhancement"]
 
-- description: "Ensure all fields produced by the Planner and agents are either utilized or removed for consistency (especially `constraints`, `assumptions`, and risk registers in Planner output)."
+- id: T2
+  group: planner-fields
+  description: "Ensure all fields produced by the Planner and agents are either utilized or removed for consistency (especially `constraints`, `assumptions`, and risk registers in Planner output)."
   acceptance_criteria:
     - "Planner output fields like `constraints`, `assumptions`, and `metrics` are passed through to downstream steps or explicitly excluded from the schema if not needed."
     - "If policy-aware planning is enabled, the Planner’s `risk_register` is mapped into the standard `risks` field of the plan or otherwise handled so that risk information surfaces in the final report."
@@ -15,7 +19,9 @@ tasks:
   test_coverage: "Extend the planning unit test to include a scenario with non-empty `constraints`/`assumptions`. Verify via an integration test that these fields, when present, either appear in the final output or are intentionally dropped. Include a test for policy-aware mode where `risk_register` is set, ensuring those risks propagate to the output or are logged."
   labels: ["schema", "consistency", "enhancement"]
 
-- description: "Audit and rationalize the agent role definitions to eliminate any dead or duplicate roles (e.g. unify Finance vs. Finance Specialist, ensure Mechanical Systems Lead is reachable or remove it)."
+- id: T3
+  group: agent-role-audit
+  description: "Audit and rationalize the agent role definitions to eliminate any dead or duplicate roles (e.g. unify Finance vs. Finance Specialist, ensure Mechanical Systems Lead is reachable or remove it)."
   acceptance_criteria:
     - "Every agent in `AGENT_REGISTRY` is actually invoked by the router under some conditions (keywords or explicit Planner assignments). Roles that cannot be reached are removed or merged into similar roles."
     - "Duplicate or overlapping roles are consolidated. (For example, if `FinanceAgent` and `FinanceSpecialistAgent` serve the same purpose, choose one implementation and update routing synonyms accordingly.)"
@@ -23,7 +29,9 @@ tasks:
   test_coverage: "Write a test that simulates planner output tasks for each role in the registry (including edge roles like Mechanical Systems Lead) and confirms the router returns a valid agent class for each. Also add an assertion that no roles in the registry remain unmapped. This protects against future dead code in the roster."
   labels: ["architecture", "refactor"]
 
-- description: "Add an end-to-end smoke test for the full Planner→Agents→Synthesizer pipeline on a simple input, using a stubbed LLM to verify overall integration.")
+- id: T4
+  group: e2e-smoke-test
+  description: "Add an end-to-end smoke test for the full Planner→Agents→Synthesizer pipeline on a simple input, using a stubbed LLM to verify overall integration.")
   acceptance_criteria:
     - "A new integration test (or script in `tests/`) can run a full cycle given a sample idea (with RAG/search off for determinism), and produce a final report without errors."
     - "The smoke test uses either a very cheap model setting or a monkey-patched LLM interface to simulate responses quickly, focusing on flow correctness rather than LLM quality."
@@ -31,7 +39,9 @@ tasks:
   test_coverage: "Implement the above integration test possibly by intercepting calls to `core.llm.complete` to return canned JSON for each agent. Ensure that the orchestrator can handle the sequence and that the final output contains sections corresponding to each agent’s findings. The test should cover at least one task per agent type (or a representative subset) to exercise the router and agent invocation thoroughly."
   labels: ["testing", "integration"]
 
-- description: "Remove deprecated mode flags and update documentation to reflect the unified Standard mode operation."
+- id: T5
+  group: mode-cleanup
+  description: "Remove deprecated mode flags and update documentation to reflect the unified Standard mode operation."
   acceptance_criteria:
     - "All references to legacy modes (\"test\", \"deep\" profiles or `DRRD_MODE` env var) are removed from the codebase or replaced with Standard where applicable, as they are no longer in use."
     - "Configuration files and feature flags are cleaned up: e.g., eliminate or ignore `DISABLE_IMAGES_BY_DEFAULT` maps for old modes, consolidate any duplicate config sections that stem from past mode distinctions."


### PR DESCRIPTION
## Summary
- add unique task IDs and group slugs to codex plan

## Testing
- `pytest -q` *(errors: ModuleNotFoundError: pptx, fastapi)*
- `mypy dr_rd` *(interrupted)*
- `ruff check dr_rd` *(757 errors)*
- `gitleaks detect`


------
https://chatgpt.com/codex/tasks/task_e_68c2e36d6f98832cba725a7d2ea56ad3