### PR TITLE
Normalize synthesizer confidence to numeric values

### DIFF
--- a/core/agents/confidence.py
+++ b/core/agents/confidence.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+"""Utilities for handling agent confidence values."""
+
+from typing import Union, Optional
+
+# Mapping of descriptive terms to normalized numeric scores.
+CONFIDENCE_MAP = {
+    "high": 0.9,
+    "moderate": 0.6,
+    "medium": 0.6,
+    "low": 0.3,
+}
+
+
+def normalize_confidence(value: Optional[Union[str, int, float]]) -> Optional[Union[int, float]]:
+    """Return a numeric confidence value.
+
+    Descriptive strings are mapped to floats in the range [0,1]. Numeric
+    inputs are returned unchanged to preserve backward compatibility.
+    Unknown strings fall back to a neutral 0.5 score.
+    """
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return value
+    if isinstance(value, str):
+        key = value.strip().lower()
+        for phrase, score in CONFIDENCE_MAP.items():
+            if phrase in key:
+                return score
+        return 0.5
+    return None

--- a/core/agents/prompt_agent.py
+++ b/core/agents/prompt_agent.py
@@ -14,6 +14,7 @@ from dr_rd.prompting.prompt_registry import RetrievalPolicy
 from utils.logging import logger
 from utils.json_fixers import attempt_auto_fix
 from utils.agent_json import clean_json_payload
+from core.agents.confidence import normalize_confidence
 
 
 class AgentRunResult(str):
@@ -122,6 +123,9 @@ class PromptFactoryAgent(LLMRoleAgent):
                 data = clean_json_payload(data, schema)
                 data = coerce_types(data, schema)
                 data = strip_additional_properties(data, schema)
+                if "confidence" in data:
+                    # Convert textual descriptors like "High" to numeric scores
+                    data["confidence"] = normalize_confidence(data["confidence"])
                 jsonschema.validate(data, schema)
             valid = True
         except Exception as e:
@@ -137,6 +141,9 @@ class PromptFactoryAgent(LLMRoleAgent):
                     data = clean_json_payload(data, schema)
                     data = coerce_types(data, schema)
                     data = strip_additional_properties(data, schema)
+                    if "confidence" in data:
+                        # Ensure confidence is numeric before validation
+                        data["confidence"] = normalize_confidence(data["confidence"])
                     jsonschema.validate(data, schema)
                 valid = True
                 logger.info(
@@ -197,6 +204,9 @@ class PromptFactoryAgent(LLMRoleAgent):
                 data = clean_json_payload(data, fallback_schema)
                 data = coerce_types(data, fallback_schema)
                 data = strip_additional_properties(data, fallback_schema)
+                if "confidence" in data:
+                    # Normalize textual confidence before final validation
+                    data["confidence"] = normalize_confidence(data["confidence"])
                 jsonschema.validate(data, fallback_schema)
             valid = True
         except Exception as e:

--- a/core/agents/synthesizer_agent.py
+++ b/core/agents/synthesizer_agent.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Dict, List
 
 from core.agents.prompt_agent import PromptFactoryAgent
+from core.agents.confidence import normalize_confidence
 from dr_rd.prompting.prompt_registry import RetrievalPolicy
 from core.llm import select_model
 from dr_rd.telemetry import metrics
@@ -45,6 +46,8 @@ class SynthesizerAgent(PromptFactoryAgent):
         if sources or safety or missing_sources:
             import json
             data = json.loads(result)
+            # Always normalize confidence to a numeric value for downstream math
+            data["confidence"] = normalize_confidence(data.get("confidence", 1.0))
             if sources:
                 data.setdefault("sources", [])
                 for src in sources:

--- a/tests/test_confidence_normalization.py
+++ b/tests/test_confidence_normalization.py
@@ -1,0 +1,68 @@
+import json
+import os
+from unittest.mock import patch
+
+import pytest
+
+from core.agents.confidence import normalize_confidence
+from core.agents.synthesizer_agent import compose_final_proposal
+from core.agents.prompt_agent import PromptFactoryAgent
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("High confidence", 0.9),
+        ("Moderate confidence", 0.6),
+        ("Low confidence", 0.3),
+        ("unknown", 0.5),
+    ],
+)
+def test_normalize_confidence_textual(text, expected):
+    assert normalize_confidence(text) == expected
+
+
+@patch.dict(os.environ, {"OPENAI_API_KEY": "x"})
+def test_synthesizer_converts_confidence(monkeypatch):
+    def fake_act(self, system, user, response_format=None, **kwargs):
+        return json.dumps(
+            {
+                "summary": "Overview",
+                "key_points": [],
+                "role": "Synthesizer",
+                "task": "compose final report",
+                "findings": "analysis",
+                "risks": [],
+                "next_steps": [],
+                "confidence": "High confidence in market demand",
+                "sources": [],
+            }
+        )
+
+    monkeypatch.setattr(PromptFactoryAgent, "act", fake_act)
+    out = compose_final_proposal("idea", {})
+    data = json.loads(out)
+    assert data["confidence"] == 0.9
+
+
+@patch.dict(os.environ, {"OPENAI_API_KEY": "x"})
+def test_synthesizer_preserves_numeric_confidence(monkeypatch):
+    def fake_act(self, system, user, response_format=None, **kwargs):
+        return json.dumps(
+            {
+                "summary": "Overview",
+                "key_points": [],
+                "role": "Synthesizer",
+                "task": "compose final report",
+                "findings": "analysis",
+                "risks": [],
+                "next_steps": [],
+                "confidence": 0.8,
+                "sources": [],
+            }
+        )
+
+    monkeypatch.setattr(PromptFactoryAgent, "act", fake_act)
+    out = compose_final_proposal("idea", {})
+    data = json.loads(out)
+    assert data["confidence"] == 0.8


### PR DESCRIPTION
## Summary
- ensure synthesizer agent converts textual confidence to numeric
- add helper `normalize_confidence` and integrate into prompt processing
- cover confidence normalization with tests

## Testing
- `pytest -q` (fails: 25 failed, 131 passed, 4 skipped, 5 errors)
- `mypy dr_rd`
- `ruff check dr_rd` (found lint errors)
- `gitleaks detect`


------
https://chatgpt.com/codex/tasks/task_e_68c4bf20e558832cb7e9836cfbd841da