### PR TITLE
[Execute] 2025-09-16 – <AG3>

### DIFF
--- a/dr_rd/prompting/prompt_registry.py
+++ b/dr_rd/prompting/prompt_registry.py
@@ -634,6 +634,7 @@ registry.register(
             "with the exact string 'no further tasks'.  Always return either a "
             "JSON array of follow-up task strings or the literal string 'no "
             "further tasks'. Do not use markdown formatting in any task string (no '-' or '*' bullets and no multi-line lists). Join multiple items with semicolons or return separate array elements.\n"
+            "You do not have access to the original project idea; base your assessment strictly on the outputs shown. Do not request or reference the idea.\n"
             "Example:\n"
             '["[Finance]: Recalculate budget"]\n'
             "Incorrect Example:\n"
@@ -641,9 +642,8 @@ registry.register(
             "Explanation: markdown-style bullets and multi-line strings break the expected JSON array format."
         ),
         user_template=(
-            "Project Idea: {{ idea | default('') }}\n\n"
-            "Existing outputs:\n{{ task | default('unknown') }}\n\n"
-            "Analyse these outputs and recommend follow-up tasks for any missing or placeholder data."
+            "Existing outputs (JSON):\n{{ task_payload }}\n\n"
+            "Analyse these outputs only and recommend follow-up tasks for any missing or placeholder data."
         ),
         io_schema_ref="dr_rd/schemas/reflection_agent.json",
         retrieval_policy=RetrievalPolicy.NONE,

--- a/tests/eval/test_compartmentalization.py
+++ b/tests/eval/test_compartmentalization.py
@@ -244,6 +244,41 @@ def test_prompt_factory_renders_isolated_task_context():
     assert "Meet IEC 62304" in user
 
 
+def test_reflection_prompt_excludes_project_idea():
+    tpl = registry.get("Reflection")
+    assert tpl is not None
+    template_user = tpl.user_template or ""
+    assert "Project Idea" not in template_user
+    assert "{{ idea" not in template_user
+
+    pf = PromptFactory()
+    task_payload = {
+        "summary": "Not determined",
+        "findings": "",
+        "risks": [],
+    }
+    spec = {
+        "role": "Reflection",
+        "task": json.dumps(task_payload),
+        "inputs": {
+            "task_payload": json.dumps(task_payload),
+            "task_description": "Not determined",
+            "task_inputs": ["Not determined"],
+            "task_outputs": ["Not determined"],
+            "task_constraints": ["Not determined"],
+            "idea": "NebulaLink Beacon Series",
+        },
+        "io_schema_ref": "dr_rd/schemas/reflection_v1.json",
+    }
+
+    prompt = pf.build_prompt(spec)
+    user = prompt["user"]
+    assert "Project Idea" not in user
+    assert "NebulaLink" not in user
+    assert "Existing outputs" in user
+    assert "Not determined" in user
+
+
 PROMPT_AGENT_CASES = [
     (
         "CTO",


### PR DESCRIPTION
## Summary
- add a regression test that confirms the Reflection prompt template never exposes the project idea
- update the Reflection prompt to drop the idea context and explicitly tell the agent to rely only on the provided outputs

## Testing
- pytest -q *(fails: existing suite requires extensive product configuration; dozens of modules and data files are missing in this environment)*
- pytest tests/eval/test_compartmentalization.py::test_reflection_prompt_excludes_project_idea -q
- mypy dr_rd
- ruff check dr_rd *(fails: repository currently reports 751 lint issues outside this change)*
- gitleaks detect --source . *(fails: gitleaks executable is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cad9d91c68832c8f81fd9e0a7929c1