### PR TITLE
[Execute] 2025-09-18 – <EV2>

### DIFF
--- a/dr_rd/reporting/composer.py
+++ b/dr_rd/reporting/composer.py
@@ -34,6 +34,10 @@ def compose(spec: dict[str, Any], artifacts: dict[str, Any]) -> dict[str, Any]:
         planner_meta["risks"].extend(
             [r.get("class", str(r)) if isinstance(r, dict) else str(r) for r in risk_reg]
         )
+    contradictions = synth.get("contradictions")
+    if not isinstance(contradictions, list):
+        contradictions = []
+
     report = {
         "report_id": spec.get("report_id", "r1"),
         "title": spec.get("title", "Report"),
@@ -47,4 +51,10 @@ def compose(spec: dict[str, Any], artifacts: dict[str, Any]) -> dict[str, Any]:
         },
         "generated_ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
     }
+    report["contradictions"] = contradictions
+
+    confidence = synth.get("confidence")
+    if isinstance(confidence, (int, float)):
+        report["confidence"] = float(confidence)
+
     return report

--- a/tests/eval/test_synthesizer_integration.py
+++ b/tests/eval/test_synthesizer_integration.py
@@ -1,0 +1,61 @@
+import json
+
+import pytest
+
+from core.agents.synthesizer_agent import SynthesizerAgent
+from core.agents.prompt_agent import PromptFactoryAgent
+
+from dr_rd.reporting import composer
+
+
+@pytest.fixture(autouse=True)
+def _stub_synthesizer_completion(monkeypatch):
+    def fake_run_with_spec(self, spec, **kwargs):
+        return json.dumps(
+            {
+                "summary": "Overview",
+                "key_points": ["kp"],
+                "role": "Synthesizer",
+                "task": "compose final report",
+                "findings": "analysis",
+                "risks": [],
+                "next_steps": [],
+                "sources": [],
+                "confidence": 1.0,
+                "contradictions": [],
+            }
+        )
+
+    monkeypatch.setattr(PromptFactoryAgent, "run_with_spec", fake_run_with_spec)
+
+
+def test_contradictions_detection_and_confidence():
+    conflicting_answers = {
+        "CTO": {"decision": "Proceed", "summary": "Ready"},
+        "Regulatory": {"decision": "Hold", "summary": "Pending"},
+        "Finance": {"decision": "Proceed"},
+        "QA": {"summary": "Not determined"},
+    }
+
+    clean_answers = {
+        "CTO": {"decision": "Proceed", "summary": "Ready"},
+        "Regulatory": {"decision": "Proceed", "summary": "Ready"},
+    }
+
+    agent = SynthesizerAgent("model")
+
+    conflicting = json.loads(agent.act("idea", conflicting_answers))
+    assert conflicting["contradictions"], "Expected contradictions to be detected"
+    assert any("decision" in msg for msg in conflicting["contradictions"])
+    assert any("Not determined" in msg for msg in conflicting["contradictions"])
+    assert conflicting["confidence"] <= 0.6
+
+    clean = json.loads(agent.act("idea", clean_answers))
+    assert clean["contradictions"] == []
+    assert clean["confidence"] == pytest.approx(1.0)
+
+    report_spec = {"planner": {"tasks": []}, "report_id": "r-1", "title": "Run"}
+    report = composer.compose(report_spec, {"agents": [], "synth": conflicting})
+
+    assert report.get("contradictions") == conflicting["contradictions"]
+    assert report.get("confidence") == conflicting["confidence"]


### PR DESCRIPTION
## Summary
- add an evaluator integration test exercising Synthesizer contradiction handling and report surfacing
- propagate contradictions and confidence signals from Synthesizer output into the report composer payload

## Testing
- pytest -q *(fails: missing optional dependencies `pptx`, `fastapi` required by unrelated integration tests)*
- mypy dr_rd
- ruff check dr_rd *(fails: existing style issues outside the change scope)*
- gitleaks detect --source . *(fails: `gitleaks` not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc9b7daea8832c9637663ba4ec0981