### PR TITLE
[Execute] 2025-09-12 – <TSK-006>

### DIFF
--- a/dr_rd/__init__.py
+++ b/dr_rd/__init__.py
@@ -13,5 +13,12 @@ def get_version() -> str:
 
 __version__ = get_version()
 
+# Ensure legacy planner outputs like "Finance Specialist" resolve to the
+# unified Finance role.
+from core import roles as _core_roles  # noqa: E402
+
+_core_roles.CANON.setdefault("finance specialist", "Finance")
+_core_roles.CANONICAL.setdefault("Finance Specialist", "Finance")
+
 __all__ = ["__version__", "get_version"]
 

--- a/tests/test_roles_canonicalization.py
+++ b/tests/test_roles_canonicalization.py
@@ -1,5 +1,6 @@
 from core.router import choose_agent_for_task
 from core.agents.unified_registry import AGENT_REGISTRY
+import dr_rd  # noqa: F401  # ensure role aliases are patched
 
 
 def _check(role, expected):
@@ -19,3 +20,9 @@ def test_software_engineer_maps():
 
 def test_ux_designer_maps():
     _check("UX/UI Designer", "Marketing Analyst")
+
+
+def test_finance_specialist_maps_to_finance():
+    resolved, cls, _model = choose_agent_for_task("Finance Specialist", "t", "d", None)
+    assert resolved == "Finance"
+    assert cls is AGENT_REGISTRY["Finance"]


### PR DESCRIPTION
## Summary
- Ensure legacy "Finance Specialist" planner outputs resolve to the unified Finance role by patching the core role maps.
- Test routing: verify "Finance Specialist" tasks are dispatched to the Finance agent.

## Testing
- `pytest -q` *(fails: FileNotFoundError, KeyError and other errors; 210 failed, 597 passed, 5 skipped, 5 errors)*
- `mypy dr_rd`
- `ruff check dr_rd` *(fails: Found 748 errors)*
- `gitleaks detect --source .`


------
https://chatgpt.com/codex/tasks/task_e_68c49b637bcc832cace505acbede7da8