### PR TITLE
[Execute] 2025-09-16 – <PL4>

### DIFF
--- a/dr_rd/prompting/prompt_factory.py
+++ b/dr_rd/prompting/prompt_factory.py
@@ -12,6 +12,7 @@ from jinja2 import Environment, meta
 
 from dr_rd.examples import safety_filters
 from dr_rd.prompting import example_selectors
+from dr_rd.prompting.sanitizers import apply_planner_neutralization
 
 from .prompt_registry import (
     RETRIEVAL_POLICY_META,
@@ -116,6 +117,8 @@ class PromptFactory:
             inputs = {}
         if isinstance(inputs.get("idea"), (dict, list)):
             inputs["idea"] = ""
+        if role == "Planner":
+            apply_planner_neutralization(inputs)
         _normalize_task_scope(spec, inputs)
         template = self.registry.get(role, task_key)
 

--- a/dr_rd/prompting/prompt_registry.py
+++ b/dr_rd/prompting/prompt_registry.py
@@ -89,7 +89,7 @@ registry.register(
             "summary, description, role, inputs, outputs, and constraints. "
             "Use arrays of strings for inputs, outputs, and constraints. Populate them even when uncertain (use \"Not determined\" for unknown entries). "
             "Inputs = prerequisites or data the assignee needs. Outputs = deliverables or decisions produced. Constraints = guardrails, policies, or limits to respect. "
-            "Keep titles, summaries, descriptions, inputs, outputs, and constraints neutral. Do not reference or hint at the overall project idea in any field. "
+            "Keep titles, summaries, descriptions, inputs, outputs, and constraints neutral. Do not reference or hint at the overall project idea in any field. Replace any idea-specific names with neutral terms like 'the system'. "
             "Allowed roles: "
             '["CTO","Research Scientist","Regulatory","Finance","Marketing '
             'Analyst","IP Analyst","HRM","Materials Engineer","QA",'
@@ -124,7 +124,9 @@ registry.register(
             'If required information is missing, return {"error":"MISSING_INFO","needs":[]} instead of leaking the idea.'
         ),
         user_template=(
-            "Project idea: {{ idea | default('') }}{{ constraints_section | default('') }}{{ risk_section | default('') }}\n\n"
+            "Project idea (neutralized): {{ idea | default('') }}{{ constraints_section | default('') }}{{ risk_section | default('') }}\n"
+            "{% if idea_alias %}Always refer to the project as '{{ idea_alias }}' and keep every field generic. {% endif %}\n"
+            "Specific names have been removed; do not attempt to recover them.\n\n"
             "Follow the planner schema exactly and return only the JSON object. No extra text."
         ),
         io_schema_ref="dr_rd/schemas/planner_v1.json",

--- a/dr_rd/prompting/sanitizers.py
+++ b/dr_rd/prompting/sanitizers.py
@@ -1,0 +1,96 @@
+"""Utilities for neutralizing idea-specific terms in prompts."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from typing import Any
+
+NEUTRAL_ALIAS = "the system"
+
+
+def _dedupe(seq: Iterable[str]) -> list[str]:
+    seen: list[str] = []
+    for item in seq:
+        if not item:
+            continue
+        if item not in seen:
+            seen.append(item)
+    return seen
+
+
+def _normalize_alias(alias: str, at_start: bool) -> str:
+    return alias.capitalize() if at_start else alias
+
+
+def neutralize_project_terms(text: str, alias: str = NEUTRAL_ALIAS) -> tuple[str, list[str]]:
+    """Replace project-specific proper nouns with a neutral alias."""
+
+    if not text:
+        return "", []
+
+    replacements: list[str] = []
+    sanitized = text
+
+    def _replace_segment(segment: str, start: int) -> str:
+        cleaned = segment.strip(" \t\n\r\f\v\"'“”‘’")
+        if not cleaned:
+            return segment
+        lowered = cleaned.lower()
+        if lowered in {alias, "the project", "project idea", "project"}:
+            return segment
+        replacements.append(cleaned)
+        return _normalize_alias(alias, start == 0)
+
+    header_pattern = re.compile(
+        r"^\s*(?P<prefix>(?:Project\s+Idea\s*:\s*)?)(?P<name>[A-Z][\w]*(?:\s+[A-Z][\w]*){0,4})\s*(?P<sep>[:\-–—])\s*"
+    )
+
+    def _header_sub(match: re.Match[str]) -> str:
+        prefix = match.group("prefix") or ""
+        name = match.group("name").strip()
+        sep = match.group("sep")
+        if name:
+            replacements.append(name)
+        alias_text = _normalize_alias(alias, not bool(prefix))
+        return f"{prefix}{alias_text} {sep} "
+
+    sanitized = header_pattern.sub(_header_sub, sanitized, count=1)
+
+    quote_pattern = re.compile(r"[\"'“”‘’]([A-Z][^\"'“”‘’]{1,60})[\"'“”‘’]")
+
+    def _quote_sub(match: re.Match[str]) -> str:
+        inner = match.group(1).strip()
+        if inner:
+            replacements.append(inner)
+        return alias
+
+    sanitized = quote_pattern.sub(_quote_sub, sanitized)
+
+    camel_pattern = re.compile(r"\b([A-Z][a-z0-9]+[A-Za-z0-9]*[A-Z][A-Za-z0-9]*)\b")
+    sanitized = camel_pattern.sub(lambda m: _replace_segment(m.group(0), m.start()), sanitized)
+
+    proper_pattern = re.compile(
+        r"\b([A-Z][a-zA-Z0-9]*\s+[A-Z][a-zA-Z0-9]*(?:\s+[A-Z][a-zA-Z0-9]*)*)\b"
+    )
+    sanitized = proper_pattern.sub(lambda m: _replace_segment(m.group(0), m.start()), sanitized)
+
+    sanitized = re.sub(r"\s{2,}", " ", sanitized)
+    sanitized = re.sub(r"\b(a|an)\s+the system\b", "the system", sanitized, flags=re.IGNORECASE)
+    sanitized = re.sub(r"\bthe\s+the system\b", "the system", sanitized, flags=re.IGNORECASE)
+    sanitized = re.sub(r"\bthe system\s+the system\b", "the system", sanitized, flags=re.IGNORECASE)
+    sanitized = sanitized.strip()
+
+    return sanitized, _dedupe(replacements)
+
+
+def apply_planner_neutralization(inputs: dict[str, Any]) -> None:
+    """Mutate planner inputs so the idea briefing stays neutral."""
+
+    alias = NEUTRAL_ALIAS
+    idea_value = inputs.get("idea")
+    if isinstance(idea_value, str) and idea_value.strip():
+        sanitized, _ = neutralize_project_terms(idea_value, alias)
+        inputs["idea"] = sanitized
+    inputs.setdefault("idea_alias", alias)
+


### PR DESCRIPTION
## Summary
- add a neutralization helper to scrub idea-specific names and expose an alias for planner prompts
- integrate the neutralization step in the prompt factory and reinforce planner prompt instructions about using "the system"
- extend compartmentalization tests to cover neutral idea prompts and the sanitizer utility

## Testing
- `pytest -q` *(fails: numerous pre-existing suite errors and missing configuration)*
- `pytest tests/eval/test_compartmentalization.py -k planner -q`
- `mypy dr_rd`
- `ruff check dr_rd` *(fails: repository-wide lint violations unrelated to this change)*
- `gitleaks detect --source .` *(fails: gitleaks executable unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68cad5d03c74832ca7213372c4f3a031