### PR TITLE
Include idea field in prompt inputs

### DIFF
--- a/core/agents/chief_scientist_agent.py
+++ b/core/agents/chief_scientist_agent.py
@@ -12,7 +12,7 @@ class ChiefScientistAgent(PromptFactoryAgent):
         spec = {
             "role": "Chief Scientist",
             "task": text,
-            "inputs": prepare_prompt_inputs(task),
+            "inputs": prepare_prompt_inputs(task, idea=idea),
             "io_schema_ref": "dr_rd/schemas/chief_scientist_v1.json",
             "retrieval_policy": RetrievalPolicy.LIGHT,
             "capabilities": "integrate findings",

--- a/core/agents/cto_agent.py
+++ b/core/agents/cto_agent.py
@@ -19,7 +19,7 @@ class CTOAgent(PromptFactoryAgent):
         spec = {
             "role": "CTO",
             "task": text,
-            "inputs": prepare_prompt_inputs(task),
+            "inputs": prepare_prompt_inputs(task, idea=idea),
             "io_schema_ref": "dr_rd/schemas/cto_v2.json",
             "retrieval_policy": RetrievalPolicy.LIGHT,
             "capabilities": "technical strategy",

--- a/core/agents/finance_agent.py
+++ b/core/agents/finance_agent.py
@@ -12,7 +12,7 @@ class FinanceAgent(PromptFactoryAgent):
         spec = {
             "role": "Finance",
             "task": text,
-            "inputs": prepare_prompt_inputs(task),
+            "inputs": prepare_prompt_inputs(task, idea=idea),
             "io_schema_ref": "dr_rd/schemas/finance_v2.json",
             "retrieval_policy": RetrievalPolicy.LIGHT,
             "capabilities": "budgeting and costs",

--- a/core/agents/hrm_agent.py
+++ b/core/agents/hrm_agent.py
@@ -12,7 +12,7 @@ class HRMAgent(PromptFactoryAgent):
         spec = {
             "role": "HRM",
             "task": text,
-            "inputs": prepare_prompt_inputs(task),
+            "inputs": prepare_prompt_inputs(task, idea=idea),
             "io_schema_ref": "dr_rd/schemas/hrm_v2.json",
             "retrieval_policy": RetrievalPolicy.NONE,
             "capabilities": "role mapping",

--- a/core/agents/ip_analyst_agent.py
+++ b/core/agents/ip_analyst_agent.py
@@ -20,7 +20,7 @@ class IPAnalystAgent(PromptFactoryAgent):
         spec = {
             "role": "IP Analyst",
             "task": text,
-            "inputs": prepare_prompt_inputs(task),
+            "inputs": prepare_prompt_inputs(task, idea=idea),
             "io_schema_ref": "dr_rd/schemas/ip_analyst_v2.json",
             "retrieval_policy": RetrievalPolicy.AGGRESSIVE,
             "top_k": top_k,

--- a/core/agents/marketing_agent.py
+++ b/core/agents/marketing_agent.py
@@ -12,7 +12,7 @@ class MarketingAgent(PromptFactoryAgent):
         spec = {
             "role": "Marketing Analyst",
             "task": text,
-            "inputs": prepare_prompt_inputs(task),
+            "inputs": prepare_prompt_inputs(task, idea=idea),
             "io_schema_ref": "dr_rd/schemas/marketing_v2.json",
             "retrieval_policy": RetrievalPolicy.LIGHT,
             "capabilities": "market analysis",

--- a/core/agents/materials_engineer_agent.py
+++ b/core/agents/materials_engineer_agent.py
@@ -10,11 +10,12 @@ class MaterialsEngineerAgent(PromptFactoryAgent):
     """Prompt-based agent for materials tasks with a simple call signature."""
 
     def __call__(self, task: Any, model: str | None = None, meta: dict | None = None) -> str:
+        idea = task.get("idea", "") if isinstance(task, dict) else ""
         text = task.get("description", "") if isinstance(task, dict) else str(task or "")
         spec = {
             "role": "Materials Engineer",
             "task": text,
-            "inputs": prepare_prompt_inputs(task),
+            "inputs": prepare_prompt_inputs(task, idea=idea),
             "io_schema_ref": "dr_rd/schemas/materials_engineer_v2.json",
             "retrieval_policy": RetrievalPolicy.LIGHT,
             "capabilities": "materials selection",

--- a/core/agents/mechanical_systems_lead_agent.py
+++ b/core/agents/mechanical_systems_lead_agent.py
@@ -12,7 +12,7 @@ class MechanicalSystemsLeadAgent(PromptFactoryAgent):
         spec = {
             "role": "Mechanical Systems Lead",
             "task": text,
-            "inputs": prepare_prompt_inputs(task),
+            "inputs": prepare_prompt_inputs(task, idea=idea),
             "io_schema_ref": "dr_rd/schemas/mechanical_systems_lead_v1.json",
             "retrieval_policy": RetrievalPolicy.LIGHT,
             "capabilities": "mechanical design",

--- a/core/agents/patent_agent.py
+++ b/core/agents/patent_agent.py
@@ -14,7 +14,7 @@ class PatentAgent(PromptFactoryAgent):
         spec = {
             "role": "Patent",
             "task": text,
-            "inputs": prepare_prompt_inputs(task),
+            "inputs": prepare_prompt_inputs(task, idea=idea),
             "io_schema_ref": "dr_rd/schemas/generic_v2.json",
             "retrieval_policy": RetrievalPolicy.AGGRESSIVE,
             "capabilities": "patent analysis",

--- a/core/agents/planner_agent.py
+++ b/core/agents/planner_agent.py
@@ -13,7 +13,7 @@ from core.safety_gate import preflight
 class PlannerAgent(PromptFactoryAgent):
     def act(self, idea: str, task: Any = None, **kwargs) -> str:
         text = str(task or "")
-        inputs = prepare_prompt_inputs(task)
+        inputs = prepare_prompt_inputs(task, idea=idea)
         spec = {
             "role": "Planner",
             "task": text,

--- a/core/agents/prompt_agent.py
+++ b/core/agents/prompt_agent.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import os
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import jsonschema
 
@@ -115,7 +115,11 @@ def _ensure_string_list(value: Any) -> list[str]:
     return [text] if text else []
 
 
-def prepare_prompt_inputs(task: Any, extra: Dict[str, Any] | None = None) -> Dict[str, Any]:
+def prepare_prompt_inputs(
+    task: Any,
+    extra: Dict[str, Any] | None = None,
+    idea: Optional[str] = None,
+) -> Dict[str, Any]:
     description = ""
     task_inputs: list[str] = []
     task_outputs: list[str] = []
@@ -143,6 +147,9 @@ def prepare_prompt_inputs(task: Any, extra: Dict[str, Any] | None = None) -> Dic
     if plan_task is not None:
         payload["plan_task"] = plan_task
         payload.setdefault("task_details", plan_task)
+
+    if idea:
+        payload["idea"] = idea
 
     if extra:
         payload.update(extra)

--- a/core/agents/qa_agent.py
+++ b/core/agents/qa_agent.py
@@ -47,7 +47,7 @@ class QAAgent:
         )
         coverage = call_tool(self.ROLE, "compute_test_coverage", {"matrix": matrix})
         stats = call_tool(self.ROLE, "classify_defects", {"defects": defects})
-        inputs = prepare_prompt_inputs(task)
+        inputs = prepare_prompt_inputs(task, idea=idea)
         inputs.update(
             {
                 "context": context,

--- a/core/agents/reflection_agent.py
+++ b/core/agents/reflection_agent.py
@@ -28,7 +28,7 @@ class ReflectionAgent(PromptFactoryAgent):
         if not any(_has_placeholder(v) for v in data.values()):
             return "no further tasks"
 
-        inputs = prepare_prompt_inputs(task)
+        inputs = prepare_prompt_inputs(task, idea=idea)
         inputs.setdefault("task_payload", task_str)
         spec = {
             "role": "Reflection",

--- a/core/agents/regulatory_agent.py
+++ b/core/agents/regulatory_agent.py
@@ -22,7 +22,7 @@ class RegulatoryAgent(PromptFactoryAgent):
         spec = {
             "role": "Regulatory",
             "task": base_task,
-            "inputs": prepare_prompt_inputs(task),
+            "inputs": prepare_prompt_inputs(task, idea=idea),
             "io_schema_ref": "dr_rd/schemas/regulatory_v2.json",
             "retrieval_policy": policy,
             "capabilities": "compliance analysis",

--- a/core/agents/regulatory_specialist_agent.py
+++ b/core/agents/regulatory_specialist_agent.py
@@ -12,7 +12,7 @@ class RegulatorySpecialistAgent(PromptFactoryAgent):
         spec = {
             "role": "Regulatory Specialist",
             "task": text,
-            "inputs": prepare_prompt_inputs(task),
+            "inputs": prepare_prompt_inputs(task, idea=idea),
             "io_schema_ref": "dr_rd/schemas/regulatory_specialist_v1.json",
             "retrieval_policy": RetrievalPolicy.LIGHT,
             "capabilities": "compliance review",

--- a/core/agents/research_scientist_agent.py
+++ b/core/agents/research_scientist_agent.py
@@ -22,7 +22,7 @@ class ResearchScientistAgent(PromptFactoryAgent):
         spec = {
             "role": "Research Scientist",
             "task": text,
-            "inputs": prepare_prompt_inputs(task),
+            "inputs": prepare_prompt_inputs(task, idea=idea),
             "io_schema_ref": "dr_rd/schemas/research_v2.json",
             "retrieval_policy": RetrievalPolicy.AGGRESSIVE,
             "capabilities": "evidence gathering",

--- a/core/agents/synthesizer_agent.py
+++ b/core/agents/synthesizer_agent.py
@@ -109,7 +109,7 @@ class SynthesizerAgent(PromptFactoryAgent):
             "outputs": ["Final synthesis"],
             "constraints": [],
         }
-        inputs = prepare_prompt_inputs(task_scope, {"materials": materials})
+        inputs = prepare_prompt_inputs(task_scope, {"materials": materials}, idea=idea)
         spec = {
             "role": "Synthesizer",
             "task": "compose final report",


### PR DESCRIPTION
## Summary
- allow `prepare_prompt_inputs` to accept an optional idea value and include it in the prompt payload
- pass the project idea from PromptFactory-based agents when preparing inputs so templates referencing `{{ idea }}` render correctly
- extract the idea from task dictionaries in agents that are invoked via `__call__`, such as the materials engineer, before building their specs

## Testing
- ruff check dr_rd *(fails: existing lint violations in unrelated modules)*
- mypy dr_rd
- pytest -q *(fails: missing optional dependencies `pptx` and `fastapi`)*
- gitleaks detect *(fails: command unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc5ebe1190832c88c0bcd210ba6e9e