### PR TITLE
[Execute] 2025-09-16 – <SY2>

### DIFF
--- a/tests/test_synthesizer.py
+++ b/tests/test_synthesizer.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from core.agents.synthesizer_agent import compose_final_proposal
+from core.agents.synthesizer_agent import SynthesizerAgent, compose_final_proposal
 from core.agents.prompt_agent import PromptFactoryAgent
 
 
@@ -30,3 +30,56 @@ def test_compose_final_proposal_merges_sources(monkeypatch):
     data = json.loads(out)
     assert data["summary"] == "Overview"
     assert data["sources"] == [{"url": "u"}]
+
+
+def _base_synth_response() -> str:
+    return json.dumps(
+        {
+            "summary": "Overview",
+            "key_points": [],
+            "role": "Synthesizer",
+            "task": "compose final report",
+            "findings": "analysis",
+            "risks": [],
+            "next_steps": [],
+            "sources": [],
+            "confidence": 0.95,
+            "contradictions": [],
+        }
+    )
+
+
+def test_synthesizer_detects_conflicting_fields(monkeypatch):
+    monkeypatch.setattr(PromptFactoryAgent, "run_with_spec", lambda self, spec, **_: _base_synth_response())
+
+    answers = {
+        "CTO": {"decision": "Proceed", "summary": "Ready"},
+        "Regulatory": {"decision": "Hold", "summary": "Pending review"},
+        "Finance": {"decision": "Proceed"},
+    }
+
+    agent = SynthesizerAgent("model")
+    data = json.loads(agent.act("idea", answers))
+
+    assert any(
+        msg.startswith("Conflicting decision: Proceed (CTO, Finance) vs. Hold (Regulatory)")
+        for msg in data.get("contradictions", [])
+    )
+    assert data["confidence"] == pytest.approx(0.6)
+
+
+def test_synthesizer_flags_placeholders(monkeypatch):
+    monkeypatch.setattr(PromptFactoryAgent, "run_with_spec", lambda self, spec, **_: _base_synth_response())
+
+    answers = {
+        "QA": {"summary": "Not determined", "notes": "Investigation pending"},
+        "Research": {"summary": "Complete", "details": "See {{ placeholder }}"},
+    }
+
+    agent = SynthesizerAgent("model")
+    data = json.loads(agent.act("idea", answers))
+
+    contradictions = data.get("contradictions", [])
+    assert any("QA contains Not determined placeholder" in msg for msg in contradictions)
+    assert any("Research contains unresolved template placeholders" in msg for msg in contradictions)
+    assert data["confidence"] == pytest.approx(0.6)


### PR DESCRIPTION
## Summary
- add focused unit tests for the Synthesizer to assert conflict and placeholder contradictions are recorded
- ensure the tests exercise confidence reduction logic when inconsistencies surface

## Testing
- pytest -q *(fails: missing optional dependencies such as pptx and fastapi)*
- mypy dr_rd
- ruff dr_rd *(fails: command not recognized)*
- ruff check dr_rd *(fails: numerous pre-existing lint issues)*
- gitleaks detect --source . *(fails: gitleaks executable unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68c9f8387154832c800874de6136bda2