### PR TITLE
[Execute] 2025-09-16 – <PL1>

### DIFF
--- a/dr_rd/prompting/prompt_registry.py
+++ b/dr_rd/prompting/prompt_registry.py
@@ -85,8 +85,10 @@ registry.register(
         task_key=None,
         system=(
             "You are the Planner. Output ONLY a JSON object of the form "
-            '{"tasks": []}. Each task MUST contain non-empty strings: id, '
-            "title, summary, description, role. Allowed roles: "
+            '{"tasks": []}. Each task MUST contain the fields id, title, '
+            "summary, description, role, inputs, outputs, and constraints. "
+            "Use arrays of strings for inputs, outputs, and constraints. "
+            "Allowed roles: "
             '["CTO","Research Scientist","Regulatory","Finance","Marketing '
             'Analyst","IP Analyst","HRM","Materials Engineer","QA",'
             '"Simulation","Dynamic Specialist"]. Each task should include a '
@@ -94,17 +96,17 @@ registry.register(
             "should default to 'Dynamic Specialist'. Prefer ids "
             '"T01","T02", etc. If the user supplies ids, convert to that '
             "format. Produce at least six tasks spanning design/architecture, "
-            "materials, regulatory/IP, finance, marketing, and QA/testing.\n"
+            "materials, regulatory/IP, finance, marketing, and QA/testing. Do not reference the overall idea in any field. Keep task descriptions neutral and redact sensitive context.\n"
             "Required JSON keys:\n"
             "- tasks\n"
             "Do not use markdown formatting in any JSON field (no '-' or '*' bullets and no multi-line lists).\n"
             "All listed keys must appear (use empty strings/arrays or 'Not determined' when no data is available) and no other keys may be added.\n"
             "Example:\n"
-            '{"tasks": [{"id": "T01", "title": "<TASK_TITLE>", "summary": "", "description": "", "role": "CTO"}]}\n'
+            '{"tasks": [{"id": "T01", "title": "<TASK_TITLE>", "summary": "", "description": "", "role": "CTO", "inputs": [], "outputs": [], "constraints": []}]}\n'
             "Incorrect Example:\n"
-            '{"tasks": [{"id": "T01", "title": "- item1\\n- item2", "summary": "", "description": "", "role": "CTO"}]}\n'
+            '{"tasks": [{"id": "T01", "title": "- item1\\n- item2", "summary": "", "description": "", "role": "CTO", "inputs": [], "outputs": [], "constraints": []}]}\n'
             "Explanation: markdown-style bullets inside string fields break the JSON schema.\n"
-            'If required information is missing, return {"error":"MISSING_INFO","needs":[]} instead of empty fields.'
+            'If required information is missing, return {"error":"MISSING_INFO","needs":[]} instead of leaking the idea.'
         ),
         user_template=(
             "Project idea: {{ idea | default('') }}{{ constraints_section | default('') }}{{ risk_section | default('') }}\n\n"

--- a/dr_rd/schemas/planner_v1.json
+++ b/dr_rd/schemas/planner_v1.json
@@ -19,12 +19,41 @@
           },
           "summary": {
             "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string"
+          },
+          "inputs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "outputs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "constraints": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "required": [
           "id",
           "title",
-          "summary"
+          "summary",
+          "description",
+          "role",
+          "inputs",
+          "outputs",
+          "constraints"
         ],
         "additionalProperties": false
       }

--- a/tests/eval/test_compartmentalization.py
+++ b/tests/eval/test_compartmentalization.py
@@ -1,0 +1,81 @@
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from dr_rd.prompting import registry
+
+
+@pytest.fixture(scope="module")
+def planner_schema():
+    schema_path = Path("dr_rd/schemas/planner_v1.json")
+    return json.loads(schema_path.read_text())
+
+
+def test_planner_schema_requires_extended_task_fields(planner_schema):
+    plan = {
+        "plan_id": "plan-001",
+        "tasks": [
+            {
+                "id": "T01",
+                "title": "Scoping",
+                "summary": "Scope technical work",
+                "description": "Outline architecture milestones.",
+                "role": "CTO",
+                "inputs": ["Not determined"],
+                "outputs": ["Architecture outline"],
+                "constraints": ["Budget cap"],
+            }
+        ],
+        "constraints": "Budget cap",
+        "assumptions": "",
+        "metrics": "",
+        "next_steps": "Continue",
+        "role": "Planner",
+        "task": "Organize",
+        "findings": "Neutral summary",
+        "risks": ["Timeline"],
+        "sources": ["Internal"],
+    }
+    jsonschema.validate(plan, planner_schema)
+
+
+def test_planner_schema_rejects_missing_extended_fields(planner_schema):
+    plan = {
+        "plan_id": "plan-001",
+        "tasks": [
+            {
+                "id": "T01",
+                "title": "Scoping",
+                "summary": "Scope technical work",
+                "description": "Outline architecture milestones.",
+                "role": "CTO",
+                "outputs": ["Architecture outline"],
+                "constraints": ["Budget cap"],
+            }
+        ],
+        "constraints": "Budget cap",
+        "assumptions": "",
+        "metrics": "",
+        "next_steps": "Continue",
+        "role": "Planner",
+        "task": "Organize",
+        "findings": "Neutral summary",
+        "risks": ["Timeline"],
+        "sources": ["Internal"],
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(plan, planner_schema)
+
+
+def test_planner_prompt_instructs_compartmentalized_fields():
+    tpl = registry.get("Planner")
+    assert tpl is not None
+    system = tpl.system
+    assert "inputs" in system
+    assert "outputs" in system
+    assert "constraints" in system
+    assert "Do not reference the overall idea" in system
+    assert "Keep task descriptions neutral" in system
+    assert '"constraints": []' in system


### PR DESCRIPTION
## Summary
- extend the planner output schema so every task requires description, role, inputs, outputs, and constraints alongside the existing identifiers
- refresh the planner prompt instructions to call out the new fields, enforce neutral task phrasing, and prevent leaking the overall idea
- add compartmentalization tests that validate the schema changes and ensure the planner prompt mentions the mandated fields and guardrails

## Testing
- pytest -q *(fails: numerous existing integration/UI tests require unavailable services and fixtures)*
- mypy dr_rd
- ruff dr_rd *(fails: the CLI expects `ruff check`; `ruff check dr_rd` reports pre-existing typing modernisation errors across the codebase)*
- gitleaks detect --source .

------
https://chatgpt.com/codex/tasks/task_e_68c9cf2c5468832c8103393f80265e7a