### PR TITLE
Support list inputs and outputs/constraints in planner tasks

### DIFF
--- a/core/agents/simulation_agent.py
+++ b/core/agents/simulation_agent.py
@@ -8,6 +8,16 @@ from dr_rd.simulation import sim_core
 from dr_rd.simulation.interfaces import SimulationSpec
 
 
+def _coerce_inputs(value: Any) -> Dict[str, Any]:
+    if isinstance(value, dict):
+        return dict(value)
+    if isinstance(value, list):
+        return {"items": list(value)}
+    if value is None:
+        return {}
+    return {"value": value}
+
+
 def determine_sim_type(role: str, design_spec: str) -> str:
     role = role.lower()
     if "mechanical" in role or "motion" in role:
@@ -30,7 +40,7 @@ class SimulationAgent(LLMRoleAgent):
         spec = SimulationSpec(
             id=str(task.get("id", "sim")),
             domain=domain,
-            inputs=task.get("inputs", {}),
+            inputs=_coerce_inputs(task.get("inputs")),
             budget_hint=task.get("budget_hint"),
             seed=task.get("seed"),
             notes=task.get("notes"),

--- a/core/reporting_bridge.py
+++ b/core/reporting_bridge.py
@@ -2,12 +2,22 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Dict, Iterable
+from typing import Any, Dict, Iterable
 
 from dr_rd.kb import store
 from dr_rd.kb.models import KBRecord, KBSource
 from dr_rd.reporting import compose
 from dr_rd.reporting.exporters import to_html, to_markdown
+
+
+def _coerce_inputs(value: Any) -> Dict[str, Any]:
+    if isinstance(value, dict):
+        return dict(value)
+    if isinstance(value, list):
+        return {"items": list(value)}
+    if value is None:
+        return {}
+    return {"value": value}
 
 
 def kb_ingest(agent_role: str, task: Dict, output_json: Dict, route_meta: Dict, spans: Iterable[Dict]) -> None:
@@ -18,7 +28,7 @@ def kb_ingest(agent_role: str, task: Dict, output_json: Dict, route_meta: Dict, 
         "agent_role": agent_role,
         "task_title": task.get("title", ""),
         "task_desc": task.get("description", ""),
-        "inputs": task.get("inputs", {}),
+        "inputs": _coerce_inputs(task.get("inputs")),
         "output_json": output_json,
         "sources": output_json.get("sources", []),
         "ts": route_meta.get("ts", 0.0),

--- a/core/schemas.py
+++ b/core/schemas.py
@@ -32,7 +32,9 @@ class Task(BaseModel):
         min_length=1, validation_alias=AliasChoices("description", "detail", "details")
     )
     role: str = Field(min_length=1)
-    inputs: dict[str, Any] | None = None
+    inputs: dict[str, Any] | list[str] | None = None
+    outputs: list[str] = Field(default_factory=list)
+    constraints: list[str] = Field(default_factory=list)
     dependencies: list[str] = Field(default_factory=list)
     stop_rules: list[str] = Field(default_factory=list)
     tags: list[str] = Field(default_factory=list)

--- a/dr_rd/kb/store.py
+++ b/dr_rd/kb/store.py
@@ -17,6 +17,16 @@ STORE_PATH = CFG_DIR / "kb.jsonl"
 INDEX_PATH = CFG_DIR / "kb_index.jsonl"
 
 
+def _coerce_inputs(value: Any) -> Dict[str, Any]:
+    if isinstance(value, dict):
+        return dict(value)
+    if isinstance(value, list):
+        return {"items": list(value)}
+    if value is None:
+        return {}
+    return {"value": value}
+
+
 def _read_all() -> List[KBRecord]:
     if not STORE_PATH.exists():
         return []
@@ -86,7 +96,7 @@ def kb_maybe_persist(agent_output: Dict[str, Any], route_meta: Dict[str, Any], p
         agent_role=route_meta.get("role", ""),
         task_title=route_meta.get("title", ""),
         task_desc=route_meta.get("description", ""),
-        inputs=route_meta.get("inputs", {}),
+        inputs=_coerce_inputs(route_meta.get("inputs")),
         output_json=agent_output,
         sources=sources,
         ts=float(route_meta.get("ts") or 0.0),

--- a/examples/templates/fastapi_service/app.py
+++ b/examples/templates/fastapi_service/app.py
@@ -9,9 +9,19 @@ class Task(BaseModel):
     role: str
     title: str
     desc: str
-    inputs: dict
+    inputs: dict | list[str] | None = None
+
+
+def _coerce_inputs(value):
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, list):
+        return {"items": list(value)}
+    if value is None:
+        return {}
+    return {"value": value}
 
 
 @app.post("/run")
 async def run(task: Task):
-    return execute_task(task.role, task.title, task.desc, task.inputs)
+    return execute_task(task.role, task.title, task.desc, _coerce_inputs(task.inputs))

--- a/tests/test_planner_schema.py
+++ b/tests/test_planner_schema.py
@@ -24,3 +24,47 @@ def test_legacy_task_field_backfilled():
     t = validated.tasks[0]
     assert t.title == "Build prototype"
     assert t.summary == "Build prototype"
+
+
+def test_task_inputs_outputs_constraints_lists():
+    data = {
+        "tasks": [
+            {
+                "id": "custom-id",
+                "role": "CTO",
+                "title": "Plan",
+                "summary": "Review",
+                "description": "Assess",
+                "inputs": ["spec", "budget"],
+                "outputs": ["report"],
+                "constraints": ["48 hours"],
+            }
+        ]
+    }
+    norm = _coerce_and_fill(data)
+    validated = Plan.model_validate(norm, strict=True)
+    task = validated.tasks[0]
+    assert task.inputs == ["spec", "budget"]
+    assert task.outputs == ["report"]
+    assert task.constraints == ["48 hours"]
+
+
+def test_task_inputs_accepts_mapping():
+    data = {
+        "tasks": [
+            {
+                "id": "T9",
+                "role": "Finance",
+                "title": "Budget",
+                "summary": "Summarize",
+                "description": "Summarize",
+                "inputs": {"sheet": "abc"},
+            }
+        ]
+    }
+    norm = _coerce_and_fill(data)
+    validated = Plan.model_validate(norm, strict=True)
+    task = validated.tasks[0]
+    assert task.inputs == {"sheet": "abc"}
+    assert task.outputs == []
+    assert task.constraints == []


### PR DESCRIPTION
## Summary
- expand the `Task` schema to accept list-based inputs and add outputs/constraints arrays so planner responses validate
- normalize list inputs before handing tasks to simulators, knowledge-base ingestion, and the FastAPI example so downstream code still receives mappings
- extend planner schema tests to cover list inputs and ensure dictionary inputs remain backwards compatible

## Testing
- pytest -q *(fails: missing optional dependencies `pptx`, `fastapi` for integration tests)*
- mypy dr_rd
- ruff check dr_rd *(fails: existing repository lint violations)*
- gitleaks detect *(fails: `gitleaks` not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc31d0a344832c8661c23193905cd0