### PR TITLE
[Execute] 2025-09-11 – <T2>

### DIFF
--- a/dr_rd/reporting/exporters.py
+++ b/dr_rd/reporting/exporters.py
@@ -11,6 +11,22 @@ def to_markdown(report: Dict) -> str:
         lines.append(f"## {sec['heading']}")
         lines.append(sec.get("body_md", ""))
         lines.append("")
+    planner = report.get("metadata", {}).get("planner", {})
+    constraints = planner.get("constraints") or []
+    assumptions = planner.get("assumptions") or []
+    if constraints or assumptions:
+        lines.append("## Constraints / Assumptions")
+        for c in constraints:
+            lines.append(f"- {c}")
+        for a in assumptions:
+            lines.append(f"- {a}")
+        lines.append("")
+    risks = planner.get("risks") or []
+    if risks:
+        lines.append("## Risks")
+        for r in risks:
+            lines.append(f"- {r}")
+        lines.append("")
     if report.get("sources"):
         lines.append("## Sources")
         for i, s in enumerate(report["sources"], 1):

--- a/tests/test_report_composer.py
+++ b/tests/test_report_composer.py
@@ -50,3 +50,24 @@ def test_compose_maps_risk_register_to_risks():
     planner_meta = report["metadata"]["planner"]
     assert planner_meta["risk_register"] == risk_reg
     assert planner_meta["risks"] == ["policy"]
+
+
+def test_markdown_includes_planner_fields():
+    risk_reg = [
+        {"class": "policy", "likelihood": "low", "mitigation": "sanitize"}
+    ]
+    spec = {
+        "report_id": "r1",
+        "title": "T",
+        "planner": {
+            "constraints": ["C1"],
+            "assumptions": ["A1"],
+            "risk_register": risk_reg,
+        },
+    }
+    report = compose(spec, {"agents": [], "synth": {"executive_summary": ""}})
+    md = to_markdown(report)
+    assert "## Constraints / Assumptions" in md
+    assert "- C1" in md and "- A1" in md
+    assert "## Risks" in md
+    assert "- policy" in md


### PR DESCRIPTION
## Summary
- surface Planner metadata in exported Markdown reports
- test that planner-supplied constraints, assumptions, and policy risks reach final reports

## Testing
- `pytest -q` *(fails: ImportError and multiple test failures)*
- `mypy dr_rd`
- `ruff check dr_rd` *(fails: numerous lint issues)*
- `gitleaks detect --source .`


------
https://chatgpt.com/codex/tasks/task_e_68c341457e18832c8d112ab31d5af9e7