### PR TITLE
[Execute] 2025-09-16 – <SY1>

### DIFF
--- a/core/agents/synthesizer_agent.py
+++ b/core/agents/synthesizer_agent.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+from collections import defaultdict
 from typing import Any, Dict, List
 
 from core.agents.prompt_agent import PromptFactoryAgent, prepare_prompt_inputs
@@ -7,6 +9,74 @@ from core.agents.confidence import normalize_confidence
 from dr_rd.prompting.prompt_registry import RetrievalPolicy
 from core.llm import select_model
 from dr_rd.telemetry import metrics
+
+
+def _iter_strings(value: Any):
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for nested in value.values():
+            yield from _iter_strings(nested)
+    elif isinstance(value, (list, tuple, set)):
+        for nested in value:
+            yield from _iter_strings(nested)
+
+
+def _normalize_scalar(value: Any) -> str | None:
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        if "not determined" in stripped.casefold():
+            return None
+        return stripped
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    return None
+
+
+def _detect_conflicts(answers: Dict[str, Any]) -> List[str]:
+    observations: dict[str, list[tuple[str, str, str]]] = defaultdict(list)
+    for module, payload in answers.items():
+        if not isinstance(payload, dict):
+            continue
+        for field, raw_value in payload.items():
+            if field in {"sources", "safety_meta", "retrieval_plan"}:
+                continue
+            normalized = _normalize_scalar(raw_value)
+            if normalized is None:
+                continue
+            observations[field].append((module, normalized.casefold(), normalized))
+
+    contradictions: List[str] = []
+    for field, items in observations.items():
+        groups: dict[str, dict[str, Any]] = {}
+        for module, norm_key, original in items:
+            bucket = groups.setdefault(norm_key, {"value": original, "modules": set()})
+            bucket["modules"].add(module)
+        if len(groups) > 1:
+            parts: List[str] = []
+            for bucket in groups.values():
+                modules = ", ".join(sorted(bucket["modules"]))
+                parts.append(f"{bucket['value']} ({modules})")
+            contradictions.append(f"Conflicting {field}: " + " vs. ".join(parts))
+    return contradictions
+
+
+def _detect_placeholders(answers: Dict[str, Any]) -> List[str]:
+    issues: List[str] = []
+    for module, payload in answers.items():
+        for text in _iter_strings(payload):
+            lowered = text.casefold()
+            if "not determined" in lowered:
+                issues.append(f"{module} contains Not determined placeholder")
+                break
+            if "{{" in text and "}}" in text:
+                issues.append(f"{module} contains unresolved template placeholders")
+                break
+    return issues
 
 
 class SynthesizerAgent(PromptFactoryAgent):
@@ -50,27 +120,37 @@ class SynthesizerAgent(PromptFactoryAgent):
             "evaluation_hooks": ["compartment_check", "self_check_minimal"],
         }
         result = super().run_with_spec(spec, **kwargs)
-        if sources or safety or missing_sources:
-            import json
-            data = json.loads(result)
-            # Always normalize confidence to a numeric value for downstream math
-            data["confidence"] = normalize_confidence(data.get("confidence", 1.0))
-            if sources:
-                data.setdefault("sources", [])
-                for src in sources:
-                    if src not in data["sources"]:
-                        data["sources"].append(src)
-            if safety:
-                data["safety_meta"] = safety
-                if any(m.get("decision", {}).get("allowed") is False for m in safety):
-                    data.setdefault("contradictions", []).append("blocked content removed")
-                    data["confidence"] = min(data.get("confidence", 1.0), 0.5)
-            if missing_sources:
-                data.setdefault("contradictions", []).append("missing sources for " + ", ".join(missing_sources))
-                data["confidence"] = min(data.get("confidence", 1.0), 0.7)
-                metrics.inc("citations_missing", value=len(missing_sources), agent="Synthesizer")
-            result = json.dumps(data)
-        return result
+        data = json.loads(result)
+        data["confidence"] = normalize_confidence(data.get("confidence", 1.0))
+        contradictions = data.setdefault("contradictions", [])
+        if sources:
+            data.setdefault("sources", [])
+            for src in sources:
+                if src not in data["sources"]:
+                    data["sources"].append(src)
+        if safety:
+            data["safety_meta"] = safety
+            if any(m.get("decision", {}).get("allowed") is False for m in safety):
+                message = "blocked content removed"
+                if message not in contradictions:
+                    contradictions.append(message)
+                data["confidence"] = min(data.get("confidence", 1.0), 0.5)
+        if missing_sources:
+            message = "missing sources for " + ", ".join(missing_sources)
+            if message not in contradictions:
+                contradictions.append(message)
+            data["confidence"] = min(data.get("confidence", 1.0), 0.7)
+            metrics.inc("citations_missing", value=len(missing_sources), agent="Synthesizer")
+
+        initial_count = len(contradictions)
+        detected = _detect_conflicts(answers) + _detect_placeholders(answers)
+        for message in detected:
+            if message not in contradictions:
+                contradictions.append(message)
+        if len(contradictions) > initial_count and contradictions:
+            data["confidence"] = min(data.get("confidence", 1.0), 0.6)
+
+        return json.dumps(data)
 
     def run(self, idea: str, answers: Dict[str, Any], **kwargs) -> str:
         return self.act(idea, answers, **kwargs)


### PR DESCRIPTION
## Summary
- add a compartmentalization test covering synthesizer contradiction handling
- teach the synthesizer agent to flag conflicting module outputs and unresolved placeholders while lowering confidence accordingly

## Testing
- pytest -q *(fails: missing optional dependencies `pptx` and `fastapi` in this environment)*
- mypy dr_rd
- ruff dr_rd *(command not recognized; ran `ruff check dr_rd` which reports pre-existing lint issues in untouched tenancy/tools modules)*
- gitleaks detect --source . *(command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ed5e6e30832cb3d51e7dd6adc425