### PR TITLE
[Execute] 2025-09-16 – <AG2>

### DIFF
--- a/core/agents/chief_scientist_agent.py
+++ b/core/agents/chief_scientist_agent.py
@@ -2,16 +2,17 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.agents.prompt_agent import PromptFactoryAgent
+from core.agents.prompt_agent import PromptFactoryAgent, prepare_prompt_inputs
 from dr_rd.prompting.prompt_registry import RetrievalPolicy
 
 
 class ChiefScientistAgent(PromptFactoryAgent):
     def act(self, idea: str, task: Any = None, **kwargs) -> str:
+        text = task.get("description", "") if isinstance(task, dict) else str(task or "")
         spec = {
             "role": "Chief Scientist",
-            "task": str(task or ""),
-            "inputs": {"idea": idea, "task": str(task or "")},
+            "task": text,
+            "inputs": prepare_prompt_inputs(task),
             "io_schema_ref": "dr_rd/schemas/chief_scientist_v1.json",
             "retrieval_policy": RetrievalPolicy.LIGHT,
             "capabilities": "integrate findings",

--- a/core/agents/cto_agent.py
+++ b/core/agents/cto_agent.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.agents.prompt_agent import PromptFactoryAgent
+from core.agents.prompt_agent import PromptFactoryAgent, prepare_prompt_inputs
 from core.agents.tool_use import should_use_tool
 from dr_rd.prompting.prompt_registry import RetrievalPolicy
 
@@ -15,13 +15,11 @@ class CTOAgent(PromptFactoryAgent):
                 self.run_tool(tool_req["tool"], tool_req.get("params", {}))
             except Exception:  # pragma: no cover - best effort
                 pass
+        text = task.get("description", "") if isinstance(task, dict) else str(task or "")
         spec = {
             "role": "CTO",
-            "task": task.get("description", "") if isinstance(task, dict) else str(task or ""),
-            "inputs": {
-                "idea": idea,
-                "task": task.get("description", "") if isinstance(task, dict) else str(task or ""),
-            },
+            "task": text,
+            "inputs": prepare_prompt_inputs(task),
             "io_schema_ref": "dr_rd/schemas/cto_v2.json",
             "retrieval_policy": RetrievalPolicy.LIGHT,
             "capabilities": "technical strategy",

--- a/core/agents/finance_agent.py
+++ b/core/agents/finance_agent.py
@@ -2,19 +2,17 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.agents.prompt_agent import PromptFactoryAgent
+from core.agents.prompt_agent import PromptFactoryAgent, prepare_prompt_inputs
 from dr_rd.prompting.prompt_registry import RetrievalPolicy
 
 
 class FinanceAgent(PromptFactoryAgent):
     def act(self, idea: str, task: Any = None, **kwargs) -> str:
+        text = task.get("description", "") if isinstance(task, dict) else str(task or "")
         spec = {
             "role": "Finance",
-            "task": task.get("description", "") if isinstance(task, dict) else str(task or ""),
-            "inputs": {
-                "idea": idea,
-                "task": task.get("description", "") if isinstance(task, dict) else str(task or ""),
-            },
+            "task": text,
+            "inputs": prepare_prompt_inputs(task),
             "io_schema_ref": "dr_rd/schemas/finance_v2.json",
             "retrieval_policy": RetrievalPolicy.LIGHT,
             "capabilities": "budgeting and costs",

--- a/core/agents/hrm_agent.py
+++ b/core/agents/hrm_agent.py
@@ -2,16 +2,17 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.agents.prompt_agent import PromptFactoryAgent
+from core.agents.prompt_agent import PromptFactoryAgent, prepare_prompt_inputs
 from dr_rd.prompting.prompt_registry import RetrievalPolicy
 
 
 class HRMAgent(PromptFactoryAgent):
     def act(self, idea: str, task: Any = None, **kwargs) -> str:
+        text = task.get("description", "") if isinstance(task, dict) else str(task or "")
         spec = {
             "role": "HRM",
-            "task": str(task or ""),
-            "inputs": {"idea": idea, "task": str(task or "")},
+            "task": text,
+            "inputs": prepare_prompt_inputs(task),
             "io_schema_ref": "dr_rd/schemas/hrm_v2.json",
             "retrieval_policy": RetrievalPolicy.NONE,
             "capabilities": "role mapping",

--- a/core/agents/ip_analyst_agent.py
+++ b/core/agents/ip_analyst_agent.py
@@ -6,7 +6,7 @@ from typing import Any
 import yaml
 
 from config import feature_flags
-from core.agents.prompt_agent import PromptFactoryAgent
+from core.agents.prompt_agent import PromptFactoryAgent, prepare_prompt_inputs
 from dr_rd.prompting.prompt_registry import RetrievalPolicy
 
 
@@ -16,13 +16,11 @@ class IPAnalystAgent(PromptFactoryAgent):
         with open(budgets_path, encoding="utf-8") as fh:
             budgets = yaml.safe_load(fh) or {}
         top_k = budgets.get(feature_flags.BUDGET_PROFILE, {}).get("exec", {}).get("top_k", 5)
+        text = task.get("description", "") if isinstance(task, dict) else str(task or "")
         spec = {
             "role": "IP Analyst",
-            "task": task.get("description", "") if isinstance(task, dict) else str(task or ""),
-            "inputs": {
-                "idea": idea,
-                "task": task.get("description", "") if isinstance(task, dict) else str(task or ""),
-            },
+            "task": text,
+            "inputs": prepare_prompt_inputs(task),
             "io_schema_ref": "dr_rd/schemas/ip_analyst_v2.json",
             "retrieval_policy": RetrievalPolicy.AGGRESSIVE,
             "top_k": top_k,

--- a/core/agents/marketing_agent.py
+++ b/core/agents/marketing_agent.py
@@ -2,19 +2,17 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.agents.prompt_agent import PromptFactoryAgent
+from core.agents.prompt_agent import PromptFactoryAgent, prepare_prompt_inputs
 from dr_rd.prompting.prompt_registry import RetrievalPolicy
 
 
 class MarketingAgent(PromptFactoryAgent):
     def act(self, idea: str, task: Any = None, **kwargs) -> str:
+        text = task.get("description", "") if isinstance(task, dict) else str(task or "")
         spec = {
             "role": "Marketing Analyst",
-            "task": task.get("description", "") if isinstance(task, dict) else str(task or ""),
-            "inputs": {
-                "idea": idea,
-                "task": task.get("description", "") if isinstance(task, dict) else str(task or ""),
-            },
+            "task": text,
+            "inputs": prepare_prompt_inputs(task),
             "io_schema_ref": "dr_rd/schemas/marketing_v2.json",
             "retrieval_policy": RetrievalPolicy.LIGHT,
             "capabilities": "market analysis",

--- a/core/agents/materials_engineer_agent.py
+++ b/core/agents/materials_engineer_agent.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.agents.prompt_agent import PromptFactoryAgent
+from core.agents.prompt_agent import PromptFactoryAgent, prepare_prompt_inputs
 from dr_rd.prompting.prompt_registry import RetrievalPolicy
 
 
@@ -10,14 +10,11 @@ class MaterialsEngineerAgent(PromptFactoryAgent):
     """Prompt-based agent for materials tasks with a simple call signature."""
 
     def __call__(self, task: Any, model: str | None = None, meta: dict | None = None) -> str:
-        idea = ""
-        if isinstance(meta, dict):
-            idea = meta.get("context", "")
         text = task.get("description", "") if isinstance(task, dict) else str(task or "")
         spec = {
             "role": "Materials Engineer",
             "task": text,
-            "inputs": {"idea": idea, "task": text},
+            "inputs": prepare_prompt_inputs(task),
             "io_schema_ref": "dr_rd/schemas/materials_engineer_v2.json",
             "retrieval_policy": RetrievalPolicy.LIGHT,
             "capabilities": "materials selection",

--- a/core/agents/mechanical_systems_lead_agent.py
+++ b/core/agents/mechanical_systems_lead_agent.py
@@ -2,19 +2,17 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.agents.prompt_agent import PromptFactoryAgent
+from core.agents.prompt_agent import PromptFactoryAgent, prepare_prompt_inputs
 from dr_rd.prompting.prompt_registry import RetrievalPolicy
 
 
 class MechanicalSystemsLeadAgent(PromptFactoryAgent):
     def act(self, idea: str, task: Any = None, **kwargs) -> str:
+        text = task.get("description", "") if isinstance(task, dict) else str(task or "")
         spec = {
             "role": "Mechanical Systems Lead",
-            "task": task.get("description", "") if isinstance(task, dict) else str(task or ""),
-            "inputs": {
-                "idea": idea,
-                "task": task.get("description", "") if isinstance(task, dict) else str(task or ""),
-            },
+            "task": text,
+            "inputs": prepare_prompt_inputs(task),
             "io_schema_ref": "dr_rd/schemas/mechanical_systems_lead_v1.json",
             "retrieval_policy": RetrievalPolicy.LIGHT,
             "capabilities": "mechanical design",

--- a/core/agents/patent_agent.py
+++ b/core/agents/patent_agent.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.agents.prompt_agent import PromptFactoryAgent
+from core.agents.prompt_agent import PromptFactoryAgent, prepare_prompt_inputs
 from dr_rd.prompting.prompt_registry import RetrievalPolicy
 
 
@@ -10,13 +10,11 @@ class PatentAgent(PromptFactoryAgent):
     """Patent Agent for intellectual property and patentability analysis."""
 
     def act(self, idea: str, task: Any = None, **kwargs) -> str:
+        text = task.get("description", "") if isinstance(task, dict) else str(task or "")
         spec = {
             "role": "Patent",
-            "task": task.get("description", "") if isinstance(task, dict) else str(task or ""),
-            "inputs": {
-                "idea": idea,
-                "task": task.get("description", "") if isinstance(task, dict) else str(task or ""),
-            },
+            "task": text,
+            "inputs": prepare_prompt_inputs(task),
             "io_schema_ref": "dr_rd/schemas/generic_v2.json",
             "retrieval_policy": RetrievalPolicy.AGGRESSIVE,
             "capabilities": "patent analysis",

--- a/core/agents/planner_agent.py
+++ b/core/agents/planner_agent.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 import json
 
-from core.agents.prompt_agent import PromptFactoryAgent
+from core.agents.prompt_agent import PromptFactoryAgent, prepare_prompt_inputs
 from dr_rd.prompting.prompt_registry import RetrievalPolicy
 from core.llm import select_model
 from config import feature_flags
@@ -12,10 +12,12 @@ from core.safety_gate import preflight
 
 class PlannerAgent(PromptFactoryAgent):
     def act(self, idea: str, task: Any = None, **kwargs) -> str:
+        text = str(task or "")
+        inputs = prepare_prompt_inputs(task)
         spec = {
             "role": "Planner",
-            "task": str(task or ""),
-            "inputs": {"idea": idea, "task": str(task or "")},
+            "task": text,
+            "inputs": inputs,
             "io_schema_ref": "dr_rd/schemas/planner_v1.json",
             "retrieval_policy": RetrievalPolicy.LIGHT,
             "capabilities": "task planning",

--- a/core/agents/qa_agent.py
+++ b/core/agents/qa_agent.py
@@ -11,7 +11,11 @@ from jsonschema import validate
 from core.llm import complete
 from core.tool_router import allow_tools, call_tool
 from dr_rd.prompting import PromptFactory, RetrievalPolicy
-from core.agents.prompt_agent import coerce_types, strip_additional_properties
+from core.agents.prompt_agent import (
+    coerce_types,
+    strip_additional_properties,
+    prepare_prompt_inputs,
+)
 
 
 class QAAgent:
@@ -43,17 +47,19 @@ class QAAgent:
         )
         coverage = call_tool(self.ROLE, "compute_test_coverage", {"matrix": matrix})
         stats = call_tool(self.ROLE, "classify_defects", {"defects": defects})
-        spec = {
-            "role": self.ROLE,
-            "task": task_txt,
-            "inputs": {
-                "idea": idea,
-                "task": task_txt,
+        inputs = prepare_prompt_inputs(task)
+        inputs.update(
+            {
                 "context": context,
                 "matrix": matrix,
                 "coverage": coverage,
                 "defects": stats,
-            },
+            }
+        )
+        spec = {
+            "role": self.ROLE,
+            "task": task_txt,
+            "inputs": inputs,
             "io_schema_ref": self.IO_SCHEMA,
             "retrieval_policy": RetrievalPolicy.NONE,
         }

--- a/core/agents/reflection_agent.py
+++ b/core/agents/reflection_agent.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from core.agents.prompt_agent import PromptFactoryAgent
+from core.agents.prompt_agent import PromptFactoryAgent, prepare_prompt_inputs
 from dr_rd.prompting.prompt_registry import RetrievalPolicy
 
 
@@ -28,10 +28,12 @@ class ReflectionAgent(PromptFactoryAgent):
         if not any(_has_placeholder(v) for v in data.values()):
             return "no further tasks"
 
+        inputs = prepare_prompt_inputs(task)
+        inputs.setdefault("task_payload", task_str)
         spec = {
             "role": "Reflection",
             "task": task_str,
-            "inputs": {"idea": idea, "task": task_str},
+            "inputs": inputs,
             "io_schema_ref": "dr_rd/schemas/reflection_v1.json",
             "retrieval_policy": RetrievalPolicy.NONE,
             "capabilities": "self critique",

--- a/core/agents/regulatory_agent.py
+++ b/core/agents/regulatory_agent.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.agents.prompt_agent import PromptFactoryAgent
+from core.agents.prompt_agent import PromptFactoryAgent, prepare_prompt_inputs
 from dr_rd.prompting.prompt_registry import RetrievalPolicy
 
 COMPLIANCE_KEYWORDS = ["compliance", "cfr", "docket", "regulations.gov"]
@@ -18,13 +18,11 @@ class RegulatoryAgent(PromptFactoryAgent):
         policy = RetrievalPolicy.LIGHT
         if any(k in text.lower() for k in COMPLIANCE_KEYWORDS):
             policy = RetrievalPolicy.AGGRESSIVE
+        base_task = task.get("description", "") if isinstance(task, dict) else str(task or "")
         spec = {
             "role": "Regulatory",
-            "task": task.get("description", "") if isinstance(task, dict) else str(task or ""),
-            "inputs": {
-                "idea": idea,
-                "task": task.get("description", "") if isinstance(task, dict) else str(task or ""),
-            },
+            "task": base_task,
+            "inputs": prepare_prompt_inputs(task),
             "io_schema_ref": "dr_rd/schemas/regulatory_v2.json",
             "retrieval_policy": policy,
             "capabilities": "compliance analysis",

--- a/core/agents/regulatory_specialist_agent.py
+++ b/core/agents/regulatory_specialist_agent.py
@@ -2,16 +2,17 @@ from __future__ import annotations
 
 from typing import Any
 
-from core.agents.prompt_agent import PromptFactoryAgent
+from core.agents.prompt_agent import PromptFactoryAgent, prepare_prompt_inputs
 from dr_rd.prompting.prompt_registry import RetrievalPolicy
 
 
 class RegulatorySpecialistAgent(PromptFactoryAgent):
     def act(self, idea: str, task: Any = None, **kwargs) -> str:
+        text = task.get("description", "") if isinstance(task, dict) else str(task or "")
         spec = {
             "role": "Regulatory Specialist",
-            "task": str(task or ""),
-            "inputs": {"idea": idea, "task": str(task or "")},
+            "task": text,
+            "inputs": prepare_prompt_inputs(task),
             "io_schema_ref": "dr_rd/schemas/regulatory_specialist_v1.json",
             "retrieval_policy": RetrievalPolicy.LIGHT,
             "capabilities": "compliance review",

--- a/core/agents/research_scientist_agent.py
+++ b/core/agents/research_scientist_agent.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from core.agents.prompt_agent import PromptFactoryAgent
+from core.agents.prompt_agent import PromptFactoryAgent, prepare_prompt_inputs
 from core.agents.tool_use import should_use_tool
 from dr_rd.prompting.prompt_registry import RetrievalPolicy
 
@@ -18,13 +18,11 @@ class ResearchScientistAgent(PromptFactoryAgent):
                 tool_result = {"output": out}
             except Exception as e:  # pragma: no cover
                 tool_result = {"error": str(e)}
+        text = task.get("description", "") if isinstance(task, dict) else str(task or "")
         spec = {
             "role": "Research Scientist",
-            "task": task.get("description", "") if isinstance(task, dict) else str(task or ""),
-            "inputs": {
-                "idea": idea,
-                "task": task.get("description", "") if isinstance(task, dict) else str(task or ""),
-            },
+            "task": text,
+            "inputs": prepare_prompt_inputs(task),
             "io_schema_ref": "dr_rd/schemas/research_v2.json",
             "retrieval_policy": RetrievalPolicy.AGGRESSIVE,
             "capabilities": "evidence gathering",

--- a/core/agents/synthesizer_agent.py
+++ b/core/agents/synthesizer_agent.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
-from core.agents.prompt_agent import PromptFactoryAgent
+from core.agents.prompt_agent import PromptFactoryAgent, prepare_prompt_inputs
 from core.agents.confidence import normalize_confidence
 from dr_rd.prompting.prompt_registry import RetrievalPolicy
 from core.llm import select_model
@@ -33,10 +33,17 @@ class SynthesizerAgent(PromptFactoryAgent):
                     sources.append(src)
                 if "safety_meta" in val:
                     safety.append(val["safety_meta"])
+        task_scope = {
+            "description": "compose final report",
+            "inputs": list(answers.keys()),
+            "outputs": ["Final synthesis"],
+            "constraints": [],
+        }
+        inputs = prepare_prompt_inputs(task_scope, {"materials": materials})
         spec = {
             "role": "Synthesizer",
             "task": "compose final report",
-            "inputs": {"idea": idea, "materials": materials},
+            "inputs": inputs,
             "io_schema_ref": "dr_rd/schemas/synthesizer_v1.json",
             "retrieval_policy": RetrievalPolicy.NONE,
             "capabilities": "summary composer",


### PR DESCRIPTION
## Summary
- add a shared `prepare_prompt_inputs` helper so PromptFactory agents always pass task description, inputs, outputs, and constraints
- update core PromptFactory-based agents to use the scoped inputs helper and drop the idea field when building specs
- extend compartmentalization tests to assert agents forward the scoped task fields, including the QA agent

## Testing
- pytest -q *(fails: optional dependencies `pptx` and `fastapi` required by unrelated integration tests are unavailable in the environment)*
- mypy dr_rd
- ruff check dr_rd *(fails: repository already contains numerous lint violations outside the touched modules)*
- gitleaks detect --source . *(fails: `gitleaks` executable is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e4513844832c8453f4dab90f8dee