### PR TITLE
Align synthesizer prompt inputs with agent

### DIFF
--- a/dr_rd/prompting/prompt_registry.py
+++ b/dr_rd/prompting/prompt_registry.py
@@ -126,7 +126,7 @@ registry.register(
             "**Goal**: “{{ idea | default('') }}”\n\n"
             "We have gathered the following domain findings (some may include "
             'loop-refined addenda separated by "--- *(Loop-refined)* ---"):\n\n'
-            "{{ findings_md | default('') }}\n\n"
+            "{{ materials | default('') }}\n\n"
             "Write a comprehensive final report that brings together the "
             "project concept, researched data, and a build guide. Use clear "
             "Markdown with these sections:\n\n"

--- a/tests/test_final_synthesis_stage.py
+++ b/tests/test_final_synthesis_stage.py
@@ -44,7 +44,7 @@ def test_compose_final_proposal_schema_enforcement(monkeypatch):
         spec = {
             "role": "Synthesizer",
             "task": "compose final report",
-            "inputs": {"idea": idea, "findings_md": materials},
+            "inputs": {"idea": idea, "materials": materials},
             "io_schema_ref": "dr_rd/schemas/synthesizer_v1.json",
             "retrieval_policy": RetrievalPolicy.NONE,
             "capabilities": "summary composer",


### PR DESCRIPTION
## Summary
- sync synthesizer prompt to expect `materials` input
- adjust final synthesis test to use `materials` key

## Testing
- `pytest -q` *(fails: fixture 'page' not found, OpenAI auth error, etc.)*
- `mypy dr_rd`
- `ruff check dr_rd` *(fails: Found 743 errors)*
- `gitleaks detect`


------
https://chatgpt.com/codex/tasks/task_e_68c3662331a8832c9128b39230c65d85