### PR TITLE
Handle string sources in SynthesizerAgent

### DIFF
--- a/core/agents/synthesizer_agent.py
+++ b/core/agents/synthesizer_agent.py
@@ -20,7 +20,11 @@ class SynthesizerAgent(PromptFactoryAgent):
                 if val.get("retrieval_plan") and not val.get("sources"):
                     missing_sources.append(key)
                 for src in val.get("sources", []):
-                    url = src.get("url", "")
+                    # src may be a dict or a direct URL string
+                    if isinstance(src, dict):
+                        url = src.get("url", "")
+                    else:
+                        url = src  # assume string is already a URL
                     canon = url.split("#")[0].rstrip("/")
                     if canon in seen:
                         continue


### PR DESCRIPTION
## Summary
- safely handle source entries that may be URL strings in `SynthesizerAgent`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pptx')*
- `mypy dr_rd`
- `ruff check dr_rd` *(fails: 743 errors)*
- `gitleaks detect` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c361d5b428832cb34383e96db2ac73