### PR TITLE
[Execute] 2025-09-18 – <PL5>

### DIFF
--- a/dr_rd/prompting/prompt_registry.py
+++ b/dr_rd/prompting/prompt_registry.py
@@ -131,6 +131,12 @@ registry.register(
         ),
         io_schema_ref="dr_rd/schemas/planner_v1.json",
         retrieval_policy=RetrievalPolicy.LIGHT,
+        provider_hints={
+            "temperature": 0.0,
+            "top_p": 0.1,
+            "presence_penalty": 0.0,
+            "frequency_penalty": 0.0,
+        },
     )
 )
 


### PR DESCRIPTION
## Summary
- add regression tests to assert the planner exposes deterministic LLM hints and retries after malformed output
- configure the planner prompt template with low-variance provider hints so first-run plans adhere to the schema

## Testing
- pytest -q *(fails: missing optional dependencies `pptx`, `fastapi` required by unrelated suites)*
- pytest tests/eval/test_compartmentalization.py::test_planner_llm_hints_are_deterministic tests/eval/test_compartmentalization.py::test_planner_auto_retry_success -q
- mypy dr_rd
- ruff dr_rd *(CLI reported `unrecognized subcommand 'dr_rd'`)*
- ruff check dr_rd *(reports pre-existing lint violations across the repository)*
- gitleaks detect --source . *(not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc831d7ad4832c94b1a478f2af25dc