### PR TITLE
[Execute] 2025-09-18 – AG3

### DIFF
--- a/dr_rd/prompting/prompt_factory.py
+++ b/dr_rd/prompting/prompt_factory.py
@@ -117,6 +117,12 @@ def _normalize_task_scope(spec: dict[str, Any], inputs: dict[str, Any]) -> None:
     if not isinstance(inputs, dict):
         return
 
+    role = spec.get("role")
+    if role == "Reflection":
+        for key in list(inputs.keys()):
+            if isinstance(key, str) and key.startswith("idea"):
+                inputs.pop(key, None)
+
     task_entry = spec.get("task")
     plan_task: dict[str, Any] | None = None
     for key in ("plan_task", "task_payload", "task_details"):


### PR DESCRIPTION
## Summary
- add a regression test that verifies the Reflection prompt factory strips idea context from prompt inputs
- drop idea-related keys during prompt normalization for Reflection roles to keep follow-up guidance scoped to agent outputs

## Testing
- pytest -q *(fails: missing optional dependencies `pptx` and `fastapi` required by unrelated integration tests)*
- mypy dr_rd
- ruff dr_rd *(command unsupported; see below for explicit `ruff check` failure due to existing lint issues outside this change)*
- gitleaks detect --source . *(fails: gitleaks not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc81128c50832cbc538ffef7b8cf6b