### PR TITLE
Fix planner missing required fields for ToT tasks

### DIFF
--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -77,8 +77,9 @@ def _coerce_and_fill(data: dict | list) -> dict:
     """Coerce planner output into a normalized task object.
 
     ``data`` may be a list or dict.  Tasks are cleaned and missing fields filled
-    without dropping entries unless ``title`` or ``summary`` are blank after
-    stripping.  Any additional keys on task objects are preserved.
+    without dropping entries unless ``title``, ``summary`` and ``description``
+    are blank after stripping.  Any additional keys on task objects are
+    preserved.
     """
 
     if isinstance(data, list):
@@ -94,12 +95,20 @@ def _coerce_and_fill(data: dict | list) -> dict:
         if not isinstance(t, dict):
             continue
         tid = str(t.get("id") or f"T{i:02d}")
-        title = (t.get("title") or "").strip()
-        summary = (t.get("summary") or t.get("description") or "").strip()
-        description = (t.get("description") or t.get("summary") or "").strip()
+        title = (t.get("title") or t.get("name") or t.get("task") or "").strip()
+        summary = (
+            t.get("summary")
+            or t.get("description")
+            or t.get("goal")
+            or t.get("task")
+            or ""
+        ).strip()
+        description = (
+            t.get("description") or t.get("summary") or t.get("task") or ""
+        ).strip()
         role_raw = t.get("role")
         role = normalize_role(role_raw) or "Dynamic Specialist"
-        if title == "" or summary == "":
+        if title == "" and summary == "" and description == "":
             continue
         nt = dict(t)
         nt.update(

--- a/planning/strategies/tot.py
+++ b/planning/strategies/tot.py
@@ -82,26 +82,41 @@ class ToTPlannerStrategy(BasePlannerStrategy):
     ) -> List[List[Dict[str, Any]]]:
         """Generate new plan branches for the given depth."""
 
+        def _make_option(role: str, task: str) -> Dict[str, Any]:
+            return {
+                "role": role,
+                "task": task,
+                "title": task,
+                "summary": task,
+                "description": task,
+            }
+
         if depth == 0:
             options = [
-                {"role": "AI R&D Coordinator", "task": "Clarify requirements with stakeholders"},
-                {"role": "AI R&D Coordinator", "task": "Assess feasibility of core technologies"},
-                {"role": "AI R&D Coordinator", "task": "Survey prior art and existing solutions"},
+                _make_option(
+                    "AI R&D Coordinator", "Clarify requirements with stakeholders"
+                ),
+                _make_option(
+                    "AI R&D Coordinator", "Assess feasibility of core technologies"
+                ),
+                _make_option(
+                    "AI R&D Coordinator", "Survey prior art and existing solutions"
+                ),
             ]
         else:
             options = [
-                {
-                    "role": "Systems Integration & Validation Engineer",
-                    "task": "Prototype critical subsystems",
-                },
-                {
-                    "role": "Data Scientist / Analytics Engineer",
-                    "task": "Validate performance against requirements",
-                },
-                {
-                    "role": "Project Manager / Principal Investigator",
-                    "task": "Review project milestones",
-                },
+                _make_option(
+                    "Systems Integration & Validation Engineer",
+                    "Prototype critical subsystems",
+                ),
+                _make_option(
+                    "Data Scientist / Analytics Engineer",
+                    "Validate performance against requirements",
+                ),
+                _make_option(
+                    "Project Manager / Principal Investigator",
+                    "Review project milestones",
+                ),
             ]
 
         branches = []

--- a/tests/test_normalizer_coerce_and_fill.py
+++ b/tests/test_normalizer_coerce_and_fill.py
@@ -34,3 +34,23 @@ def test_normalizer_zero_failfast(tmp_path):
     assert str(exc.value) == "planner.normalization_zero"
     assert list(log_dir.glob("planner_payload_*.json"))
 
+
+def test_normalizer_tot_task_field_fallback():
+    data = {
+        "tasks": [
+            {"role": "AI R&D Coordinator", "task": "Clarify requirements with stakeholders"}
+        ]
+    }
+
+    norm = _coerce_and_fill(data)
+    assert norm["_raw_count"] == 1
+    assert len(norm["tasks"]) == 1
+
+    task = norm["tasks"][0]
+    assert task["id"] == "T01"
+    assert task["title"] == "Clarify requirements with stakeholders"
+    assert task["summary"] == "Clarify requirements with stakeholders"
+    assert task["description"] == "Clarify requirements with stakeholders"
+
+    Plan.model_validate(norm, strict=True)
+


### PR DESCRIPTION
## Summary
- update `_coerce_and_fill` to treat the `task` field as a fallback for missing title, summary, and description data so Tree-of-Thoughts plans are preserved during normalization
- emit fully populated task dictionaries from the Tree-of-Thoughts planner itself, ensuring downstream consumers always receive the required fields
- add a regression test that exercises normalization of a ToT-style plan and validates the `Plan` schema without raising `missing required fields`

## Testing
- `pytest -q tests/test_normalizer_coerce_and_fill.py tests/test_tot_planner_strategy.py`
- `pytest -q` *(fails: environment lacks numerous optional dependencies and assets; e.g., Streamlit thin UI tooling, otel/span directories, cached data, and various schema files. Original failure that triggered this work—1758143993-dfa32190—was reproduced and is now resolved by the normalization fallback.)*
- `mypy dr_rd`
- `ruff check dr_rd` *(fails: repository currently has 751 pre-existing lint violations unrelated to this change)*
- `gitleaks detect` *(fails: `gitleaks` binary not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb5b302120832c820adb746178c58b