### PR TITLE
[Execute] 2025-09-11 – <T5>

### DIFF
--- a/dr_rd/tenancy/policy.py
+++ b/dr_rd/tenancy/policy.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-import os
-from typing import Iterable, Set
+from typing import Iterable
 
 from .models import TenantContext
 
@@ -13,13 +12,7 @@ AUDITOR = "AUDITOR"
 CONFIG = "CONFIG"
 
 
-def _superuser() -> bool:
-    return os.getenv("DRRD_SUPERUSER_MODE") == "1"
-
-
 def _has_role(ctx: TenantContext, roles: Iterable[str]) -> bool:
-    if _superuser():
-        return True
     principal = ctx.principal if ctx else None
     if principal is None or principal.disabled:
         return False

--- a/tests/tenancy/test_rbac_policy.py
+++ b/tests/tenancy/test_rbac_policy.py
@@ -15,8 +15,8 @@ def test_permission_matrix():
     assert policy.can_manage_keys(_ctx(["OWNER"]))
 
 
-def test_superuser(monkeypatch):
+def test_env_superuser_ignored(monkeypatch):
     ctx = _ctx([])
     assert not policy.can_manage_keys(ctx)
     monkeypatch.setenv("DRRD_SUPERUSER_MODE", "1")
-    assert policy.can_manage_keys(ctx)
+    assert not policy.can_manage_keys(ctx)

--- a/tests/test_mode_cleanup.py
+++ b/tests/test_mode_cleanup.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from dr_rd.config.loader import load_config
+
+DEPRECATED_TERMS = [
+    "TEST_MODE",
+    "DRRD_MODE",
+    "deep mode",
+    "DISABLE_IMAGES_BY_DEFAULT",
+    "DRRD_SUPERUSER_MODE",
+]
+
+
+def test_load_config_rejects_non_standard_profile():
+    with pytest.raises(ValueError):
+        load_config("defaults", profile="legacy")
+
+
+def test_no_deprecated_mode_terms():
+    root = pathlib.Path(__file__).resolve().parents[1]
+    bases = [root / "dr_rd", root / "scripts"]
+    for base in bases:
+        if not base.exists():
+            continue
+        for path in base.rglob("*"):
+            if path.is_file():
+                text = path.read_text(encoding="utf-8", errors="ignore")
+                for term in DEPRECATED_TERMS:
+                    assert term not in text, f"{term} found in {path}"


### PR DESCRIPTION
## Summary
- remove deprecated `DRRD_SUPERUSER_MODE` flag and rely purely on role checks
- add tests enforcing standard profile use and verifying absence of legacy mode terms
- ensure RBAC tests confirm environment variable no longer bypasses permissions

## Testing
- `pytest tests/test_mode_cleanup.py tests/tenancy/test_rbac_policy.py -q`
- `pytest -q` *(fails: missing files and module dependencies, e.g. fastapi, streamlit, config paths)*
- `mypy dr_rd`
- `ruff check dr_rd` *(fails: found 743 errors)*
- `gitleaks detect --source .`

------
https://chatgpt.com/codex/tasks/task_e_68c3480d6744832cb872bd527a628ab8