### PR TITLE
[Execute] 2025-09-16 – <PL2>

### DIFF
--- a/dr_rd/prompting/prompt_registry.py
+++ b/dr_rd/prompting/prompt_registry.py
@@ -87,7 +87,9 @@ registry.register(
             "You are the Planner. Output ONLY a JSON object of the form "
             '{"tasks": []}. Each task MUST contain the fields id, title, '
             "summary, description, role, inputs, outputs, and constraints. "
-            "Use arrays of strings for inputs, outputs, and constraints. "
+            "Use arrays of strings for inputs, outputs, and constraints. Populate them even when uncertain (use \"Not determined\" for unknown entries). "
+            "Inputs = prerequisites or data the assignee needs. Outputs = deliverables or decisions produced. Constraints = guardrails, policies, or limits to respect. "
+            "Keep titles, summaries, descriptions, inputs, outputs, and constraints neutral. Do not reference or hint at the overall project idea in any field. "
             "Allowed roles: "
             '["CTO","Research Scientist","Regulatory","Finance","Marketing '
             'Analyst","IP Analyst","HRM","Materials Engineer","QA",'
@@ -96,7 +98,7 @@ registry.register(
             "should default to 'Dynamic Specialist'. Prefer ids "
             '"T01","T02", etc. If the user supplies ids, convert to that '
             "format. Produce at least six tasks spanning design/architecture, "
-            "materials, regulatory/IP, finance, marketing, and QA/testing. Do not reference the overall idea in any field. Keep task descriptions neutral and redact sensitive context.\n"
+            "materials, regulatory/IP, finance, marketing, and QA/testing. Redact sensitive context.\n"
             "Required JSON keys:\n"
             "- tasks\n"
             "Do not use markdown formatting in any JSON field (no '-' or '*' bullets and no multi-line lists).\n"

--- a/tests/eval/test_compartmentalization.py
+++ b/tests/eval/test_compartmentalization.py
@@ -73,9 +73,14 @@ def test_planner_prompt_instructs_compartmentalized_fields():
     tpl = registry.get("Planner")
     assert tpl is not None
     system = tpl.system
-    assert "inputs" in system
-    assert "outputs" in system
-    assert "constraints" in system
-    assert "Do not reference the overall idea" in system
-    assert "Keep task descriptions neutral" in system
-    assert '"constraints": []' in system
+    assert (
+        "Each task MUST contain the fields id, title, summary, description, role, inputs, outputs, and constraints." in system
+    )
+    assert "Inputs = prerequisites or data the assignee needs" in system
+    assert "Outputs = deliverables or decisions produced" in system
+    assert "Constraints = guardrails, policies, or limits to respect" in system
+    assert "Populate them even when uncertain" in system
+    assert (
+        "Keep titles, summaries, descriptions, inputs, outputs, and constraints neutral." in system
+    )
+    assert "Do not reference or hint at the overall project idea in any field." in system


### PR DESCRIPTION
## Summary
- tighten the Planner prompt guidance so each task lists inputs, outputs, and constraints with neutral language and no idea leakage
- extend the compartmentalization test to assert the new Planner instructions for inputs, outputs, constraints, and neutral phrasing

## Testing
- pytest -q *(fails: missing optional dependencies `pptx` and `fastapi`)*
- mypy dr_rd
- ruff dr_rd *(fails: modern CLI expects `ruff check`)*
- ruff check dr_rd *(fails: repository has existing lint violations)*
- gitleaks detect --source . *(fails: `gitleaks` command unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d2e604dc832cb35876c3fe70d43b