### PR TITLE
[Execute] 2025-09-18 – <PL4>

### DIFF
--- a/dr_rd/prompting/sanitizers.py
+++ b/dr_rd/prompting/sanitizers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 from collections.abc import Iterable
 from typing import Any
@@ -90,7 +91,126 @@ def apply_planner_neutralization(inputs: dict[str, Any]) -> None:
     alias = NEUTRAL_ALIAS
     idea_value = inputs.get("idea")
     if isinstance(idea_value, str) and idea_value.strip():
-        sanitized, _ = neutralize_project_terms(idea_value, alias)
+        sanitized, replaced = neutralize_project_terms(idea_value, alias)
         inputs["idea"] = sanitized
+        existing = inputs.get("idea_forbidden_terms")
+        combined = []
+        if isinstance(existing, list):
+            combined.extend(item for item in existing if isinstance(item, str))
+        combined.extend(replaced)
+        inputs["idea_forbidden_terms"] = _dedupe(combined)
     inputs.setdefault("idea_alias", alias)
+
+
+def _expand_forbidden_terms(terms: Iterable[str], alias: str) -> list[str]:
+    expanded: list[str] = []
+    for term in terms:
+        if not term:
+            continue
+        cleaned = str(term).strip()
+        if not cleaned:
+            continue
+        expanded.append(cleaned)
+        pieces = [p for p in re.split(r"[\s\-_/]+", cleaned) if p]
+        if len(pieces) > 1:
+            for size in range(1, len(pieces) + 1):
+                for start in range(0, len(pieces) - size + 1):
+                    segment = " ".join(pieces[start : start + size]).strip()
+                    if segment and len(segment) > 3:
+                        expanded.append(segment)
+        else:
+            part = pieces[0] if pieces else cleaned
+            if len(part) > 3:
+                expanded.append(part)
+
+    seen: set[str] = set()
+    result: list[str] = []
+    for term in expanded:
+        key = term.lower()
+        if key == alias.lower():
+            continue
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(term)
+    return result
+
+
+def _neutralize_explicit_terms(text: str, terms: Iterable[str], alias: str) -> tuple[str, bool]:
+    if not text or not terms:
+        return text, False
+
+    pattern_parts = []
+    for term in terms:
+        if not term:
+            continue
+        escaped = re.escape(term)
+        pattern_parts.append(rf"\b{escaped}\b")
+    if not pattern_parts:
+        return text, False
+
+    pattern = re.compile("|".join(sorted(pattern_parts, key=len, reverse=True)), re.IGNORECASE)
+
+    replaced = False
+
+    def _sub(match: re.Match[str]) -> str:
+        nonlocal replaced
+        replaced = True
+        prefix = text[: match.start()]
+        alias_token = _normalize_alias(alias, not prefix.strip())
+        return alias_token
+
+    sanitized = pattern.sub(_sub, text)
+    if not replaced:
+        return text, False
+
+    sanitized = re.sub(r"\b(a|an|the)\s+the system\b", "the system", sanitized, flags=re.IGNORECASE)
+    sanitized = re.sub(r"\bthe\s+the system\b", "the system", sanitized, flags=re.IGNORECASE)
+    sanitized = re.sub(r"\bthe system\s+the system\b", "the system", sanitized, flags=re.IGNORECASE)
+    sanitized = re.sub(r"\s{2,}", " ", sanitized).strip()
+    return sanitized, True
+
+
+def sanitize_planner_plan(
+    plan: Any,
+    forbidden_terms: Iterable[str],
+    alias: str = NEUTRAL_ALIAS,
+) -> tuple[Any, bool]:
+    terms = _expand_forbidden_terms(forbidden_terms, alias)
+    if not terms:
+        return plan, False
+
+    changed = False
+
+    def _walk(value: Any) -> Any:
+        nonlocal changed
+        if isinstance(value, str):
+            sanitized, touched = _neutralize_explicit_terms(value, terms, alias)
+            if touched and sanitized != value:
+                changed = True
+            return sanitized
+        if isinstance(value, list):
+            return [_walk(item) for item in value]
+        if isinstance(value, dict):
+            return {key: _walk(val) for key, val in value.items()}
+        return value
+
+    sanitized_plan = _walk(plan)
+    return sanitized_plan, changed
+
+
+def sanitize_planner_response(
+    raw: str,
+    forbidden_terms: Iterable[str],
+    alias: str = NEUTRAL_ALIAS,
+) -> str:
+    try:
+        data = json.loads(raw)
+    except Exception:
+        return raw
+
+    sanitized, changed = sanitize_planner_plan(data, forbidden_terms, alias)
+    if not changed:
+        return raw
+    return json.dumps(sanitized)
 


### PR DESCRIPTION
## Summary
- add a regression test that verifies planner outputs neutralized task fields even when the model returns idea-specific wording
- extend the planner sanitizers to capture forbidden terms from the idea brief and scrub them from generated plans
- wrap `PromptFactoryAgent.run_with_spec` for the planner to apply the sanitization post-processing automatically during prompt builds

## Testing
- `pytest -q` *(fails: missing optional dependencies `pptx`, `fastapi` required by unrelated integration tests)*
- `mypy dr_rd`
- `ruff check dr_rd` *(fails: pre-existing lint violations across dr_rd package)*
- `gitleaks detect --source .` *(fails: gitleaks CLI not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc7e5ef38c832c94af3576dffe7dfd