### PR TITLE
[Execute] 2025-09-12 – <TSK-007>

### DIFF
--- a/dr_rd/prompting/prompt_registry.py
+++ b/dr_rd/prompting/prompt_registry.py
@@ -123,26 +123,14 @@ registry.register(
         task_key=None,
         system="You are a multi-disciplinary R&D lead.",
         user_template=(
-            "**Goal**: “{{ idea | default('') }}”\n\n"
+            "Goal: {{ idea | default('') }}\n\n"
             "We have gathered the following domain findings (some may include "
-            'loop-refined addenda separated by "--- *(Loop-refined)* ---"):\n\n'
+            'loop-refined addenda separated by "--- *(Loop-refined)* ---")\n\n'
             "{{ materials | default('') }}\n\n"
-            "Write a comprehensive final report that brings together the "
-            "project concept, researched data, and a build guide. Use clear "
-            "Markdown with these sections:\n\n"
-            "- ## Executive Summary\n"
-            "- ## Key Results\n"
-            "- ## Problem & Value\n"
-            "- ## Research Findings\n"
-            "- ## Risks & Unknowns\n"
-            "- ## Architecture & Interfaces\n"
-            "- ## Regulatory & Compliance\n"
-            "- ## IP & Prior Art\n"
-            "- ## Market & GTM\n"
-            "- ## Cost Overview\n"
-            "- ## Gaps and Unresolved Issues\n"
-            "- ## Next Steps\n\n"
-            "Summarize the most important findings in 'Key Results'."
+            "Produce a final project analysis as JSON following the schema "
+            "fields: summary, key_points, contradictions, confidence, "
+            "sources, citations_json, role, task, findings, risks, and "
+            "next_steps. Return only valid JSON with no markdown."
         ),
         io_schema_ref="dr_rd/schemas/synthesizer_agent.json",
         retrieval_policy=RetrievalPolicy.NONE,

--- a/tests/test_legacy_prompt_removed.py
+++ b/tests/test_legacy_prompt_removed.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+from dr_rd.prompting import registry
+
+
+def test_synthesizer_prompt_no_legacy_headings():
+    tpl = registry.get("Synthesizer")
+    assert tpl is not None
+    legacy_headings = ["## Regulatory & Compliance", "## IP & Prior Art"]
+    for heading in legacy_headings:
+        assert heading not in tpl.user_template
+
+
+def test_no_legacy_strings_in_dr_rd():
+    root = Path(__file__).resolve().parents[1] / "dr_rd"
+    legacy_headings = ["## Regulatory & Compliance", "## IP & Prior Art"]
+    for path in root.rglob("*"):
+        if path.is_file():
+            try:
+                text = path.read_text(encoding="utf-8")
+            except UnicodeDecodeError:
+                continue
+            for heading in legacy_headings:
+                assert heading not in text, f"{heading} found in {path}"


### PR DESCRIPTION
## Summary
- remove deprecated sectioned final report prompt in `PromptRegistry` to focus on JSON-based schema
- add tests ensuring legacy prompt headings are absent in the codebase

## Testing
- `pytest -q tests/test_legacy_prompt_removed.py`
- `pytest -q` *(fails: 25 failed, 5 errors)*
- `mypy dr_rd` *(terminated: no output)*
- `ruff check dr_rd` *(fails: 748 errors)*
- `gitleaks detect --source .`


------
https://chatgpt.com/codex/tasks/task_e_68c4a379542c832ca5c71feee6e12a2d