### PR TITLE
[Execute] 2025-09-12 – <TSK-008>

### DIFF
--- a/dr_rd/reporting/composer.py
+++ b/dr_rd/reporting/composer.py
@@ -20,7 +20,13 @@ def compose(spec: dict[str, Any], artifacts: dict[str, Any]) -> dict[str, Any]:
     processed_sections, bundled_sources = bundle_citations(sections_data)
     sections = []
     for a, body in zip(agents, processed_sections):
-        sections.append({"heading": a.get("title", a.get("role", "")), "body_md": body})
+        sections.append(
+            {
+                "heading": a.get("title", a.get("role", "")),
+                "body_md": body,
+                "group": a.get("group"),
+            }
+        )
     planner_meta = spec.get("planner", {}).copy()
     risk_reg = planner_meta.get("risk_register")
     if isinstance(risk_reg, list):

--- a/dr_rd/reporting/exporters.py
+++ b/dr_rd/reporting/exporters.py
@@ -1,14 +1,24 @@
 from __future__ import annotations
 
 import html
-import json
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 
 def to_markdown(report: Dict) -> str:
     lines: List[str] = [f"# {report['title']}", "", report.get("executive_summary", ""), ""]
-    for sec in report.get("sections", []):
-        lines.append(f"## {sec['heading']}")
+    sections = report.get("sections", [])
+    grouped_mode = any(s.get("group") for s in sections)
+    current_group: Optional[str] = None
+    for sec in sections:
+        group = sec.get("group")
+        if grouped_mode and group:
+            if group != current_group:
+                lines.append(f"## {group}")
+                lines.append("")
+                current_group = group
+            lines.append(f"### {sec['heading']}")
+        else:
+            lines.append(f"## {sec['heading']}")
         lines.append(sec.get("body_md", ""))
         lines.append("")
     planner = report.get("metadata", {}).get("planner", {})

--- a/dr_rd/reporting/schemas/report_v1.json
+++ b/dr_rd/reporting/schemas/report_v1.json
@@ -13,7 +13,8 @@
         "required": ["heading", "body_md"],
         "properties": {
           "heading": {"type": "string"},
-          "body_md": {"type": "string"}
+          "body_md": {"type": "string"},
+          "group": {"type": ["string", "null"]}
         }
       }
     },

--- a/tests/test_report_composer.py
+++ b/tests/test_report_composer.py
@@ -71,3 +71,25 @@ def test_markdown_includes_planner_fields():
     assert "- C1" in md and "- A1" in md
     assert "## Risks" in md
     assert "- policy" in md
+
+
+def test_compose_groups_sections_by_group():
+    spec = {"report_id": "r1", "title": "T"}
+    artifacts = {
+        "agents": [
+            {"role": "A", "title": "A1", "body": "alpha", "group": "Phase 1"},
+            {"role": "B", "title": "B1", "body": "beta", "group": "Phase 1"},
+            {"role": "C", "title": "C1", "body": "gamma", "group": "Phase 2"},
+        ],
+        "synth": {"executive_summary": ""},
+    }
+    report = compose(spec, artifacts)
+    assert [s.get("group") for s in report["sections"]] == [
+        "Phase 1",
+        "Phase 1",
+        "Phase 2",
+    ]
+    md = to_markdown(report)
+    assert "## Phase 1" in md and "## Phase 2" in md
+    assert md.index("## Phase 1") < md.index("### A1") < md.index("### B1")
+    assert md.index("## Phase 2") < md.index("### C1")


### PR DESCRIPTION
## Summary
- support task grouping metadata in report composition
- render grouped sections in markdown output
- validate groups in report schema and cover with tests

## Testing
- `pytest -q` *(fails: many tests fail; see log for details)*
- `mypy dr_rd`
- `ruff dr_rd` *(fails: unrecognized subcommand and lint errors; see log)*
- `gitleaks detect --source .`


------
https://chatgpt.com/codex/tasks/task_e_68c4a5d9f308832c89df4ffbd478a377